### PR TITLE
docs: remove emoji from CONTRIBUTING closing line

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,4 +64,4 @@ Do not use `chore:` or `chore(ci):` for CI-only changes.
 - [Using Pull Requests](https://help.github.com/articles/about-pull-requests/)
 - [GitHub Help](https://docs.github.com)
 
-Thanks for contributing to `webfont`! 👏👌✨
+Thanks for contributing to `webfont`! 👏✨


### PR DESCRIPTION
## Summary
- Remove the 👌 emoji from the closing line in `CONTRIBUTING.md`.

## Test plan
- [x] Documentation-only change

Made with [Cursor](https://cursor.com)