### PR TITLE
build: drop support for Node.js 8 (EOL)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -33,7 +33,7 @@
 *.sass text eol=lf
 *.scm text eol=lf
 *.scss text eol=lf
-*.sh text eolf=lf
+*.sh text eol=lf
 *.sql text eol=lf
 *.styl text eol=lf
 *.ts text eol=lf

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,20 +30,12 @@ matrix:
       node_js: "10"
       script: npm run $JOB_PART
       env: JOB_PART=test:only
-    - os: linux
-      node_js: "8"
-      script: npm run $JOB_PART
-      env: JOB_PART=test:only
     - os: osx
       node_js: "11"
       script: npm run $JOB_PART
       env: JOB_PART=test:only
     - os: osx
       node_js: "10"
-      script: npm run $JOB_PART
-      env: JOB_PART=test:only
-    - os: osx
-      node_js: "8"
       script: npm run $JOB_PART
       env: JOB_PART=test:only
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,7 +6,6 @@ environment:
   matrix:
     - nodejs_version: 11
     - nodejs_version: 10
-    - nodejs_version: 8
 
 version: "{build}"
 build: off

--- a/package.json
+++ b/package.json
@@ -191,7 +191,7 @@
     "testEnvironment": "node"
   },
   "engines": {
-    "node": ">= 10.0.0"
+    "node": ">= 10.13.0"
   },
   "snyk": true
 }

--- a/package.json
+++ b/package.json
@@ -67,14 +67,13 @@
     "xml2js": "^0.4.17"
   },
   "devDependencies": {
-    "@babel/core": "^7.1.5",
     "@babel/cli": "^7.1.5",
+    "@babel/core": "^7.1.5",
     "@babel/preset-env": "^7.1.5",
     "babel-eslint": "^10.0.1",
     "babel-jest": "24.7.1",
     "coveralls": "^3.0.0",
     "cross-env": "^5.0.0",
-    "execa": "^1.0.0",
     "eslint": "^5.16.0",
     "eslint-plugin-ava": "^6.0.0",
     "eslint-plugin-html": "^5.0.3",
@@ -88,21 +87,22 @@
     "eslint-plugin-promise": "^4.1.1",
     "eslint-plugin-react": "^7.1.0",
     "eslint-plugin-unicorn": "^8.0.2",
+    "execa": "^1.0.0",
+    "husky": "^1.1.3",
     "is-eot": "^1.0.0",
     "is-svg": "^4.1.0",
     "is-ttf": "^0.2.0",
     "is-woff": "^1.0.0",
     "is-woff2": "^1.0.0",
     "jest": "^24.7.1",
-    "standard-version": "^8.0.1",
+    "lint-staged": "^8.0.4",
     "npm-run-all": "^4.0.0",
     "nyc": "^14.0.0",
     "prettier": "^1.17.0",
     "remark-cli": "^6.0.0",
     "remark-preset-lint-itgalaxy": "^14.0.0",
     "rimraf": "^2.5.2",
-    "husky": "^1.1.3",
-    "lint-staged": "^8.0.4"
+    "standard-version": "^8.0.1"
   },
   "scripts": {
     "build": "babel src -d dist --ignore '**/__tests__/**'",
@@ -191,7 +191,7 @@
     "testEnvironment": "node"
   },
   "engines": {
-    "node": ">= 8.9.0"
+    "node": ">= 10.0.0"
   },
   "snyk": true
 }


### PR DESCRIPTION
## Summary

### Proposed changes

This PR drops support to Node 8. No dependencies were added, updated or removed in this PR.

### Related issue

This PR closes https://github.com/itgalaxy/webfont/issues/210.

---

#### Development environment configuration

- Node.js version: `v12.17.0`
- NPM version: `6.14.4`

---

## Checklist

- [x] I have added corresponding labels to this PR (like bug, enhancement...);
- [x] My commits follow the [Conventional Commits 1.0 Guidelines](https://www.conventionalcommits.org/en/v1.0.0/);
- [x] My code follows the style guidelines of this project;
- [x] I have performed a self-review of my own code;
- [x] I have mapped technical debts found on my changes;
- [ ] I have made corresponding changes to the documentation (if applicable);
- [x] My changes generate no new warnings or errors;
