### PR TITLE
Correct short options for --formats and --fontName in help

### DIFF
--- a/src/cli/meow/__mocks__/index.ts
+++ b/src/cli/meow/__mocks__/index.ts
@@ -36,7 +36,7 @@ meowMock.showHelp = () => `
           The search will begin in the working directory and move up the
           directory tree until a configuration file is found.
 
-      -f, --fontName
+      -u, --fontName
 
           The font family name you want, default: "webfont".
 
@@ -48,7 +48,7 @@ meowMock.showHelp = () => `
 
           Output the version number.
 
-      -r, --formats
+      -f, --formats
 
           Only this formats generate.
 

--- a/src/cli/meow/index.ts
+++ b/src/cli/meow/index.ts
@@ -24,7 +24,7 @@ const meowCLI = meow(`
             The search will begin in the working directory and move up the
             directory tree until a configuration file is found.
 
-        -f, --fontName
+        -u, --fontName
 
             The font family name you want, default: "webfont".
 
@@ -36,7 +36,7 @@ const meowCLI = meow(`
 
             Output the version number.
 
-        -r, --formats
+        -f, --formats
 
             Only this formats generate.
 


### PR DESCRIPTION
## Summary

The output of `webfont --help` currently includes `-f, --fontName` and `-r, --formats`, but these don't match the definitions later in the file, so `-f myfont` produces no output (as `myfont` is not a valid format).  This patch corrects the help message to match the definitions.

#### How to test

Describe the tests that you ran to verify your changes:

1. Run `webfont --help`.
2. Check if the lines now read `-u, --fontName` and `-f, --formats`

## Checklist

- [ ] I have added corresponding labels to this PR (like bug, enhancement...);
- [x] My commits follow the [Conventional Commits 1.0 Guidelines](https://www.conventionalcommits.org/en/v1.0.0/);
- [x] My code follows the style guidelines of this project;
- [x] I have performed a self-review of my own code;
- [ ] I have mapped technical debts found on my changes;
- [x] I have made changes to the documentation (if applicable);
- [x] My changes generate no new warnings or errors;
