### PR TITLE
test: cover ttf2eot conversion in dedicated unit tests

### DIFF
--- a/src/lib/ttf2eot/index.test.ts
+++ b/src/lib/ttf2eot/index.test.ts
@@ -1,0 +1,42 @@
+import convertTtfToEot from "./index";
+import crypto from "crypto";
+import isEot from "is-eot";
+import standalone from "../../standalone";
+
+const fixturesGlob = "src/fixtures/svg-icons/*.svg";
+
+describe("ttf2eot", () => {
+  it("should convert a ttf buffer to a valid eot buffer", async () => {
+    const {ttf} = await standalone({
+      files: fixturesGlob,
+      formats: ["ttf"],
+    });
+
+    const eot = convertTtfToEot(ttf);
+
+    expect(isEot(eot)).toBe(true);
+    expect(eot.length).toBeGreaterThan(0);
+  });
+
+  it("should produce deterministic eot output for fixture icons", async () => {
+    const {ttf} = await standalone({
+      files: fixturesGlob,
+      formats: ["ttf"],
+    });
+
+    const hash = crypto.createHash("md5").
+      update(convertTtfToEot(ttf)).
+      digest("hex");
+
+    expect(hash).toBe("90ed04c53c7534b2e66979f6c0a94afe");
+  });
+
+  it("should match eot from the standalone eot format pipeline", async () => {
+    const {ttf, eot} = await standalone({
+      files: fixturesGlob,
+      formats: ["ttf", "eot"],
+    });
+
+    expect(convertTtfToEot(ttf)).toEqual(eot);
+  });
+});

--- a/src/lib/ttf2eot/index.ts
+++ b/src/lib/ttf2eot/index.ts
@@ -1,0 +1,5 @@
+import ttf2eot from "ttf2eot";
+
+const convertTtfToEot = (ttf: Buffer): Buffer => Buffer.from(ttf2eot(ttf).buffer);
+
+export default convertTtfToEot;

--- a/src/standalone/index.ts
+++ b/src/standalone/index.ts
@@ -11,8 +11,9 @@ import {getOptions} from "./options";
 import globby from "globby";
 import nunjucks from "nunjucks";
 import path from "path";
+// eslint-disable-next-line sort-imports -- keep ttf2eot adapter beside font converter imports
+import convertTtfToEot from "../lib/ttf2eot";
 import svg2ttf from "svg2ttf";
-import ttf2eot from "ttf2eot";
 import ttf2woff from "ttf2woff";
 import wawoff2 from "wawoff2";
 
@@ -76,7 +77,7 @@ const toSvg = (glyphsData, options) => {
 
 const toTtf = (buffer, options) => Buffer.from(svg2ttf(buffer, options).buffer);
 
-const toEot = (buffer) => Buffer.from(ttf2eot(buffer).buffer);
+const toEot = (buffer) => convertTtfToEot(buffer);
 
 const toWoff = (buffer, options) => Buffer.from(ttf2woff(buffer, options).buffer);
 


### PR DESCRIPTION
## Summary

Adds direct test coverage for `ttf2eot` usage before upgrading Dependabot PR #545 (`ttf2eot` 2.0.0 → 3.1.0).

- Introduce `src/lib/ttf2eot` adapter (current v2 API: `Buffer.from(ttf2eot(ttf).buffer)`).
- Route `standalone` EOT generation through the adapter.
- Add unit tests that validate:
  - output is a valid EOT buffer (`is-eot`)
  - deterministic MD5 hash for fixture icons
  - adapter output matches `formats: ["ttf", "eot"]` pipeline

## Context: Dependabot #545

PR #545 only bumps manifests. **v3.0.0 is a breaking change**: `ttf2eot()` returns `Uint8Array` directly instead of a `microbuffer` object with `.buffer`. The current code would break without updating the adapter to `Buffer.from(ttf2eot(ttf))`.

Merge this PR first, then rebase #545 and update the adapter for v3.

## Test plan

- [x] `npm test` (48 tests pass)

Made with [Cursor](https://cursor.com)