### PR TITLE
Adding an option to center glyphs vertically.

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,6 +246,12 @@ These can be appended to [webfont options](#options). These are passed directly 
 - Default: `false`
 - Description: Calculate the bounds of a glyph and center it horizontally.
 
+#### `svgicons2svgfont.centerVertically`
+
+- Type: `boolean`
+- Default: `false`
+- Description: Centers the glyphs vertically in the generated font.
+
 #### `svgicons2svgfont.normalize`
 
 - Type: `boolean`
@@ -414,6 +420,10 @@ If you're using cross-env:
         --center-horizontally
 
             Calculate the bounds of a glyph and center it horizontally.
+
+        --center-vertically
+
+            centers the glyphs vertically in the generated font.
 
         --normalize
 

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -118,6 +118,12 @@ if (cli.flags.centerHorizontally) {
 
 }
 
+if (cli.flags.centerVertically) {
+
+  optionsBase.centerVertically = cli.flags.centerVertically;
+
+}
+
 if (cli.flags.normalize) {
 
   optionsBase.normalize = cli.flags.normalize;

--- a/src/cli/meow/__mocks__/index.ts
+++ b/src/cli/meow/__mocks__/index.ts
@@ -118,6 +118,10 @@ meowMock.showHelp = () => `
 
           Calculate the bounds of a glyph and center it horizontally.
 
+      --centerVertically
+
+          Centers the glyphs vertically in the generated font.
+
       --normalize
 
           Normalize icons by scaling them to the height of the highest icon.

--- a/src/cli/meow/index.ts
+++ b/src/cli/meow/index.ts
@@ -106,6 +106,10 @@ const meowCLI = meow(`
 
             Calculate the bounds of a glyph and center it horizontally.
 
+        --centerVertically
+
+            Centers the glyphs vertically in the generated font.
+
         --normalize
 
             Normalize icons by scaling them to the height of the highest icon.
@@ -149,6 +153,9 @@ const meowCLI = meow(`
       type: "string",
     },
     centerHorizontally: {
+      type: "boolean",
+    },
+    centerVertically: {
       type: "boolean",
     },
     config: {

--- a/src/standalone/index.ts
+++ b/src/standalone/index.ts
@@ -57,6 +57,7 @@ const toSvg = (glyphsData, options) => {
     const fontStream = new SVGIcons2SVGFontStream({
       ascent: options.ascent,
       centerHorizontally: options.centerHorizontally,
+      centerVertically: options.centerVertically,
       descent: options.descent,
       fixedWidth: options.fixedWidth,
       fontHeight: options.fontHeight,

--- a/src/standalone/options.ts
+++ b/src/standalone/options.ts
@@ -11,6 +11,7 @@ export const getOptions: OptionsGetter = (initialOptions) => {
 
   return {
     centerHorizontally: false,
+    centerVertically: false,
     descent: 0,
     fixedWidth: false,
     fontHeight: null,

--- a/src/types/OptionsBase.ts
+++ b/src/types/OptionsBase.ts
@@ -18,6 +18,7 @@ export type OptionsBase = {
   fontWeight?: string | unknown;
   fixedWidth?: string | unknown;
   centerHorizontally?: boolean | unknown;
+  centerVertically?: boolean | unknown;
   normalize?: boolean;
   fontHeight?: string | unknown;
   round?: string | number;


### PR DESCRIPTION
## Summary

### Proposed changes

This PR brings the following changes:

- Add `centerHorizontally` option via `svgicons2svgfont.options`.

### Related issue

None

### Dependencies added/removed (if applicable)

None

---

### Testing

- [ ] I have added or updated tests that prove my fix is effective or that my feature works (if applicable)
  - [ ] Unit test
  - [ ] Snapshot test
  - [x] Manual test

---

## Checklist

- [ ] I have added corresponding labels to this PR (like bug, enhancement...);
- [x] My commits follow the [Conventional Commits 1.0 Guidelines](https://www.conventionalcommits.org/en/v1.0.0/);
- [x] My code follows the style guidelines of this project;
- [x] I have performed a self-review of my own code;
- [x] I have mapped technical debts found on my changes;
- [x] I have made changes to the documentation (if applicable);
- [x] My changes generate no new warnings or errors;
