### PR TITLE
ci: replace deprecated --no-optional with --omit=optional

### DIFF
--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -25,7 +25,7 @@ jobs:
           node-version: 22.x
           cache: npm
       - name: Install project dependencies
-        run: npm ci --no-optional
+        run: npm ci --omit=optional
       - name: Sync package version with latest git tag
         run: |
           LATEST=$(git tag -l 'v*' --sort=-v:refname | head -1 | sed 's/^v//')


### PR DESCRIPTION
## Summary
- Replaces `npm ci --no-optional` with `npm ci --omit=optional` in the version-bump workflow
- Removes the npm deprecation warning about the `--no-optional` config flag

## Test plan
- [ ] CI passes on this PR
- [ ] Version-bump workflow no longer prints the `--no-optional` deprecation warning


Made with [Cursor](https://cursor.com)