### PR TITLE
fix(deps): switch out from latest versions in dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15882,9 +15882,9 @@
       }
     },
     "node_modules/trim-newlines": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-3.0.0.tgz",
-      "integrity": "sha512-C4+gOpvmxaSMKuEf9Qc134F1ZuOHVXKRbtEflf4NTtuuJDEIJ9p5PXsalL8SkeRw+qit1Mo+yuvMPAKwWg/1hA==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-3.0.1.tgz",
+      "integrity": "sha512-c1PTsA3tYrIsLGkJkzHF+w9F2EyxfXGo4UyJc4pFL++FMjnq0HJS69T3M7d//gKrFKwy429bouPescbjecU+Zw==",
       "engines": {
         "node": ">=8"
       }
@@ -28689,9 +28689,9 @@
       }
     },
     "trim-newlines": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-3.0.0.tgz",
-      "integrity": "sha512-C4+gOpvmxaSMKuEf9Qc134F1ZuOHVXKRbtEflf4NTtuuJDEIJ9p5PXsalL8SkeRw+qit1Mo+yuvMPAKwWg/1hA=="
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-3.0.1.tgz",
+      "integrity": "sha512-c1PTsA3tYrIsLGkJkzHF+w9F2EyxfXGo4UyJc4pFL++FMjnq0HJS69T3M7d//gKrFKwy429bouPescbjecU+Zw=="
     },
     "trim-off-newlines": {
       "version": "1.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,60 +5,60 @@
   "requires": true,
   "packages": {
     "": {
-      "version": "11.2.13",
+      "version": "11.2.15",
       "license": "MIT",
       "dependencies": {
-        "deepmerge": "*",
-        "globby": "*",
-        "meow": "9.x",
-        "nunjucks": "*",
-        "p-limit": "*",
-        "parse-json": "*",
-        "resolve-from": "*",
-        "svg2ttf": "*",
-        "svgicons2svgfont": "10.0.1",
-        "ttf2eot": "*",
-        "ttf2woff": "*",
+        "deepmerge": "^4.2.2",
+        "globby": "^11.0.0",
+        "meow": "^9.0.0",
+        "nunjucks": "^3.2.3",
+        "p-limit": "^3.1.0",
+        "parse-json": "^5.2.0",
+        "resolve-from": "^5.0.0",
+        "svg2ttf": "^6.0.2",
+        "svgicons2svgfont": "^10.0.3",
+        "ttf2eot": "^2.0.0",
+        "ttf2woff": "^2.0.2",
         "wawoff2": "^2.0.0",
-        "xml2js": "*"
+        "xml2js": "^0.4.23"
       },
       "bin": {
         "webfont": "dist/cli.js"
       },
       "devDependencies": {
-        "@babel/eslint-plugin": "*",
-        "@babel/preset-env": "*",
-        "@babel/preset-typescript": "*",
-        "@rollup/plugin-commonjs": "*",
-        "@rollup/plugin-typescript": "*",
-        "@types/jest": "*",
-        "@types/node": "*",
-        "@types/nunjucks": "*",
-        "@types/rimraf": "*",
+        "@babel/eslint-plugin": "latest",
+        "@babel/preset-env": "latest",
+        "@babel/preset-typescript": "latest",
+        "@rollup/plugin-commonjs": "latest",
+        "@rollup/plugin-typescript": "latest",
+        "@types/jest": "latest",
+        "@types/node": "latest",
+        "@types/nunjucks": "latest",
+        "@types/rimraf": "latest",
         "@typescript-eslint/eslint-plugin": "latest",
-        "@typescript-eslint/parser": "*",
-        "babel-jest": "*",
+        "@typescript-eslint/parser": "latest",
+        "babel-jest": "latest",
         "cosmiconfig": "^5.2.0",
-        "eslint": "*",
-        "eslint-plugin-import": "*",
-        "eslint-plugin-jest": "*",
-        "eslint-plugin-node": "*",
-        "eslint-plugin-promise": "*",
-        "eslint-plugin-unicorn": "*",
-        "husky": "*",
-        "is-eot": "*",
-        "is-svg": "*",
-        "is-ttf": "*",
-        "is-woff": "*",
-        "is-woff2": "*",
+        "eslint": "latest",
+        "eslint-plugin-import": "latest",
+        "eslint-plugin-jest": "latest",
+        "eslint-plugin-node": "latest",
+        "eslint-plugin-promise": "latest",
+        "eslint-plugin-unicorn": "latest",
+        "husky": "latest",
+        "is-eot": "latest",
+        "is-svg": "latest",
+        "is-ttf": "latest",
+        "is-woff": "latest",
+        "is-woff2": "latest",
         "jest": "26.x",
-        "lint-staged": "*",
-        "rimraf": "*",
-        "rollup": "*",
-        "standard-version": "*",
+        "lint-staged": "latest",
+        "rimraf": "latest",
+        "rollup": "latest",
+        "standard-version": "latest",
         "ts-node": "latest",
-        "tslib": "*",
-        "typescript": "*"
+        "tslib": "latest",
+        "typescript": "latest"
       },
       "engines": {
         "node": ">= 12.0.0"
@@ -5493,9 +5493,9 @@
       "dev": true
     },
     "node_modules/cubic2quad": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/cubic2quad/-/cubic2quad-1.1.1.tgz",
-      "integrity": "sha1-abGcYaP1tB7PLx1fro+wNBWqixU="
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/cubic2quad/-/cubic2quad-1.2.1.tgz",
+      "integrity": "sha512-wT5Y7mO8abrV16gnssKdmIhIbA9wSkeMzhh27jAguKrV82i24wER0vL5TGhUJ9dbJNDcigoRZ0IAHFEEEI4THQ=="
     },
     "node_modules/currently-unhandled": {
       "version": "0.4.1",
@@ -15567,24 +15567,24 @@
       }
     },
     "node_modules/svg-pathdata": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/svg-pathdata/-/svg-pathdata-5.0.2.tgz",
-      "integrity": "sha512-tmfwioGZZaSMZnAGCFiWd30O2sVbA5/wVP/CS8Pcf9s1ptd6J26bZUFwkIRZy+GYmD+uCECdiAP7bPpLszj+1w==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/svg-pathdata/-/svg-pathdata-6.0.0.tgz",
+      "integrity": "sha512-8XoCZjKbP0fvJbDsm6KFxVau2N3SkWkMj8OniADm87q4OiFXk/gSgri5Uyr8hE1fQ9npI+9XzRlTUObgWmBBNw==",
       "engines": {
-        "node": ">=6.9.5"
+        "node": ">=12.0.0"
       }
     },
     "node_modules/svg2ttf": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/svg2ttf/-/svg2ttf-5.2.0.tgz",
-      "integrity": "sha512-CzxPnSm2/CrMnJuKlXVllOx+q9wuarbIMi4Vf14eJoeESRqAOxVZiH0Ias71mhyXYGgz88A4T/E8fN/Y8eXoYA==",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/svg2ttf/-/svg2ttf-6.0.2.tgz",
+      "integrity": "sha512-QiDMuvYMHVPm543Pg99QpUsw6QXm7totYLeF23JJCS6g+0+xUgnapzCFFSKEKPwT7kfQHzR+S/JqP6vptJucyA==",
       "dependencies": {
         "argparse": "^2.0.1",
-        "cubic2quad": "^1.0.0",
+        "cubic2quad": "^1.2.1",
         "lodash": "^4.17.10",
         "microbuffer": "^1.0.0",
         "svgpath": "^2.1.5",
-        "xmldom": "~0.5.0"
+        "xmldom": "~0.6.0"
       },
       "bin": {
         "svg2ttf": "svg2ttf.js"
@@ -15596,9 +15596,9 @@
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
     },
     "node_modules/svgicons2svgfont": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/svgicons2svgfont/-/svgicons2svgfont-10.0.1.tgz",
-      "integrity": "sha512-fz7kku98BIfOqstzLQYcbdUn+yYV4mDG4WxYtNAIaKi3XNGQ9hloQdv+NIGLBH0mf2j0/3kDTKJKEzaqpkbd7A==",
+      "version": "10.0.3",
+      "resolved": "https://registry.npmjs.org/svgicons2svgfont/-/svgicons2svgfont-10.0.3.tgz",
+      "integrity": "sha512-tV0/KV1obxil8iHxTh+XpceIRFAgC1vHBreF7J9ke6K1U6QZAoUHxGzdP/e1NLdU6GVivL08f4W8PgcHyZWBhQ==",
       "dependencies": {
         "commander": "^7.2.0",
         "geometry-interfaces": "^1.1.4",
@@ -15606,7 +15606,7 @@
         "neatequal": "^1.0.0",
         "readable-stream": "^3.4.0",
         "sax": "^1.2.4",
-        "svg-pathdata": "5.0.2"
+        "svg-pathdata": "^6.0.0"
       },
       "bin": {
         "svgicons2svgfont": "bin/svgicons2svgfont.js"
@@ -16607,9 +16607,9 @@
       "dev": true
     },
     "node_modules/xmldom": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.5.0.tgz",
-      "integrity": "sha512-Foaj5FXVzgn7xFzsKeNIde9g6aFBxTPi37iwsno8QvApmtg7KYrr+OPyRHcJF7dud2a5nGRBXK3n0dL62Gf7PA==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.6.0.tgz",
+      "integrity": "sha512-iAcin401y58LckRZ0TkI4k0VSM1Qg0KGSc3i8rU+xrxe19A/BN1zHyVSJY7uoutVlaTSzYyk/v5AmkewAP7jtg==",
       "engines": {
         "node": ">=10.0.0"
       }
@@ -20754,9 +20754,9 @@
       }
     },
     "cubic2quad": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/cubic2quad/-/cubic2quad-1.1.1.tgz",
-      "integrity": "sha1-abGcYaP1tB7PLx1fro+wNBWqixU="
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/cubic2quad/-/cubic2quad-1.2.1.tgz",
+      "integrity": "sha512-wT5Y7mO8abrV16gnssKdmIhIbA9wSkeMzhh27jAguKrV82i24wER0vL5TGhUJ9dbJNDcigoRZ0IAHFEEEI4THQ=="
     },
     "currently-unhandled": {
       "version": "0.4.1",
@@ -28433,21 +28433,21 @@
       }
     },
     "svg-pathdata": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/svg-pathdata/-/svg-pathdata-5.0.2.tgz",
-      "integrity": "sha512-tmfwioGZZaSMZnAGCFiWd30O2sVbA5/wVP/CS8Pcf9s1ptd6J26bZUFwkIRZy+GYmD+uCECdiAP7bPpLszj+1w=="
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/svg-pathdata/-/svg-pathdata-6.0.0.tgz",
+      "integrity": "sha512-8XoCZjKbP0fvJbDsm6KFxVau2N3SkWkMj8OniADm87q4OiFXk/gSgri5Uyr8hE1fQ9npI+9XzRlTUObgWmBBNw=="
     },
     "svg2ttf": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/svg2ttf/-/svg2ttf-5.2.0.tgz",
-      "integrity": "sha512-CzxPnSm2/CrMnJuKlXVllOx+q9wuarbIMi4Vf14eJoeESRqAOxVZiH0Ias71mhyXYGgz88A4T/E8fN/Y8eXoYA==",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/svg2ttf/-/svg2ttf-6.0.2.tgz",
+      "integrity": "sha512-QiDMuvYMHVPm543Pg99QpUsw6QXm7totYLeF23JJCS6g+0+xUgnapzCFFSKEKPwT7kfQHzR+S/JqP6vptJucyA==",
       "requires": {
         "argparse": "^2.0.1",
-        "cubic2quad": "^1.0.0",
+        "cubic2quad": "^1.2.1",
         "lodash": "^4.17.10",
         "microbuffer": "^1.0.0",
         "svgpath": "^2.1.5",
-        "xmldom": "~0.5.0"
+        "xmldom": "~0.6.0"
       },
       "dependencies": {
         "argparse": {
@@ -28458,9 +28458,9 @@
       }
     },
     "svgicons2svgfont": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/svgicons2svgfont/-/svgicons2svgfont-10.0.1.tgz",
-      "integrity": "sha512-fz7kku98BIfOqstzLQYcbdUn+yYV4mDG4WxYtNAIaKi3XNGQ9hloQdv+NIGLBH0mf2j0/3kDTKJKEzaqpkbd7A==",
+      "version": "10.0.3",
+      "resolved": "https://registry.npmjs.org/svgicons2svgfont/-/svgicons2svgfont-10.0.3.tgz",
+      "integrity": "sha512-tV0/KV1obxil8iHxTh+XpceIRFAgC1vHBreF7J9ke6K1U6QZAoUHxGzdP/e1NLdU6GVivL08f4W8PgcHyZWBhQ==",
       "requires": {
         "commander": "^7.2.0",
         "geometry-interfaces": "^1.1.4",
@@ -28468,7 +28468,7 @@
         "neatequal": "^1.0.0",
         "readable-stream": "^3.4.0",
         "sax": "^1.2.4",
-        "svg-pathdata": "5.0.2"
+        "svg-pathdata": "^6.0.0"
       }
     },
     "svgpath": {
@@ -29243,9 +29243,9 @@
       "dev": true
     },
     "xmldom": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.5.0.tgz",
-      "integrity": "sha512-Foaj5FXVzgn7xFzsKeNIde9g6aFBxTPi37iwsno8QvApmtg7KYrr+OPyRHcJF7dud2a5nGRBXK3n0dL62Gf7PA=="
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.6.0.tgz",
+      "integrity": "sha512-iAcin401y58LckRZ0TkI4k0VSM1Qg0KGSc3i8rU+xrxe19A/BN1zHyVSJY7uoutVlaTSzYyk/v5AmkewAP7jtg=="
     },
     "xtend": {
       "version": "4.0.2",

--- a/package.json
+++ b/package.json
@@ -40,19 +40,19 @@
     "testu": "npm test -- -u"
   },
   "dependencies": {
-    "deepmerge": "latest",
-    "globby": "latest",
-    "meow": "9.x",
-    "nunjucks": "latest",
-    "p-limit": "latest",
-    "parse-json": "latest",
-    "resolve-from": "latest",
-    "svg2ttf": "latest",
-    "svgicons2svgfont": "10.0.1",
-    "ttf2eot": "latest",
-    "ttf2woff": "latest",
+    "deepmerge": "^4.2.2",
+    "globby": "^11.0.0",
+    "meow": "^9.0.0",
+    "nunjucks": "^3.2.3",
+    "p-limit": "^3.1.0",
+    "parse-json": "^5.2.0",
+    "resolve-from": "^5.0.0",
+    "svg2ttf": "^6.0.2",
+    "svgicons2svgfont": "^10.0.3",
+    "ttf2eot": "^2.0.0",
+    "ttf2woff": "^2.0.2",
     "wawoff2": "^2.0.0",
-    "xml2js": "latest"
+    "xml2js": "^0.4.23"
   },
   "devDependencies": {
     "@babel/eslint-plugin": "latest",

--- a/src/standalone/index.test.ts
+++ b/src/standalone/index.test.ts
@@ -69,11 +69,11 @@ describe("standalone", () => {
       update(result.woff2).
       digest("hex");
 
-    expect(svgHash).toBe("5babeea3094bba0b5e2001390b0811fd");
-    expect(ttfHash).toBe("c78d2714960175fdf8eaebd44b4159e9");
-    expect(eotHash).toBe("024ccffe146cfdbcc501241516479f16");
-    expect(woffHash).toBe("6a11601283f57dd7d016ac91bc33179a");
-    expect(woff2Hash).toBe("23c6010d69f43c96aa9c6bed0f5529bb");
+    expect(svgHash).toBe("1154313a3843c5f5ec70890715e8a527");
+    expect(ttfHash).toBe("a78de3c54fa46d77540c2c96c4194f16");
+    expect(eotHash).toBe("90ed04c53c7534b2e66979f6c0a94afe");
+    expect(woffHash).toBe("20d0a901f75c638e7be9df714a93d5a0");
+    expect(woff2Hash).toBe("60fe7d6d658fef07b9e8af362e4b8f36");
   });
 
   it("should generate only `svg`, `ttf` and `eot` fonts", async () => {
@@ -438,7 +438,7 @@ describe("standalone", () => {
     return standalone({
       files: `${fixturesGlob}/svg-icons/**/*`,
     }).then((result) => {
-      expect(result.hash).toBe("5babeea3094bba0b5e2001390b0811fd");
+      expect(result.hash).toBe("1154313a3843c5f5ec70890715e8a527");
 
       return result;
     });


### PR DESCRIPTION
fixes #464

## Summary

Due to uncontrolled updates of third party dependencies used by webfont i've prepared this PR to switch out from `latest` versions in `dependencies` section in `package.json`.
Using `latest` versions is very risky and may break `webfont` at any time (which happend in #464)

### Proposed changes

This PR brings the following changes:

- Update dependencies to use specified by semver range versions
- Upgrade svgicons2svgfont
- Update hashes in tests

### Related issue

#464

### Dependencies added/removed (if applicable)

- svgicons2svgfont (update patch)
- svg2ttf (update major)

---

### Testing

- [X] I have added or updated tests that prove my fix is effective or that my feature works (if applicable)
  - [X] Unit tests (updated hashes)

---

## Checklist

- [x] I have added corresponding labels to this PR (like bug, enhancement...);
- [X] My commits follow the [Conventional Commits 1.0 Guidelines](https://www.conventionalcommits.org/en/v1.0.0/);
- [X] My code follows the style guidelines of this project;
- [X] I have performed a self-review of my own code;
- [x] I have mapped technical debts found on my changes;
- [x] I have made changes to the documentation (if applicable);
- [X] My changes generate no new warnings or errors;
