### PR TITLE
ci: fix version-bump when release tag already exists

### DIFF
--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -4,7 +4,10 @@ on:
     branches: [ master ]
 jobs:
   build:
+    if: ${{ !startsWith(github.event.head_commit.message, 'chore(release)') }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Set commit author email
         run: git config --global user.email "development@itgalaxy.company"
@@ -23,6 +26,22 @@ jobs:
           cache: npm
       - name: Install project dependencies
         run: npm ci --no-optional
+      - name: Sync package version with latest git tag
+        run: |
+          LATEST=$(git tag -l 'v*' --sort=-v:refname | head -1 | sed 's/^v//')
+          node -e "
+            const fs = require('fs');
+            const semver = require('semver');
+            const latest = process.argv[1];
+            for (const file of ['package.json', 'package-lock.json']) {
+              const pkg = JSON.parse(fs.readFileSync(file, 'utf8'));
+              if (semver.gt(latest, pkg.version)) {
+                console.log('Syncing ' + file + ' from ' + pkg.version + ' to ' + latest);
+                pkg.version = latest;
+                fs.writeFileSync(file, JSON.stringify(pkg, null, 2) + '\n');
+              }
+            }
+          " "$LATEST"
       - name: Bump versions and create release
         run: npm run release
       - name: Push tags

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "webfont",
-  "version": "11.3.0",
+  "version": "11.4.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "webfont",
-      "version": "11.3.0",
+      "version": "11.4.0",
       "license": "MIT",
       "dependencies": {
         "cosmiconfig": "^5.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webfont",
-  "version": "11.3.0",
+  "version": "11.4.0",
   "description": "Generator of fonts from svg icons, svg icons to svg font, svg font to ttf, ttf to eot, ttf to woff, ttf to woff2",
   "directories": {
     "lib": "dist",


### PR DESCRIPTION
## Summary
- Fixes `npm run release` failing with `fatal: tag 'v11.4.0' already exists` in the version-bump workflow
- Syncs `package.json` / `package-lock.json` with the latest git tag before running `standard-version`
- Skips the workflow when the pushed commit is already a `chore(release)` commit (prevents release loops)
- Aligns the repository version to `11.4.0` to match the existing `v11.4.0` tag

## Root cause
`package.json` was still at `11.3.0` while tag `v11.4.0` already existed on a diverged commit from 2021. The workflow tried to create the same tag again after bumping to `11.4.0`.

## Test plan
- [x] `npm test` passes locally
- [ ] After merge, version-bump workflow should create `v11.5.0` successfully


Made with [Cursor](https://cursor.com)