### PR TITLE
Replace a non-breaking whitespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Default: `webfont`
 
 The font family name you want.
 
-### `formats`
+### `formats`
 
 Type: `Array`
 Default value: `['svg', 'ttf', 'eot', 'woff', 'woff2']`


### PR DESCRIPTION
Replace a non-breaking whitespace to a normal space. (`0xa0` to `0x20`)
I don't have any idea who did this but I fixed it.

Before: (`formats` was not rendered as `<h3>`)
![Screen Shot 2019-06-18 at 2 27 48 AM](https://user-images.githubusercontent.com/579366/59624044-bb860d00-9170-11e9-9221-a6c9aa615f0f.png)
