### PR TITLE
chore(ci): upgrade GitHub Actions to Node 22/24

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -8,9 +8,10 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
-          node-version: 12
+          node-version: 22.x
+          cache: npm
       - run: npm ci
       - run: npm test

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -11,14 +11,14 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [14.x, 16.x]
+        node-version: [22.x, 24.x]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v2
+      uses: actions/setup-node@v4
       with:
         node-version: ${{ matrix.node-version }}
-        cache: 'npm'
+        cache: npm
     - run: npm ci
     - run: npm test

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -5,24 +5,22 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        node-version: [14.x]
     steps:
       - name: Set commit author email
         run: git config --global user.email "development@itgalaxy.company"
       - name: Set commit author name
         run: git config --global user.name "itgalaxy"
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           fetch-depth: "0"
       - name: Pull all tags from Lerna semantic release
         run: git fetch --depth=1 origin +refs/tags/*:refs/tags/*
-      - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v1
+      - name: Use Node.js
+        uses: actions/setup-node@v4
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: 22.x
+          cache: npm
       - name: Install project dependencies
         run: npm ci --no-optional
       - name: Bump versions and create release

--- a/package.json
+++ b/package.json
@@ -113,7 +113,7 @@
   },
   "homepage": "https://github.com/itgalaxy/webfont#readme",
   "engines": {
-    "node": ">= 12.0.0"
+    "node": ">= 18.0.0"
   },
   "keywords": [
     "cli",


### PR DESCRIPTION
## Summary
- Upgrades `actions/checkout` to v4 and `actions/setup-node` to v4 across all workflows
- Replaces EOL Node 12/14/16 with Node 22.x (LTS) and 24.x in the PR CI matrix
- Fixes the `Cache service responded with 400` error caused by outdated `setup-node@v2` on current GitHub Actions runners
- Updates `package.json` engines to `>= 18.0.0` to reflect supported Node versions

## Test plan
- [x] `npm test` passes locally
- [x] CI passes on Node 22.x and 24.x


Made with [Cursor](https://cursor.com)