### PR TITLE
Bug fix: Add @rollup/plugin-node-resolve to rollup configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "@babel/preset-env": "latest",
     "@babel/preset-typescript": "latest",
     "@rollup/plugin-commonjs": "latest",
+    "@rollup/plugin-node-resolve": "latest",
     "@rollup/plugin-typescript": "latest",
     "@types/jest": "26.0.24",
     "@types/node": "15.14.9",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,6 +1,7 @@
 import commonjs from "@rollup/plugin-commonjs";
 import {dependencies} from "./package.json";
 import typescript from "@rollup/plugin-typescript";
+import { nodeResolve } from '@rollup/plugin-node-resolve';
 
 const dir = "dist";
 
@@ -17,6 +18,7 @@ const external = [
 const plugins = [
   typescript(),
   commonjs(),
+  nodeResolve(),
 ];
 
 module.exports = [


### PR DESCRIPTION
## Summary

### Proposed changes

When building the package, rollup warns:
```
src/cli/index.ts → dist/cli.js...
(!) Unresolved dependencies
https://rollupjs.org/troubleshooting/#warning-treating-module-as-external-dependency
svgicons2svgfont/src/filesorter (imported by "src/standalone/glyphsData.ts")
svgicons2svgfont/src/metadata (imported by "src/standalone/glyphsData.ts")
created dist/cli.js in 5.8s

src/index.ts → dist...
(!) Unresolved dependencies
https://rollupjs.org/troubleshooting/#warning-treating-module-as-external-dependency
svgicons2svgfont/src/filesorter (imported by "src/standalone/glyphsData.ts")
svgicons2svgfont/src/metadata (imported by "src/standalone/glyphsData.ts")
```

This PR follows the advice in the referred-to website, and adds the `@rollup/plugin-node-resolve` plugin to the rollup configuration.

### Dependencies added/removed (if applicable)

- Add: `@rollup/plugin-node-resolve`;

I have added this to `package.json` but not modified `package-lock.json`.

The package builds (on Debian) with this patch without the rollup warnings.

---

## Checklist

- [x] I have added corresponding labels to this PR (like bug, enhancement...);
- [x] My commits follow the [Conventional Commits 1.0 Guidelines](https://www.conventionalcommits.org/en/v1.0.0/);
- [x] My code follows the style guidelines of this project;
- [x] I have performed a self-review of my own code;
- [ ] I have mapped technical debts found on my changes;
- [ ] I have made changes to the documentation (if applicable);
- [x] My changes generate no new warnings or errors;
