### PR TITLE
feat: add new transformation function

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ Default value getting from `fontName` options, but you can specify any value.
 Type: `function`
 Default: `null`
 
-If you need transform glyph metadata (e.g. titles of CSS classes) before transferred in style template for your icons, you can use this option with glyphs metadata object.
+If you need to transform glyph metadata (e.g. titles of CSS classes, or unicode) before font creation for your icons, you can use this option with glyphs metadata object.
 
 Example:
 
@@ -135,42 +135,6 @@ webfont({
   files: "src/svg-icons/**/*.svg",
   glyphTransformFn: obj => {
     obj.name += "_transform";
-
-    return obj;
-  }
-})
-  .then(result => {
-    console.log(result);
-
-    return result;
-  })
-  .catch(error => {
-    throw error;
-  });
-```
-
-### `beforeFontGenerationGlyphTransformation`
-
-Type: `function`
-Default: `(glyph) => { return glyph }`
-
-If you need transform glyph before transferred in to any font, you can use this option with glyphs metadata object.
-
-Example:
-
-```js
-import webfont from "webfont";
-
-const historyMap = new Map(...filled);
-
-webfont({
-  files: "src/svg-icons/**/*.svg",
-  beforeFontGenerationGlyphTransformation: obj => {
-    if (historyMap.has(obj.metadata.name)) {
-      obj.metadata.unicode = [
-        String.fromCodePoint(historyMap.get(obj.metadata.unicode))
-      ];
-    }
 
     return obj;
   }

--- a/README.md
+++ b/README.md
@@ -149,6 +149,42 @@ webfont({
   });
 ```
 
+### `beforeFontGenerationGlyphTransformation`
+
+Type: `function`
+Default: `(glyph) => { return glyph }`
+
+If you need transform glyph before transferred in to any font, you can use this option with glyphs metadata object.
+
+Example:
+
+```js
+import webfont from "webfont";
+
+const historyMap = new Map(...filled);
+
+webfont({
+  files: "src/svg-icons/**/*.svg",
+  beforeFontGenerationGlyphTransformation: obj => {
+    if (historyMap.has(obj.metadata.name)) {
+      obj.metadata.unicode = [
+        String.fromCodePoint(historyMap.get(obj.metadata.unicode))
+      ];
+    }
+
+    return obj;
+  }
+})
+  .then(result => {
+    console.log(result);
+
+    return result;
+  })
+  .catch(error => {
+    throw error;
+  });
+```
+
 ### `sort`
 
 Type: `bool`

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ Default value getting from `fontName` options, but you can specify any value.
 
 ### `glyphTransformFn`
 
-Type: `function`
+Type: `async function`
 Default: `null`
 
 If you need to transform glyph metadata (e.g. titles of CSS classes, or unicode) before font creation for your icons, you can use this option with glyphs metadata object.
@@ -133,7 +133,7 @@ import webfont from "webfont";
 
 webfont({
   files: "src/svg-icons/**/*.svg",
-  glyphTransformFn: obj => {
+  glyphTransformFn: async obj => {
     obj.name += "_transform";
 
     return obj;

--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ webfont({
   files: "src/svg-icons/**/*.svg",
   glyphTransformFn: async obj => {
     obj.name += "_transform";
+    await something();
 
     return obj;
   }

--- a/src/__tests__/.eslintrc.json
+++ b/src/__tests__/.eslintrc.json
@@ -1,5 +1,6 @@
 {
   "rules": {
-    "node/no-unpublished-import": "off"
+    "node/no-unpublished-import": "off",
+    "require-await": "off"
   }
 }

--- a/src/__tests__/.eslintrc.json
+++ b/src/__tests__/.eslintrc.json
@@ -1,6 +1,5 @@
 {
   "rules": {
-    "node/no-unpublished-import": "off",
-    "require-await": "off"
+    "node/no-unpublished-import": "off"
   }
 }

--- a/src/__tests__/__snapshots__/standalone.test.js.snap
+++ b/src/__tests__/__snapshots__/standalone.test.js.snap
@@ -1,5 +1,124 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`standalone should change unicode symbols in the result 1`] = `
+"@font-face {
+  font-family: \\"webfont\\";
+  font-style: normal;
+  font-weight: 400;
+  font-display: auto;
+  src: url(\\"./webfont.eot\\");
+  src: url(\\"./webfont.eot?#iefix\\") format(\\"embedded-opentype\\"); 
+}
+
+.webfont {
+  display: inline-block;
+  font-family: \\"webfont\\";
+  font-weight: 400;
+  font-style: normal;
+  font-variant: normal;
+  text-rendering: auto;
+  line-height: 1;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+.webfont-lg {
+  font-size: 1.33333em;
+  line-height: 0.75em;
+  vertical-align: -0.0667em;
+}
+
+.webfont-xs {
+  font-size: 0.75em;
+}
+
+.webfont-sm {
+  font-size: 0.875em;
+}
+
+.webfont-1x {
+  font-size: 1em;
+}
+
+.webfont-2x {
+  font-size: 2em;
+}
+
+.webfont-3x {
+  font-size: 3em;
+}
+
+.webfont-4x {
+  font-size: 4em;
+}
+
+.webfont-5x {
+  font-size: 5em;
+}
+
+.webfont-6x {
+  font-size: 6em;
+}
+
+.webfont-7x {
+  font-size: 7em;
+}
+
+.webfont-8x {
+  font-size: 8em;
+}
+
+.webfont-9x {
+  font-size: 9em;
+}
+
+.webfont-10x {
+  font-size: 10em;
+}
+
+.webfont-fw {
+  text-align: center;
+  width: 1.25em;
+}
+
+.webfont-border {
+  border: solid 0.08em #eee;
+  border-radius: 0.1em;
+  padding: 0.2em 0.25em 0.15em;
+}
+
+.webfont-pull-left {
+  float: left;
+}
+
+.webfont-pull-right {
+  float: right;
+}
+
+.webfont.webfont-pull-left {
+  margin-right: 0.3em;
+}
+
+.webfont.webfont-pull-right {
+  margin-left: 0.3em;
+}
+
+
+.webfont-avatar::before {
+  content: \\"\\\\1\\";
+}
+
+.webfont-envelope::before {
+  content: \\"\\\\1\\";
+}
+
+.webfont-phone-call::before {
+  content: \\"\\\\1\\";
+}
+
+"
+`;
+
 exports[`standalone should create css selectors with transform titles through function 1`] = `
 "@font-face {
   font-family: \\"webfont\\";

--- a/src/__tests__/__snapshots__/standalone.test.js.snap
+++ b/src/__tests__/__snapshots__/standalone.test.js.snap
@@ -1,5 +1,124 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`standalone should be a async function 1`] = `
+"@font-face {
+  font-family: \\"webfont\\";
+  font-style: normal;
+  font-weight: 400;
+  font-display: auto;
+  src: url(\\"./webfont.eot\\");
+  src: url(\\"./webfont.eot?#iefix\\") format(\\"embedded-opentype\\"); 
+}
+
+.webfont {
+  display: inline-block;
+  font-family: \\"webfont\\";
+  font-weight: 400;
+  font-style: normal;
+  font-variant: normal;
+  text-rendering: auto;
+  line-height: 1;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+.webfont-lg {
+  font-size: 1.33333em;
+  line-height: 0.75em;
+  vertical-align: -0.0667em;
+}
+
+.webfont-xs {
+  font-size: 0.75em;
+}
+
+.webfont-sm {
+  font-size: 0.875em;
+}
+
+.webfont-1x {
+  font-size: 1em;
+}
+
+.webfont-2x {
+  font-size: 2em;
+}
+
+.webfont-3x {
+  font-size: 3em;
+}
+
+.webfont-4x {
+  font-size: 4em;
+}
+
+.webfont-5x {
+  font-size: 5em;
+}
+
+.webfont-6x {
+  font-size: 6em;
+}
+
+.webfont-7x {
+  font-size: 7em;
+}
+
+.webfont-8x {
+  font-size: 8em;
+}
+
+.webfont-9x {
+  font-size: 9em;
+}
+
+.webfont-10x {
+  font-size: 10em;
+}
+
+.webfont-fw {
+  text-align: center;
+  width: 1.25em;
+}
+
+.webfont-border {
+  border: solid 0.08em #eee;
+  border-radius: 0.1em;
+  padding: 0.2em 0.25em 0.15em;
+}
+
+.webfont-pull-left {
+  float: left;
+}
+
+.webfont-pull-right {
+  float: right;
+}
+
+.webfont.webfont-pull-left {
+  margin-right: 0.3em;
+}
+
+.webfont.webfont-pull-right {
+  margin-left: 0.3em;
+}
+
+
+.webfont-avatar::before {
+  content: \\"\\\\1\\";
+}
+
+.webfont-envelope::before {
+  content: \\"\\\\1\\";
+}
+
+.webfont-phone-call::before {
+  content: \\"\\\\1\\";
+}
+
+"
+`;
+
 exports[`standalone should change unicode symbols in the result 1`] = `
 "@font-face {
   font-family: \\"webfont\\";

--- a/src/__tests__/standalone.test.js
+++ b/src/__tests__/standalone.test.js
@@ -329,7 +329,7 @@ describe("standalone", () => {
     const result = await standalone({
       files: `${fixturesGlob}/svg-icons/**/*`,
       formats: ["eot"],
-      glyphTransformFn: async obj => {
+      glyphTransformFn: obj => {
         obj.name += "_transform";
 
         return obj;
@@ -344,7 +344,7 @@ describe("standalone", () => {
     const result = await standalone({
       files: `${fixturesGlob}/svg-icons/**/*`,
       formats: ["eot"],
-      glyphTransformFn: async obj => {
+      glyphTransformFn: obj => {
         obj.unicode = ["\u0001"];
 
         return obj;
@@ -376,7 +376,7 @@ describe("standalone", () => {
       await standalone({
         files: `${fixturesGlob}/svg-icons/**/*`,
         formats: ["eot"],
-        glyphTransformFn: async () => {
+        glyphTransformFn: () => {
           throw new Error("Name Invalid");
         },
         template: "css"

--- a/src/__tests__/standalone.test.js
+++ b/src/__tests__/standalone.test.js
@@ -9,6 +9,8 @@ import standalone from "../standalone";
 
 const fixturesGlob = "src/__tests__/fixtures";
 
+const wait = () => Promise.resolve(true);
+
 describe("standalone", () => {
   it("should throw error if `files` not passed", async () => {
     try {
@@ -342,7 +344,8 @@ describe("standalone", () => {
     const result = await standalone({
       files: `${fixturesGlob}/svg-icons/**/*`,
       formats: ["eot"],
-      glyphTransformFn: obj => {
+      glyphTransformFn: async obj => {
+        await wait();
         obj.unicode = ["\u0001"];
 
         return obj;

--- a/src/__tests__/standalone.test.js
+++ b/src/__tests__/standalone.test.js
@@ -9,7 +9,7 @@ import standalone from "../standalone";
 
 const fixturesGlob = "src/__tests__/fixtures";
 
-const wait = () => Promise.resolve(true);
+const waitFor = ms => new Promise(resolve => setTimeout(resolve, ms));
 
 describe("standalone", () => {
   it("should throw error if `files` not passed", async () => {
@@ -332,7 +332,7 @@ describe("standalone", () => {
       glyphTransformFn: obj => {
         obj.name += "_transform";
 
-        return obj;
+        return Promise.resolve(obj);
       },
       template: "css"
     });
@@ -344,9 +344,24 @@ describe("standalone", () => {
     const result = await standalone({
       files: `${fixturesGlob}/svg-icons/**/*`,
       formats: ["eot"],
-      glyphTransformFn: async obj => {
-        await wait();
+      glyphTransformFn: obj => {
         obj.unicode = ["\u0001"];
+
+        return Promise.resolve(obj);
+      },
+      template: "css"
+    });
+
+    expect(result.template).toMatchSnapshot();
+  });
+
+  it("should be a async function", async () => {
+    const result = await standalone({
+      files: `${fixturesGlob}/svg-icons/**/*`,
+      formats: ["eot"],
+      glyphTransformFn: async obj => {
+        obj.unicode = ["\u0001"];
+        await waitFor(500);
 
         return obj;
       },

--- a/src/__tests__/standalone.test.js
+++ b/src/__tests__/standalone.test.js
@@ -371,6 +371,21 @@ describe("standalone", () => {
     expect(result.template).toMatchSnapshot();
   });
 
+  it("should handle errors properly", async () => {
+    try {
+      await standalone({
+        files: `${fixturesGlob}/svg-icons/**/*`,
+        formats: ["eot"],
+        glyphTransformFn: async () => {
+          throw new Error("Name Invalid");
+        },
+        template: "css"
+      });
+    } catch (error) {
+      expect(error.message).toMatch("Name Invalid");
+    }
+  });
+
   it("should respect `template` options", async () => {
     const result = await standalone({
       files: `${fixturesGlob}/svg-icons/**/*`,

--- a/src/__tests__/standalone.test.js
+++ b/src/__tests__/standalone.test.js
@@ -338,22 +338,19 @@ describe("standalone", () => {
     expect(result.template).toMatchSnapshot();
   });
 
-  it("should transform icons before creating icons", async () => {
+  it("should change unicode symbols in the result", async () => {
     const result = await standalone({
       files: `${fixturesGlob}/svg-icons/**/*`,
       formats: ["eot"],
-      beforeFontGenerationGlyphTransformation: obj => {
-        obj.metadata.unicode = ["\u0001"];
+      glyphTransformFn: obj => {
+        obj.unicode = ["\u0001"];
 
         return obj;
       },
       template: "css"
     });
-    const transformed = result.glyphsData.map(
-      glyph => glyph.metadata.unicode[0]
-    );
 
-    expect(transformed.every(uni => uni === "\u0001")).toBe(true);
+    expect(result.template).toMatchSnapshot();
   });
 
   it("should respect `template` options", async () => {

--- a/src/__tests__/standalone.test.js
+++ b/src/__tests__/standalone.test.js
@@ -338,6 +338,24 @@ describe("standalone", () => {
     expect(result.template).toMatchSnapshot();
   });
 
+  it("should transform icons before creating icons", async () => {
+    const result = await standalone({
+      files: `${fixturesGlob}/svg-icons/**/*`,
+      formats: ["eot"],
+      beforeFontGenerationGlyphTransformation: obj => {
+        obj.metadata.unicode = ["\u0001"];
+
+        return obj;
+      },
+      template: "css"
+    });
+    const transformed = result.glyphsData.map(
+      glyph => glyph.metadata.unicode[0]
+    );
+
+    expect(transformed.every(uni => uni === "\u0001")).toBe(true);
+  });
+
   it("should respect `template` options", async () => {
     const result = await standalone({
       files: `${fixturesGlob}/svg-icons/**/*`,

--- a/src/__tests__/standalone.test.js
+++ b/src/__tests__/standalone.test.js
@@ -329,10 +329,10 @@ describe("standalone", () => {
     const result = await standalone({
       files: `${fixturesGlob}/svg-icons/**/*`,
       formats: ["eot"],
-      glyphTransformFn: obj => {
+      glyphTransformFn: async obj => {
         obj.name += "_transform";
 
-        return Promise.resolve(obj);
+        return obj;
       },
       template: "css"
     });
@@ -344,10 +344,10 @@ describe("standalone", () => {
     const result = await standalone({
       files: `${fixturesGlob}/svg-icons/**/*`,
       formats: ["eot"],
-      glyphTransformFn: obj => {
+      glyphTransformFn: async obj => {
         obj.unicode = ["\u0001"];
 
-        return Promise.resolve(obj);
+        return obj;
       },
       template: "css"
     });

--- a/src/standalone.js
+++ b/src/standalone.js
@@ -191,6 +191,7 @@ export default async function(initialOptions) {
         }
       },
       glyphTransformFn: null,
+      beforeFontGenerationGlyphTransformation: glyph => glyph,
       // Maybe allow setup from CLI
       // This is usually less than file read maximums while staying performance
       maxConcurrency: 100,
@@ -231,6 +232,8 @@ export default async function(initialOptions) {
   const result = {};
 
   result.glyphsData = await getGlyphsData(filteredFiles, options);
+  result.glyphsData.map(options.beforeFontGenerationGlyphTransformation);
+
   result.svg = await toSvg(result.glyphsData, options);
   result.ttf = toTtf(
     result.svg,

--- a/src/standalone.js
+++ b/src/standalone.js
@@ -231,13 +231,16 @@ export default async function(initialOptions) {
   const result = {};
 
   result.glyphsData = await getGlyphsData(filteredFiles, options);
-  result.glyphsData = result.glyphsData.map(glyphData => {
-    if (typeof options.glyphTransformFn === "function") {
-      glyphData.metadata = options.glyphTransformFn(glyphData.metadata);
-    }
 
-    return glyphData;
-  });
+  if (options.glyphTransformFn) {
+    const transformedGlyphs = result.glyphsData.map(async glyphData => {
+      const metadata = await options.glyphTransformFn(glyphData.metadata);
+
+      return { ...glyphData, metadata };
+    });
+
+    result.glyphsData = await Promise.all(transformedGlyphs);
+  }
 
   result.svg = await toSvg(result.glyphsData, options);
   result.ttf = toTtf(


### PR DESCRIPTION
Adds a new transformation function for modifying glyphs before the fonts are created. This could be used for implementing a history for the unicode symbols to make them persistent.