### PR TITLE
feat: adding config option to prevent ligature unicode generation

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -30,7 +30,7 @@ module.exports = {
       rules: {
         "max-lines": ["error", 510],
         "max-lines-per-function": ["error", 495],
-        "max-statements": ["error", 27],
+        "max-statements": ["error", 28],
       },
     },
     {

--- a/README.md
+++ b/README.md
@@ -160,6 +160,12 @@ webfont({
 - Default: Gets is from `fontName` if not set, but you can specify any value.
 - Description: Template font family name you want.
 
+#### `ligatures`
+
+- Type: `boolean`
+- Default: `true`
+- Description: Turn on/off adding ligature unicode
+
 #### `glyphTransformFn`
 
 - Type: `function`

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -172,6 +172,12 @@ if (cli.flags.sort === false) {
 
 }
 
+if (cli.flags.ligatures === false) {
+
+  optionsBase.ligatures = cli.flags.ligatures;
+
+}
+
 if (cli.flags.addHashInFontUrl) {
 
   optionsBase.addHashInFontUrl = cli.flags.addHashInFontUrl;

--- a/src/cli/meow/__mocks__/index.ts
+++ b/src/cli/meow/__mocks__/index.ts
@@ -88,6 +88,10 @@ meowMock.showHelp = () => `
 
           Keeps the files in the same order of entry
 
+      --no-ligatures
+
+          Prevents adding ligature unicode
+
       --verbose
 
           Tell me everything!.

--- a/src/cli/meow/index.ts
+++ b/src/cli/meow/index.ts
@@ -76,6 +76,10 @@ const meowCLI = meow(`
 
             Keeps the files in the same order of entry
 
+        --no-ligatures
+
+            Prevents adding ligature unicode
+
         --verbose
 
             Tell me everything!.
@@ -191,6 +195,10 @@ const meowCLI = meow(`
     },
     help: {
       alias: "h",
+      type: "boolean",
+    },
+    ligatures: {
+      default: true,
       type: "boolean",
     },
     normalize: {

--- a/src/standalone/glyphsData.ts
+++ b/src/standalone/glyphsData.ts
@@ -57,13 +57,18 @@ export const getGlyphsData : GlyphsDataGetter = (files, options) => {
       sortedGlyphsData = glyphsData.sort(sortCallback);
     }
 
+    const { ligatures } = options;
+
     return Promise.all(sortedGlyphsData.map((glyphData: GlyphData) => new Promise((resolve, reject) => {
       metadataProvider(glyphData.srcPath, (error, metadata) => {
         if (error) {
           return reject(error);
         }
 
-        metadata.unicode.push(metadata.name.replace(/-/gu, "_"));
+        if (ligatures) {
+          metadata.unicode.push(metadata.name.replace(/-/gu, "_"));
+        }
+
         glyphData.metadata = metadata;
 
         return resolve(glyphData);

--- a/src/standalone/index.test.ts
+++ b/src/standalone/index.test.ts
@@ -432,6 +432,21 @@ describe("standalone", () => {
     expect(result.glyphsData.length > 0).toBe(true);
   });
 
+  it("should remove ligature unicode when `ligatures` set to `false`", async () => {
+    const result = await standalone({
+      files: `${fixturesGlob}/svg-icons/**/*`,
+      ligatures: false,
+      template: "css",
+    });
+
+    expect(Array.isArray(result.glyphsData)).toBe(true);
+    expect(result.glyphsData.length > 0).toBe(true);
+
+    result.glyphsData.forEach((glyph) => {
+      expect(glyph.metadata?.unicode).toHaveLength(1);
+    });
+  });
+
   it("should export `hash` in `result`", () => {
     expect.assertions(1);
 

--- a/src/standalone/options.ts
+++ b/src/standalone/options.ts
@@ -27,6 +27,7 @@ export const getOptions: OptionsGetter = (initialOptions) => {
       },
     },
     glyphTransformFn: null,
+    ligatures: true,
 
     /*
      * Maybe allow setup from CLI

--- a/src/types/OptionsBase.ts
+++ b/src/types/OptionsBase.ts
@@ -27,5 +27,6 @@ export type OptionsBase = {
   prependUnicode?: boolean | unknown;
   metadata?: unknown;
   sort?: boolean;
+  ligatures?: boolean;
   addHashInFontUrl?: boolean | unknown;
 };


### PR DESCRIPTION
fixes #457

## Summary

This PR adds an option to prevent ligature unicode generation.

### Proposed changes

This PR brings the following changes:

- Adding config option `ligatures`

### Related issue

#457

### Dependencies added/removed (if applicable)

- Add: `dependency1`;
- Update: `dependency2`;
- Remove: `dependency3`;

---

### Testing

- [X] I have added or updated tests that prove my fix is effective or that my feature works (if applicable)
  - [X] Unit test (added test to check if no extra unicode is added if `ligatures=false`)
  - [X] Adjusted test snapshots to respect new config option

#### How to test

Describe the tests that you ran to verify your changes:

Using cli: `webfont --no-ligatures ...`
Using node:

```js
webfont({
    ...,
    ligatures: false
})
```

## Checklist

- [ ] I have added corresponding labels to this PR (like bug, enhancement...);
- [X] My commits follow the [Conventional Commits 1.0 Guidelines](https://www.conventionalcommits.org/en/v1.0.0/);
- [X] My code follows the style guidelines of this project;
- [X] I have performed a self-review of my own code;
- [ ] I have mapped technical debts found on my changes;
- [X] I have made changes to the documentation (if applicable);
- [X] My changes generate no new warnings or errors;
