### PR TITLE
Glyph Title Transform Function for CSS styles

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,19 @@ Type: `string`
 
 Default value getting from `fontName` options, but you can specify any value.
 
+### `glyphTransformFn`
+Type: `function`
+
+If you need some transform it titles of CSS classes for your icons, you can use option glyphTransformFn with glyphs
+metadata object
+
+Example:
+```
+glyphTransformFn: (obj) => {
+    obj.name += '_transform';
+}
+```
+
 ### `fontId`
 ### `fontStyle`
 ### `fontWeight`

--- a/src/__tests__/standalone-test.js
+++ b/src/__tests__/standalone-test.js
@@ -225,7 +225,7 @@ test('should throw error of config file not found', (t) => {
 });
 
 test('should create css selectors with transform titles through function', (t) => {
-    t.plan(8);
+    t.plan(3);
 
     return standalone({
         files: `${fixturesPath}/svg-icons/**/*`,
@@ -235,11 +235,6 @@ test('should create css selectors with transform titles through function', (t) =
         },
         template: 'css'
     }).then((result) => {
-        t.true(typeof result.svg === 'undefined');
-        t.true(typeof result.ttf === 'undefined');
-        t.true(typeof result.woff === 'undefined');
-        t.true(typeof result.woff2 === 'undefined');
-        t.true(isEot(result.eot));
         t.regex(result.styles, /\.webfont-avatar_transform/);
         t.regex(result.styles, /\.webfont-envelope_transform/);
         t.regex(result.styles, /\.webfont-phone-call_transform/);


### PR DESCRIPTION
If you need some transform in titles of CSS classes for your icons, you can use option glyphTransformFn with glyphs metadata object