### PR TITLE
Use named import for globby

### DIFF
--- a/src/standalone/index.ts
+++ b/src/standalone/index.ts
@@ -8,7 +8,7 @@ import crypto from "crypto";
 import deepmerge from "deepmerge";
 import {getGlyphsData} from "./glyphsData";
 import {getOptions} from "./options";
-import globby from "globby";
+import {globby} from "globby";
 import nunjucks from "nunjucks";
 import path from "path";
 import svg2ttf from "svg2ttf";


### PR DESCRIPTION
## Summary

When building webfont, I received the following warning/error:

```
(!) Plugin typescript: @rollup/plugin-typescript TS2349: This expression is not callable.
  Type 'typeof import("/usr/share/nodejs/globby/index")' has no call signatures.
src/standalone/index.ts: (121:28)

121   const foundFiles = await globby([].concat(options.files));
                               ~~~~~~
```

### Proposed changes

This PR, written by Israel Galadima, fixes this.

---

#### How to test

Describe the tests that you ran to verify your changes:

1. Run the build.
2. Notice that this warning/error message no longer appears.

#### Test configuration

- Node.js version (if applicable): 18.12.1

---

## Checklist

- [x] I have added corresponding labels to this PR (like bug, enhancement...); it's a bug, but I don't know how to add labels
- [x] My commits follow the [Conventional Commits 1.0 Guidelines](https://www.conventionalcommits.org/en/v1.0.0/);
- [x] My code follows the style guidelines of this project;
- [x] I have performed a self-review of my own code;
- [x] I have mapped technical debts found on my changes; N/A
- [ ] I have made changes to the documentation (if applicable); N/A
- [x] My changes generate no new warnings or errors;
