### PR TITLE
fix issue 328

### DIFF
--- a/src/standalone.js
+++ b/src/standalone.js
@@ -306,13 +306,15 @@ export default async function (initialOptions) {
         fontPath: options.templateFontPath.replace(/\/?$/, "/"),
       },
       hashOption,
-      { fonts: {
-        eot: options.formats.includes("eot") ? result.eot.toString('base64') : undefined,
-        woff: options.formats.includes("woff") ? result.woff.toString('base64') : undefined,
-        woff2: options.formats.includes("woff2") ? Buffer.from(result.woff2).toString('base64') : undefined,
-        svg: options.formats.includes("svg") ? result.svg.toString('base64') : undefined,
-        ttf: options.formats.includes("ttf") ? result.ttf.toString('base64') : undefined
-      }}
+      { 
+        fonts: options.formats.map((format) => {
+          if (format === "woff2") {
+            return {}[format] = Buffer.from(result.woff2).toString("base64");
+          } else {
+            return {}[format] = result[format].toString("base64")
+          }
+        })
+      }
     ]);
 
     result.template = nunjucks.render(templateFilePath, nunjucksOptions);

--- a/src/standalone.js
+++ b/src/standalone.js
@@ -307,13 +307,16 @@ export default async function (initialOptions) {
       },
       hashOption,
       { 
-        fonts: options.formats.map((format) => {
-          if (format === "woff2") {
-            return {}[format] = Buffer.from(result.woff2).toString("base64");
-          } else {
-            return {}[format] = result[format].toString("base64")
-          }
-        })
+        fonts: Object.fromEntries(new Map(
+          options.formats.map(format => [
+            format, (() => {
+              if (format === "woff2") {
+                return Buffer.from(result.woff2).toString("base64");
+              } else {
+                return result[format].toString("base64");
+              }
+          })()])
+        ))  
       }
     ]);
 

--- a/src/standalone.js
+++ b/src/standalone.js
@@ -306,6 +306,13 @@ export default async function (initialOptions) {
         fontPath: options.templateFontPath.replace(/\/?$/, "/"),
       },
       hashOption,
+      { fonts: {
+        eot: options.formats.includes("eot") ? result.eot.toString('base64') : undefined,
+        woff: options.formats.includes("woff") ? result.woff.toString('base64') : undefined,
+        woff2: options.formats.includes("woff2") ? Buffer.from(result.woff2).toString('base64') : undefined,
+        svg: options.formats.includes("svg") ? result.svg.toString('base64') : undefined,
+        ttf: options.formats.includes("ttf") ? result.ttf.toString('base64') : undefined
+      }}
     ]);
 
     result.template = nunjucks.render(templateFilePath, nunjucksOptions);


### PR DESCRIPTION
## Summary

As stated in issue 328, this pull request provides access to the generated fonts in base64 formats so it is possible to embed the font inside the scss file while generating it (this is my particular use case)

### Proposed changes

The proposed change is to add "fonts" to nunjucksOptions and one key for each generated font. Then, the key value is the base64 encoded content of the array (or generated file)

### Related issue

Issue 328

### Dependencies added/removed (if applicable)

None

---

#### How to test

I've modified line 68 of template.html.njk as follows:

from:
`url("{{ fontPath }}{{ fontName }}.woff2?{{ cacheString }}{% if hash %}&v={{ hash }}{% endif %}") format("woff2")`
to
`url("data:font/woff2;base64,{{ fonts.woff2 }}") format("woff2")`

And tested the document in a browser (Chrome), then, in the network tab you can see the font has been loaded from embeded resource rather than external URL.

#### Test configuration

Same original configuration

