### PR TITLE
feat(cli): create output folder if it's not present. (#280) 

### DIFF
--- a/README.md
+++ b/README.md
@@ -354,6 +354,10 @@ If you're using cross-env:
 
             Destination for generated fonts.
 
+        -m, --dest-create
+
+            Create destination directory if it does not exist.
+
         -t, --template
 
             Type of template (\`css\`, \`scss\`, \`styl\`) or path to custom template.

--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
     "standard-version": "^9.0.0"
   },
   "scripts": {
-    "build": "babel src -d dist --ignore '**/__tests__/**'",
+    "build": "babel src -d dist --ignore '**/__tests__/**', '**/__mocks__/**'",
     "demo": "npm run build && node dist/cli.js './src/__tests__/fixtures/svg-icons/*.svg' -d demo -t html --normalize --center-horizontally",
     "fix": "npm-run-all -l prettify -p 'fix:**'",
     "fix:js": "npm run lint:js -- --fix",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,8 @@
   "files": [
     "dist",
     "templates",
-    "!**/__tests__"
+    "!**/__tests__",
+    "!**/__mocks__"
   ],
   "dependencies": {
     "cosmiconfig": "^5.2.0",
@@ -103,7 +104,7 @@
     "standard-version": "^9.0.0"
   },
   "scripts": {
-    "build": "babel src -d dist --ignore '**/__tests__/**', '**/__mocks__/**'",
+    "build": "babel src -d dist --ignore '**/__tests__/**','**/__mocks__/**'",
     "demo": "npm run build && node dist/cli.js './src/__tests__/fixtures/svg-icons/*.svg' -d demo -t html --normalize --center-horizontally",
     "fix": "npm-run-all -l prettify -p 'fix:**'",
     "fix:js": "npm run lint:js -- --fix",

--- a/src/__mocks__/cli.js
+++ b/src/__mocks__/cli.js
@@ -62,6 +62,10 @@ cli.showHelp = function () {
 
           Destination for generated fonts.
 
+      -m, --dest-create
+
+          Create destination directory if it does not exist.
+
       -t, --template
 
           Type of template ('css', 'scss', 'styl') or path to custom template.

--- a/src/__tests__/cli.test.js
+++ b/src/__tests__/cli.test.js
@@ -306,12 +306,8 @@ describe("cli", () => {
         nonExistentDestination,
         { encoding: "utf-8" },
         (readdirError) => {
-          expect(() => {
-            throw readdirError;
-          }).toThrow(
-            new Error(
-              `ENOENT: no such file or directory, scandir '${nonExistentDestination}'`
-            )
+          expect(readdirError.message).toContain(
+            "ENOENT: no such file or directory, scandir"
           );
 
           done();

--- a/src/__tests__/cli.test.js
+++ b/src/__tests__/cli.test.js
@@ -261,4 +261,62 @@ describe("cli", () => {
     expect(output.code).toBe(0);
     expect(output.stderr).toBe("");
   });
+
+  it("should create dest directory if it does not exist and --dest-create flag is provided", async (done) => {
+    const nonExistentDestination = `${destination}/that/does/not/exist`;
+    const output = await execCLI(
+      `${source} -d ${nonExistentDestination} --dest-create`
+    );
+
+    fs.access(nonExistentDestination, fs.constants.F_OK, (accessError) => {
+      /* eslint-disable-next-line no-unneeded-ternary */
+      const destinationWasCreated = accessError ? false : true;
+
+      expect(destinationWasCreated).toBe(true);
+      fs.readdir(
+        nonExistentDestination,
+        { encoding: "utf-8" },
+        (readdirError, files) => {
+          if (readdirError) {
+            done(readdirError);
+
+            return;
+          }
+
+          output.files = files.filter((file) => file !== "that");
+
+          expect(output.files).toEqual(files);
+          done();
+        }
+      );
+    });
+  });
+
+  it("should not create dest directory if it does not exist", async (done) => {
+    const nonExistentDestination = `${destination}/that/does/not/exist`;
+
+    await execCLI(`${source} -d ${nonExistentDestination}`);
+
+    fs.access(nonExistentDestination, fs.constants.F_OK, (accessError) => {
+      /* eslint-disable-next-line no-unneeded-ternary */
+      const destinationWasCreated = accessError ? false : true;
+
+      expect(destinationWasCreated).toBe(false);
+      fs.readdir(
+        nonExistentDestination,
+        { encoding: "utf-8" },
+        (readdirError) => {
+          expect(() => {
+            throw readdirError;
+          }).toThrow(
+            new Error(
+              `ENOENT: no such file or directory, scandir '${nonExistentDestination}'`
+            )
+          );
+
+          done();
+        }
+      );
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Creates the destination/output folder if it is not preset and the
`--dest-create` flag is provided in the command.

I decided to make it a command instead of just creating the
folder just incase the provided destination path was a mistake or
a typo and you don't want your fonts to be exported there.

### Proposed changes

This PR brings the following changes:

- Add flag `dist-create` with alias `m` to `cli`

### Related issue

Fixes #280

### Dependencies added/removed (if applicable)

N/A

---

### Testing

- [x] I have added or updated tests that prove my fix is effective or that my feature works (if applicable)
  - [x] Unit test
  - [ ] Snapshot test
  - [ ] Manual test
  - [ ] Another test...

#### How to test

Describe the tests that you ran to verify your changes:

1. Run `npm test`

#### Test configuration

- Node.js version: v12.18.0
- NPM version: 6.14.4

---

## Checklist

- [ ] I have added corresponding labels to this PR (like bug, enhancement...);
- [x] My commits follow the [Conventional Commits 1.0 Guidelines](https://www.conventionalcommits.org/en/v1.0.0/);
- [x] My code follows the style guidelines of this project;
- [x] I have performed a self-review of my own code;
- [x] I have mapped technical debts found on my changes;
- [x] I have made corresponding changes to the documentation (if applicable);
- [x] My changes generate no new warnings or errors;
