### PR TITLE
refactor: isolate svgicons2svgfont usage for v16 upgrade

### DIFF
--- a/src/lib/svgicons2svgfont/index.ts
+++ b/src/lib/svgicons2svgfont/index.ts
@@ -1,0 +1,59 @@
+import type {WebfontOptions} from "../../types";
+/* eslint-disable sort-imports -- v10 uses internal paths; v16 will switch to public named exports */
+import SVGIcons2SVGFontStream from "svgicons2svgfont";
+import fileSorter from "svgicons2svgfont/src/filesorter";
+import getMetadataService from "svgicons2svgfont/src/metadata";
+/* eslint-enable sort-imports */
+
+export {fileSorter, getMetadataService, SVGIcons2SVGFontStream};
+
+type MetadataServiceOptions = {
+  prependUnicode: boolean;
+  startUnicode: number;
+};
+
+export const getMetadataServiceOptions = (options: WebfontOptions): MetadataServiceOptions => ({
+  prependUnicode: Boolean(options.prependUnicode),
+  startUnicode: Number(options.startUnicode),
+});
+
+type FontStreamOptions = {
+  ascent?: WebfontOptions["ascent"];
+  centerHorizontally?: WebfontOptions["centerHorizontally"];
+  descent?: WebfontOptions["descent"];
+  fixedWidth?: WebfontOptions["fixedWidth"];
+  fontHeight?: WebfontOptions["fontHeight"];
+  fontId?: WebfontOptions["fontId"];
+  fontName?: WebfontOptions["fontName"];
+  fontStyle?: WebfontOptions["fontStyle"];
+  fontWeight?: WebfontOptions["fontWeight"];
+  // eslint-disable-next-line no-unused-vars
+  log?: (...args: unknown[]) => void;
+  metadata?: WebfontOptions["metadata"];
+  normalize?: WebfontOptions["normalize"];
+  round?: WebfontOptions["round"];
+};
+
+export const getFontStreamOptions = (options: WebfontOptions): FontStreamOptions => {
+  const fontStreamOptions: FontStreamOptions = {
+    ascent: options.ascent,
+    centerHorizontally: options.centerHorizontally,
+    descent: options.descent,
+    fixedWidth: options.fixedWidth,
+    fontHeight: options.fontHeight,
+    fontId: options.fontId,
+    fontName: options.fontName,
+    fontStyle: options.fontStyle,
+    fontWeight: options.fontWeight,
+    metadata: options.metadata,
+    normalize: options.normalize,
+    round: options.round,
+  };
+
+  if (options.verbose) {
+    // eslint-disable-next-line no-console
+    fontStreamOptions.log = console.log.bind(console);
+  }
+
+  return fontStreamOptions;
+};

--- a/src/standalone/glyphsData.ts
+++ b/src/standalone/glyphsData.ts
@@ -1,9 +1,24 @@
-import type {GlyphData, WebfontOptions} from "../types";
-import { createReadStream } from "fs";
-import fileSorter from "svgicons2svgfont/src/filesorter";
-import getMetadataService from "svgicons2svgfont/src/metadata";
+import type {GlyphData, GlyphMetadata, WebfontOptions} from "../types";
+import {fileSorter, getMetadataService, getMetadataServiceOptions} from "../lib/svgicons2svgfont";
+import {createReadStream} from "fs";
 import pLimit from "p-limit";
 import xml2js from "xml2js";
+
+const normalizeUnicode = (unicode: GlyphMetadata["unicode"]): string[] => {
+  if (Array.isArray(unicode)) {
+    return unicode;
+  }
+
+  return [unicode];
+};
+
+const toGlyphMetadata = (metadata: {
+  name: string;
+  unicode: GlyphMetadata["unicode"] | string | string[];
+}): GlyphMetadata => ({
+  name: metadata.name,
+  unicode: normalizeUnicode(metadata.unicode as GlyphMetadata["unicode"]),
+});
 
 // eslint-disable-next-line no-unused-vars
 type GlyphsDataGetter = (files: Array<GlyphData["srcPath"]>, options: WebfontOptions) => unknown;
@@ -11,10 +26,7 @@ type GlyphsDataGetter = (files: Array<GlyphData["srcPath"]>, options: WebfontOpt
 export const getGlyphsData : GlyphsDataGetter = (files, options) => {
   const metadataProvider =
     options.metadataProvider ||
-    getMetadataService({
-      prependUnicode: options.prependUnicode,
-      startUnicode: options.startUnicode,
-    });
+    getMetadataService(getMetadataServiceOptions(options));
 
   const xmlParser = new xml2js.Parser();
   const throttle = pLimit(options.maxConcurrency);
@@ -65,11 +77,13 @@ export const getGlyphsData : GlyphsDataGetter = (files, options) => {
           return reject(error);
         }
 
+        const glyphMetadata = toGlyphMetadata(metadata);
+
         if (ligatures) {
-          metadata.unicode.push(metadata.name.replace(/-/gu, "_"));
+          glyphMetadata.unicode.push(metadata.name.replace(/-/gu, "_"));
         }
 
-        glyphData.metadata = metadata;
+        glyphData.metadata = glyphMetadata;
 
         return resolve(glyphData);
       });

--- a/src/standalone/index.ts
+++ b/src/standalone/index.ts
@@ -1,8 +1,8 @@
 import type {Format, GlyphData, InitialOptions} from "../types";
+import {SVGIcons2SVGFontStream, getFontStreamOptions} from "../lib/svgicons2svgfont";
 import {getBuiltInTemplates, getTemplateFilePath} from "../../templates";
 import {Readable} from "stream";
 import type {Result} from "../types/Result";
-import SVGIcons2SVGFontStream from "svgicons2svgfont";
 import cosmiconfig from "cosmiconfig";
 import crypto from "crypto";
 import deepmerge from "deepmerge";
@@ -45,30 +45,7 @@ const toSvg = (glyphsData, options) => {
 
   return new Promise((resolve, reject) => {
 
-    let log = () => {
-      Function.prototype();
-    };
-
-    if (options.verbose) {
-      // eslint-disable-next-line no-console
-      log = console.log.bind(console);
-    }
-
-    const fontStream = new SVGIcons2SVGFontStream({
-      ascent: options.ascent,
-      centerHorizontally: options.centerHorizontally,
-      descent: options.descent,
-      fixedWidth: options.fixedWidth,
-      fontHeight: options.fontHeight,
-      fontId: options.fontId,
-      fontName: options.fontName,
-      fontStyle: options.fontStyle,
-      fontWeight: options.fontWeight,
-      log,
-      metadata: options.metadata,
-      normalize: options.normalize,
-      round: options.round,
-    }).
+    const fontStream = new SVGIcons2SVGFontStream(getFontStreamOptions(options)).
       on("finish", () => resolve(result)).
       on("data", (data) => {
         result += data;


### PR DESCRIPTION
## Summary
Preparatory refactor to reduce the work needed for a future `svgicons2svgfont` upgrade from `10.0.3` to `16.0.0`. **No dependency version change in this PR.**

- Adds `src/lib/svgicons2svgfont/` as the single integration point for the library
- Moves font stream option mapping (including `--verbose` / `log`) into `getFontStreamOptions()`
- Normalizes glyph metadata (`unicode` as `string[]`, explicit `GlyphMetadata` mapping)
- Removes direct imports from internal `svgicons2svgfont/src/*` paths outside the adapter

## Still required in a follow-up PR (dependency bump)
- Bump `svgicons2svgfont` to `^16.0.0`
- Switch adapter imports to public named exports from `svgicons2svgfont`
- Remove unsupported `log` option handling for `--verbose` (or replace with webfont-owned logging)
- Update Jest config for ESM dependency (`transformIgnorePatterns`)
- Upgrade `@types/node` (keep `skipLibCheck: false`)
- Raise `engines.node` to `>=24.14.0` and adjust CI matrix

## Test plan
- [x] `npm test` — 42 tests pass on `svgicons2svgfont@10.0.3`


Made with [Cursor](https://cursor.com)