### PR TITLE
ci: upgrade checkout and setup-node to v6 for Node 24

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -8,8 +8,8 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: 22.x
           cache: npm

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -14,9 +14,9 @@ jobs:
         node-version: [22.x, 24.x]
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v6
       with:
         node-version: ${{ matrix.node-version }}
         cache: npm

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -14,13 +14,13 @@ jobs:
       - name: Set commit author name
         run: git config --global user.name "itgalaxy"
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: "0"
       - name: Pull all tags from Lerna semantic release
         run: git fetch --depth=1 origin +refs/tags/*:refs/tags/*
       - name: Use Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 22.x
           cache: npm


### PR DESCRIPTION
## Summary
- Upgrades `actions/checkout` from v4 to **v6** across all workflows
- Upgrades `actions/setup-node` from v4 to **v6** across all workflows
- Removes GitHub Actions deprecation warnings about Node 20 actions being forced to run on Node 24

## Context
GitHub-hosted runners now default to Node 24. `checkout@v4` and `setup-node@v4` still target Node 20 internally, which triggers warnings like:

> Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24

v6 actions are built for Node 24 natively.

## Test plan
- [x] CI passes on Node 22.x and 24.x (`pr.yml`)
- [ ] No Node 20 deprecation warnings in workflow logs


Made with [Cursor](https://cursor.com)