### PR TITLE
ci: publish to npm when Release Please ships a GitHub Release

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -3,16 +3,37 @@ name: npm publish
 # Runs when Release Please creates a GitHub Release (see release-please.yml and ADR 0004).
 on:
   release:
-    types: [created]
+    types: [published]
 
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.release.tag_name }}
       - uses: actions/setup-node@v6
         with:
           node-version: 24.x
           cache: npm
       - run: npm ci
       - run: npm test
+
+  publish-npm:
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.release.tag_name }}
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24.x
+          registry-url: https://registry.npmjs.org/
+          cache: npm
+      - run: npm ci
+      - run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -20,8 +20,6 @@ jobs:
       - uses: googleapis/release-please-action@v4
         id: release
         with:
-          # PAT required so the GitHub Release it creates triggers npm-publish.yml
-          # (events from the default GITHUB_TOKEN do not start other workflows).
-          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -20,6 +20,8 @@ jobs:
       - uses: googleapis/release-please-action@v4
         id: release
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          # PAT required so the GitHub Release it creates triggers npm-publish.yml
+          # (events from the default GITHUB_TOKEN do not start other workflows).
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -161,13 +161,12 @@ Versioning is automated with [Release Please](https://github.com/googleapis/rele
 
 Do not run local `npm version` or push version tags manually unless coordinating an emergency release with maintainers.
 
-#### npm publishing prerequisites
+#### Release and npm publishing prerequisites
 
-Before the first automated publish to [npm](https://www.npmjs.com/package/webfont), configure a repository secret:
+Configure these repository secrets under **Settings → Secrets and variables → Actions**:
 
+- **`RELEASE_PLEASE_TOKEN`** — GitHub fine-grained or classic PAT with **Contents** and **Pull requests** write access on this repository. Release Please uses it instead of the default `GITHUB_TOKEN` so the GitHub Release it creates can trigger [`npm-publish.yml`](.github/workflows/npm-publish.yml) (releases created by `GITHUB_TOKEN` do not start downstream workflows).
 - **`NPM_TOKEN`** — npm access token with publish permission for the `webfont` package (Automation or Granular Access Token).
-
-Add it under **Settings → Secrets and variables → Actions** for this repository.
 
 If CI publish is unavailable, maintainers can publish manually from the release tag:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -157,9 +157,29 @@ Versioning is automated with [Release Please](https://github.com/googleapis/rele
 1. Merge changes to `master` using [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `docs:`, `ci:`, etc.).
 2. Release Please opens or updates a **Release PR** with the next version, `CHANGELOG.md`, and `package.json` updates.
 3. Review and merge the Release PR to create the git tag and GitHub Release.
-4. The `npm-publish` workflow runs when a GitHub Release is created.
+4. The [`npm-publish`](.github/workflows/npm-publish.yml) workflow runs on the published release: `npm test`, then `npm publish --access public` (the `prepublishOnly` script builds before upload).
 
 Do not run local `npm version` or push version tags manually unless coordinating an emergency release with maintainers.
+
+#### npm publishing prerequisites
+
+Before the first automated publish to [npm](https://www.npmjs.com/package/webfont), configure a repository secret:
+
+- **`NPM_TOKEN`** — npm access token with publish permission for the `webfont` package (Automation or Granular Access Token).
+
+Add it under **Settings → Secrets and variables → Actions** for this repository.
+
+If CI publish is unavailable, maintainers can publish manually from the release tag:
+
+```shell
+git fetch origin --tags
+git checkout v12.0.0   # use the tag created by Release Please
+npm ci
+npm test
+npm publish --access public
+```
+
+Automated publishing does **not** retroactively upload versions that already exist as git tags only (for example `11.5.x` never published to npm).
 
 ## Resources
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -156,19 +156,18 @@ Versioning is automated with [Release Please](https://github.com/googleapis/rele
 
 1. Merge changes to `master` using [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `docs:`, `ci:`, etc.).
 2. Release Please opens or updates a **Release PR** with the next version, `CHANGELOG.md`, and `package.json` updates.
-3. Review and merge the Release PR to create the git tag and GitHub Release.
-4. The [`npm-publish`](.github/workflows/npm-publish.yml) workflow runs on the published release: `npm test`, then `npm publish --access public` (the `prepublishOnly` script builds before upload).
+3. Review and merge the Release PR to create the git tag and GitHub Release on GitHub.
+4. Publish to npm (see **npm publishing** below). The [`npm-publish`](.github/workflows/npm-publish.yml) workflow listens for `release: published`, but releases created with the default `GITHUB_TOKEN` usually **do not** trigger downstream workflows — use manual publish or re-run the workflow from the Actions tab if needed.
 
 Do not run local `npm version` or push version tags manually unless coordinating an emergency release with maintainers.
 
-#### Release and npm publishing prerequisites
+#### npm publishing
 
-Configure these repository secrets under **Settings → Secrets and variables → Actions**:
+Configure this repository secret under **Settings → Secrets and variables → Actions**:
 
-- **`RELEASE_PLEASE_TOKEN`** — GitHub fine-grained or classic PAT with **Contents** and **Pull requests** write access on this repository. Release Please uses it instead of the default `GITHUB_TOKEN` so the GitHub Release it creates can trigger [`npm-publish.yml`](.github/workflows/npm-publish.yml) (releases created by `GITHUB_TOKEN` do not start downstream workflows).
 - **`NPM_TOKEN`** — npm access token with publish permission for the `webfont` package (Automation or Granular Access Token).
 
-If CI publish is unavailable, maintainers can publish manually from the release tag:
+After merging the Release PR, publish from the release tag (recommended):
 
 ```shell
 git fetch origin --tags

--- a/docs/adr/0004-release-please-instead-of-standard-version.md
+++ b/docs/adr/0004-release-please-instead-of-standard-version.md
@@ -82,7 +82,7 @@ The project already uses [Conventional Commits](https://www.conventionalcommits.
 ### Negative / trade-offs
 
 - **Release PR cadence:** Version bumps no longer land instantly on every `master` push; they accumulate in a Release PR until merged.
-- **`GITHUB_TOKEN` limitation:** Releases created with the default token do **not** trigger other workflows (including `npm-publish.yml`). Configure **`RELEASE_PLEASE_TOKEN`** (GitHub PAT with Contents + Pull requests write) for [`release-please.yml`](../../.github/workflows/release-please.yml) — see [Release Please Action docs](https://github.com/googleapis/release-please-action#github-credentials).
+- **`GITHUB_TOKEN` limitation:** Releases created with the default token do **not** trigger other workflows (including `npm-publish.yml`). Publish manually from the release tag, or configure a PAT for Release Please later if fully automated publish is required (see [Release Please Action docs](https://github.com/googleapis/release-please-action#github-credentials)).
 - **Prereleases:** The old `npm run release-alpha` script is removed; use Conventional Commit prerelease notation or Release Please `release-as` / manifest options when needed.
 
 ### Follow-up

--- a/docs/adr/0004-release-please-instead-of-standard-version.md
+++ b/docs/adr/0004-release-please-instead-of-standard-version.md
@@ -82,7 +82,7 @@ The project already uses [Conventional Commits](https://www.conventionalcommits.
 ### Negative / trade-offs
 
 - **Release PR cadence:** Version bumps no longer land instantly on every `master` push; they accumulate in a Release PR until merged.
-- **`GITHUB_TOKEN` limitation:** Releases and Release PRs created by the default token do not trigger other workflows that listen to `pull_request` from those events. If CI must run on Release PRs with full permissions, configure a PAT secret (see [Release Please Action docs](https://github.com/googleapis/release-please-action#github-credentials)).
+- **`GITHUB_TOKEN` limitation:** Releases created with the default token do **not** trigger other workflows (including `npm-publish.yml`). Configure **`RELEASE_PLEASE_TOKEN`** (GitHub PAT with Contents + Pull requests write) for [`release-please.yml`](../../.github/workflows/release-please.yml) — see [Release Please Action docs](https://github.com/googleapis/release-please-action#github-credentials).
 - **Prereleases:** The old `npm run release-alpha` script is removed; use Conventional Commit prerelease notation or Release Please `release-as` / manifest options when needed.
 
 ### Follow-up

--- a/docs/adr/0004-release-please-instead-of-standard-version.md
+++ b/docs/adr/0004-release-please-instead-of-standard-version.md
@@ -87,7 +87,7 @@ The project already uses [Conventional Commits](https://www.conventionalcommits.
 
 ### Follow-up
 
-- If npm registry publish should run automatically, extend `npm-publish.yml` with `npm publish` and `NPM_TOKEN` (today it only runs `npm test` on `release: created`).
+- ~~If npm registry publish should run automatically, extend `npm-publish.yml` with `npm publish` and `NPM_TOKEN` (today it only runs `npm test` on `release: created`).~~ Done in PR [#639](https://github.com/itgalaxy/webfont/pull/639): publish on `release: published` with `NPM_TOKEN`.
 
 ## References
 


### PR DESCRIPTION
## Summary

### Proposed changes

This PR brings the following changes:

- Extend [`.github/workflows/npm-publish.yml`](.github/workflows/npm-publish.yml) with a `publish-npm` job (`npm test` → `npm publish --access public`) using `secrets.NPM_TOKEN`.
- **Trigger:** `release: types: [published]` with `ref: ${{ github.event.release.tag_name }}` (aligned with Release Please — [ADR 0004](docs/adr/0004-release-please-instead-of-standard-version.md)). The original draft’s `push: tags: v*` + `version-bump` triggers were removed.
- **Release Please** keeps the default `GITHUB_TOKEN` (no `RELEASE_PLEASE_TOKEN` required).
- Document npm publishing in [`CONTRIBUTING.md`](CONTRIBUTING.md): `NPM_TOKEN` secret + **manual publish** from the release tag when the default token does not trigger downstream workflows.
- Mark the ADR 0004 npm-publish follow-up as addressed.

### Related issue

N/A

### Dependencies added/removed (if applicable)

N/A

---

### Testing

- [x] I have added or updated tests that prove my fix is effective or that my feature works (if applicable)

#### How to test

1. Review workflow YAML (`on: release published`, checkout `tag_name`, `npm ci` without `--omit=optional`, `NPM_TOKEN`).
2. Ensure **`NPM_TOKEN`** is set under **Settings → Secrets and variables → Actions**.
3. Merge this PR, then merge Release PR [#658](https://github.com/itgalaxy/webfont/pull/658).
4. If **npm publish** does not start automatically (expected with `GITHUB_TOKEN` releases), publish manually from `v12.0.0` (see CONTRIBUTING) or re-run the workflow from the Actions tab.

#### Test configuration

N/A

---

## Checklist

- [x] I have added corresponding labels to this PR (like bug, enhancement...);
- [x] My commits follow the [Conventional Commits 1.0 Guidelines](https://www.conventionalcommits.org/en/v1.0.0/);
- [x] My code follows the style guidelines of this project;
- [x] I have performed a self-review of my own code;
- [ ] I have mapped technical debts found on my changes;
- [x] I have made changes to the documentation (if applicable);
- [x] My changes generate no new warnings or errors;

## Copilot review (addressed)

| Comment | Status |
|---------|--------|
| `push: tags: v*` + `version-bump` + `GITHUB_TOKEN` will not trigger publish | **Outdated** — trigger is now `release: published`; `version-bump` is gone. The underlying `GITHUB_TOKEN` downstream-workflow limit still applies; docs recommend manual `npm publish` from the release tag. |
| `npm ci --omit=optional` diverges from PR CI | **Fixed** — both jobs use plain `npm ci`. |
| CONTRIBUTING mentions tag push / `version-bump` | **Fixed** — documents Release Please + manual npm publish. |

## Maintainer checklist before 12.0.0

1. **`NPM_TOKEN`** configured in repository secrets.
2. Merge this PR ([#639](https://github.com/itgalaxy/webfont/pull/639)).
3. Merge Release PR ([#658](https://github.com/itgalaxy/webfont/pull/658)).
4. Publish to npm manually from `v12.0.0` if the release workflow does not auto-trigger (see CONTRIBUTING).