### PR TITLE
test: add nunjucks template coverage before 3.2.4 upgrade

### DIFF
--- a/src/cli/__snapshots__/index.test.ts.snap
+++ b/src/cli/__snapshots__/index.test.ts.snap
@@ -119,6 +119,336 @@ exports[`cli should generate all fonts with build-in template 1`] = `
 "
 `;
 
+exports[`cli should generate built-in html template 1`] = `
+"<!doctype html>
+<html lang=\\"en\\">
+  <head>
+    <meta charset=\\"utf-8\\">
+    <title>webfont</title>
+    <style type=\\"text/css\\">
+      body {
+        margin: 0;
+        padding:10px 20px;
+        background: #fff;
+        color: #222;
+        font-family:\\"Helvetica Neue\\", Arial, sans-serif;
+      }
+
+      h1 {
+        margin:0 0 20px;
+        font-size: 32px;
+        font-weight: normal;
+      }
+
+      .icons {
+        margin-bottom: 40px;
+        -webkit-column-count: 5;
+           -moz-column-count: 5;
+                column-count: 5;
+      }
+
+      .icons__item {
+        padding: 4px 0;
+      }
+
+      .icons__item,
+      .icons__item i {
+        cursor: pointer;
+        vertical-align: middle;
+      }
+
+      .icons__item:hover {
+        color: #3c90be;
+      }
+
+      .icons__item span {
+        display: inline-block;
+        line-height: 3em;
+        margin-left: 5px;
+        white-space: nowrap;
+      }
+
+      @font-face {
+        font-display: block;
+        font-family: \\"webfont\\";
+        font-style: normal;
+        font-weight: 400;
+        src: url(\\"./webfont.eot?test\\");
+        src: url(\\"./webfont.eot?#iefix\\") format(\\"embedded-opentype\\"), url(\\"./webfont.woff2?test\\") format(\\"woff2\\"), url(\\"./webfont.woff?test\\") format(\\"woff\\"), url(\\"./webfont.ttf?test\\") format(\\"truetype\\"), url(\\"./webfont.svg?test#webfont\\") format(\\"svg\\");
+      }
+
+      .webfont {
+        display: inline-block;
+        font-family: \\"webfont\\";
+        font-weight: 400;
+        font-style: normal;
+        font-variant: normal;
+        text-rendering: auto;
+        line-height: 1;
+        -moz-osx-font-smoothing: grayscale;
+        -webkit-font-smoothing: antialiased;
+      }
+
+      .webfont-lg {
+        font-size: 1.33333em;
+        line-height: 0.75em;
+        vertical-align: -0.0667em;
+      }
+
+      .webfont-xs {
+        font-size: 0.75em;
+      }
+
+      .webfont-sm {
+        font-size: 0.875em;
+      }
+
+      .webfont-1x {
+        font-size: 1em;
+      }
+
+      .webfont-2x {
+        font-size: 2em;
+      }
+
+      .webfont-3x {
+        font-size: 3em;
+      }
+
+      .webfont-4x {
+        font-size: 4em;
+      }
+
+      .webfont-5x {
+        font-size: 5em;
+      }
+
+      .webfont-6x {
+        font-size: 6em;
+      }
+
+      .webfont-7x {
+        font-size: 7em;
+      }
+
+      .webfont-8x {
+        font-size: 8em;
+      }
+
+      .webfont-9x {
+        font-size: 9em;
+      }
+
+      .webfont-10x {
+        font-size: 10em;
+      }
+
+      .webfont-fw {
+        text-align: center;
+        width: 1.25em;
+      }
+
+      .webfont-border {
+        border: solid 0.08em #eee;
+        border-radius: 0.1em;
+        padding: 0.2em 0.25em 0.15em;
+      }
+
+      .webfont-pull-left {
+        float: left;
+      }
+
+      .webfont-pull-right {
+        float: right;
+      }
+
+      .webfont.webfont-pull-left {
+        margin-right: 0.3em;
+      }
+
+      .webfont.webfont-pull-right {
+        margin-left: 0.3em;
+      }
+
+      
+      .webfont-avatar::before {
+        content: \\"\\\\ea01\\";
+      }
+      
+      .webfont-envelope::before {
+        content: \\"\\\\ea02\\";
+      }
+      
+      .webfont-phone-call::before {
+        content: \\"\\\\ea03\\";
+      }
+      
+    </style>
+  </head>
+  <body>
+    <h1>List Icons</h1>
+      <h3>Class</h3>
+      <div class=\\"icons\\" id=\\"icon-classes\\">
+          
+            <div class=\\"icons__item\\">
+              <i class=\\"webfont webfont-3x webfont-avatar\\"></i><br />
+              <span>.webfont-avatar</span>
+            </div>
+          
+            <div class=\\"icons__item\\">
+              <i class=\\"webfont webfont-3x webfont-envelope\\"></i><br />
+              <span>.webfont-envelope</span>
+            </div>
+          
+            <div class=\\"icons__item\\">
+              <i class=\\"webfont webfont-3x webfont-phone-call\\"></i><br />
+              <span>.webfont-phone-call</span>
+            </div>
+          
+      </div>
+      <h3>Ligature</h3>
+      <div class=\\"icons\\" id=\\"icon-ligatures\\">
+          
+            <div class=\\"icons__item\\">
+              <i class=\\"webfont webfont-3x\\">avatar</i><br />
+              <span>avatar</span>
+            </div>
+          
+            <div class=\\"icons__item\\">
+              <i class=\\"webfont webfont-3x\\">envelope</i><br />
+              <span>envelope</span>
+            </div>
+          
+            <div class=\\"icons__item\\">
+              <i class=\\"webfont webfont-3x\\">phone_call</i><br />
+              <span>phone_call</span>
+            </div>
+          
+      </div>
+  </body>
+</html>
+"
+`;
+
+exports[`cli should include font hash in template when addHashInFontUrl is enabled 1`] = `
+"@font-face {
+  font-display: auto;
+  font-family: \\"webfont\\";
+  font-style: normal;
+  font-weight: 400;
+  src: url(\\"./webfont.eot?test&v=1154313a3843c5f5ec70890715e8a527\\");
+  src: url(\\"./webfont.eot?v=1154313a3843c5f5ec70890715e8a527#iefix\\") format(\\"embedded-opentype\\"), url(\\"./webfont.woff2?test&v=1154313a3843c5f5ec70890715e8a527\\") format(\\"woff2\\"), url(\\"./webfont.woff?test&v=1154313a3843c5f5ec70890715e8a527\\") format(\\"woff\\"), url(\\"./webfont.ttf?test&v=1154313a3843c5f5ec70890715e8a527\\") format(\\"truetype\\"), url(\\"./webfont.svg?test&v=1154313a3843c5f5ec70890715e8a527#webfont\\") format(\\"svg\\");
+}
+
+.webfont {
+  display: inline-block;
+  font-family: \\"webfont\\";
+  font-weight: 400;
+  font-style: normal;
+  font-variant: normal;
+  text-rendering: auto;
+  line-height: 1;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+.webfont-lg {
+  font-size: 1.33333em;
+  line-height: 0.75em;
+  vertical-align: -0.0667em;
+}
+
+.webfont-xs {
+  font-size: 0.75em;
+}
+
+.webfont-sm {
+  font-size: 0.875em;
+}
+
+.webfont-1x {
+  font-size: 1em;
+}
+
+.webfont-2x {
+  font-size: 2em;
+}
+
+.webfont-3x {
+  font-size: 3em;
+}
+
+.webfont-4x {
+  font-size: 4em;
+}
+
+.webfont-5x {
+  font-size: 5em;
+}
+
+.webfont-6x {
+  font-size: 6em;
+}
+
+.webfont-7x {
+  font-size: 7em;
+}
+
+.webfont-8x {
+  font-size: 8em;
+}
+
+.webfont-9x {
+  font-size: 9em;
+}
+
+.webfont-10x {
+  font-size: 10em;
+}
+
+.webfont-fw {
+  text-align: center;
+  width: 1.25em;
+}
+
+.webfont-border {
+  border: solid 0.08em #eee;
+  border-radius: 0.1em;
+  padding: 0.2em 0.25em 0.15em;
+}
+
+.webfont-pull-left {
+  float: left;
+}
+
+.webfont-pull-right {
+  float: right;
+}
+
+.webfont.webfont-pull-left {
+  margin-right: 0.3em;
+}
+
+.webfont.webfont-pull-right {
+  margin-left: 0.3em;
+}
+
+
+.webfont-avatar::before {
+  content: \\"\\\\ea01\\";
+}
+
+.webfont-envelope::before {
+  content: \\"\\\\ea02\\";
+}
+
+.webfont-phone-call::before {
+  content: \\"\\\\ea03\\";
+}
+
+"
+`;
+
 exports[`cli should respect \`font\` options 1`] = `
 "<?xml version=\\"1.0\\" standalone=\\"no\\"?>
 <!DOCTYPE svg PUBLIC \\"-//W3C//DTD SVG 1.1//EN\\" \\"http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd\\" >

--- a/src/cli/index.test.ts
+++ b/src/cli/index.test.ts
@@ -141,6 +141,44 @@ describe("cli", () => {
     expect(data).toMatchSnapshot();
   });
 
+  it("should generate built-in html template", async () => {
+    const output = await execCLI(`${source} -d ${destination} --template html --templateCacheString test`);
+
+    expect(output.files).toEqual([
+      "webfont.eot",
+      "webfont.html",
+      "webfont.svg",
+      "webfont.ttf",
+      "webfont.woff",
+      "webfont.woff2",
+    ]);
+    expect(output.code).toBe(0);
+    expect(output.stderr).toBe("");
+    const data = await fsPromise.readFile(`${destination}/webfont.html`, { encoding: "utf-8" });
+    expect(data).toContain("<!doctype html>");
+    expect(data).toMatchSnapshot();
+  });
+
+  it("should include font hash in template when addHashInFontUrl is enabled", async () => {
+    const output = await execCLI(
+      `${source} -d ${destination} --template css --templateCacheString test --addHashInFontUrl`,
+    );
+
+    expect(output.files).toEqual([
+      "webfont.css",
+      "webfont.eot",
+      "webfont.svg",
+      "webfont.ttf",
+      "webfont.woff",
+      "webfont.woff2",
+    ]);
+    expect(output.code).toBe(0);
+    expect(output.stderr).toBe("");
+    const css = await fsPromise.readFile(`${destination}/webfont.css`, { encoding: "utf-8" });
+    expect(css).toMatch(/&v=[a-f0-9]{32}/u);
+    expect(css).toMatchSnapshot();
+  });
+
   it("can set font name", async () => {
     const output = await execCLI(`${source} -d ${destination} --fontName foobar`);
 

--- a/src/standalone/__snapshots__/index.test.ts.snap
+++ b/src/standalone/__snapshots__/index.test.ts.snap
@@ -608,6 +608,331 @@ exports[`standalone should generate all fonts with custom \`template\` with rela
 "
 `;
 
+exports[`standalone should generate built-in html template 1`] = `
+"<!doctype html>
+<html lang=\\"en\\">
+  <head>
+    <meta charset=\\"utf-8\\">
+    <title>webfont</title>
+    <style type=\\"text/css\\">
+      body {
+        margin: 0;
+        padding:10px 20px;
+        background: #fff;
+        color: #222;
+        font-family:\\"Helvetica Neue\\", Arial, sans-serif;
+      }
+
+      h1 {
+        margin:0 0 20px;
+        font-size: 32px;
+        font-weight: normal;
+      }
+
+      .icons {
+        margin-bottom: 40px;
+        -webkit-column-count: 5;
+           -moz-column-count: 5;
+                column-count: 5;
+      }
+
+      .icons__item {
+        padding: 4px 0;
+      }
+
+      .icons__item,
+      .icons__item i {
+        cursor: pointer;
+        vertical-align: middle;
+      }
+
+      .icons__item:hover {
+        color: #3c90be;
+      }
+
+      .icons__item span {
+        display: inline-block;
+        line-height: 3em;
+        margin-left: 5px;
+        white-space: nowrap;
+      }
+
+      @font-face {
+        font-display: block;
+        font-family: \\"webfont\\";
+        font-style: normal;
+        font-weight: 400;
+        src: url(\\"./webfont.eot?test\\");
+        src: url(\\"./webfont.eot?#iefix\\") format(\\"embedded-opentype\\"), url(\\"./webfont.woff2?test\\") format(\\"woff2\\"), url(\\"./webfont.woff?test\\") format(\\"woff\\"), url(\\"./webfont.ttf?test\\") format(\\"truetype\\"), url(\\"./webfont.svg?test#webfont\\") format(\\"svg\\");
+      }
+
+      .webfont {
+        display: inline-block;
+        font-family: \\"webfont\\";
+        font-weight: 400;
+        font-style: normal;
+        font-variant: normal;
+        text-rendering: auto;
+        line-height: 1;
+        -moz-osx-font-smoothing: grayscale;
+        -webkit-font-smoothing: antialiased;
+      }
+
+      .webfont-lg {
+        font-size: 1.33333em;
+        line-height: 0.75em;
+        vertical-align: -0.0667em;
+      }
+
+      .webfont-xs {
+        font-size: 0.75em;
+      }
+
+      .webfont-sm {
+        font-size: 0.875em;
+      }
+
+      .webfont-1x {
+        font-size: 1em;
+      }
+
+      .webfont-2x {
+        font-size: 2em;
+      }
+
+      .webfont-3x {
+        font-size: 3em;
+      }
+
+      .webfont-4x {
+        font-size: 4em;
+      }
+
+      .webfont-5x {
+        font-size: 5em;
+      }
+
+      .webfont-6x {
+        font-size: 6em;
+      }
+
+      .webfont-7x {
+        font-size: 7em;
+      }
+
+      .webfont-8x {
+        font-size: 8em;
+      }
+
+      .webfont-9x {
+        font-size: 9em;
+      }
+
+      .webfont-10x {
+        font-size: 10em;
+      }
+
+      .webfont-fw {
+        text-align: center;
+        width: 1.25em;
+      }
+
+      .webfont-border {
+        border: solid 0.08em #eee;
+        border-radius: 0.1em;
+        padding: 0.2em 0.25em 0.15em;
+      }
+
+      .webfont-pull-left {
+        float: left;
+      }
+
+      .webfont-pull-right {
+        float: right;
+      }
+
+      .webfont.webfont-pull-left {
+        margin-right: 0.3em;
+      }
+
+      .webfont.webfont-pull-right {
+        margin-left: 0.3em;
+      }
+
+      
+      .webfont-avatar::before {
+        content: \\"\\\\ea01\\";
+      }
+      
+      .webfont-envelope::before {
+        content: \\"\\\\ea02\\";
+      }
+      
+      .webfont-phone-call::before {
+        content: \\"\\\\ea03\\";
+      }
+      
+    </style>
+  </head>
+  <body>
+    <h1>List Icons</h1>
+      <h3>Class</h3>
+      <div class=\\"icons\\" id=\\"icon-classes\\">
+          
+            <div class=\\"icons__item\\">
+              <i class=\\"webfont webfont-3x webfont-avatar\\"></i><br />
+              <span>.webfont-avatar</span>
+            </div>
+          
+            <div class=\\"icons__item\\">
+              <i class=\\"webfont webfont-3x webfont-envelope\\"></i><br />
+              <span>.webfont-envelope</span>
+            </div>
+          
+            <div class=\\"icons__item\\">
+              <i class=\\"webfont webfont-3x webfont-phone-call\\"></i><br />
+              <span>.webfont-phone-call</span>
+            </div>
+          
+      </div>
+      <h3>Ligature</h3>
+      <div class=\\"icons\\" id=\\"icon-ligatures\\">
+          
+            <div class=\\"icons__item\\">
+              <i class=\\"webfont webfont-3x\\">avatar</i><br />
+              <span>avatar</span>
+            </div>
+          
+            <div class=\\"icons__item\\">
+              <i class=\\"webfont webfont-3x\\">envelope</i><br />
+              <span>envelope</span>
+            </div>
+          
+            <div class=\\"icons__item\\">
+              <i class=\\"webfont webfont-3x\\">phone_call</i><br />
+              <span>phone_call</span>
+            </div>
+          
+      </div>
+  </body>
+</html>
+"
+`;
+
+exports[`standalone should generate built-in json template 1`] = `
+Array [
+  Object {
+    "id": "avatar",
+    "name": "Avatar",
+    "unicode": Array [
+      "ea01",
+      "avatar",
+    ],
+  },
+  Object {
+    "id": "envelope",
+    "name": "Envelope",
+    "unicode": Array [
+      "ea02",
+      "envelope",
+    ],
+  },
+  Object {
+    "id": "phone-call",
+    "name": "Phone Call",
+    "unicode": Array [
+      "ea03",
+      "phone_call",
+    ],
+  },
+]
+`;
+
+exports[`standalone should generate built-in json template 2`] = `
+"[
+  {
+    \\"id\\": \\"avatar\\",
+    \\"name\\": \\"Avatar\\",
+    \\"unicode\\": [\\"ea01\\", \\"avatar\\"]
+  },
+{
+    \\"id\\": \\"envelope\\",
+    \\"name\\": \\"Envelope\\",
+    \\"unicode\\": [\\"ea02\\", \\"envelope\\"]
+  },
+{
+    \\"id\\": \\"phone-call\\",
+    \\"name\\": \\"Phone Call\\",
+    \\"unicode\\": [\\"ea03\\", \\"phone_call\\"]
+  }
+]"
+`;
+
+exports[`standalone should generate built-in styl template 1`] = `
+"$webfont-avatar = \\"\\\\ea01\\";
+$webfont-envelope = \\"\\\\ea02\\";
+$webfont-phone-call = \\"\\\\ea03\\";
+
+@font-face {
+    font-family: webfont;
+    src: url(\\"./webfont.eot\\");
+    src: url(\\"./webfont.eot?#iefix\\") format(\\"embedded-opentype\\"), url(\\"./webfont.woff2\\") format(\\"woff2\\"), url(\\"./webfont.woff\\") format(\\"woff\\"), url(\\"./webfont.ttf\\") format(\\"truetype\\"), url(\\"./webfont.svg#webfont\\") format(\\"svg\\");
+    font-display: block;
+    font-style: normal;
+    font-weight: 400;
+}
+
+.webfont {
+    display: inline-block;
+    transform: translate(0, 0);
+    text-rendering: auto;
+    font: normal normal 400 14px/1 webfont;
+    font-size: inherit;
+    -moz-osx-font-smoothing: grayscale;
+    -webkit-font-smoothing: antialiased;
+}
+
+.webfont-lg {
+    vertical-align: -15%;
+    line-height: 0.75em;
+    font-size: 1.33333333em;
+}
+
+.webfont-2x {
+    font-size: 2em;
+}
+
+.webfont-3x {
+    font-size: 3em;
+}
+
+.webfont-4x {
+    font-size: 4em;
+}
+
+.webfont-5x {
+    font-size: 5em;
+}
+
+.webfont-fw {
+    width: 1.28571429em;
+    text-align: center;
+}
+
+.webfont-avatar::before {
+    content: $webfont-avatar;
+}
+
+.webfont-envelope::before {
+    content: $webfont-envelope;
+}
+
+.webfont-phone-call::before {
+    content: $webfont-phone-call;
+}
+"
+`;
+
 exports[`standalone should generate only \`woff\` and \`woff2\` fonts with build-in template 1`] = `
 "@font-face {
   font-display: auto;
@@ -616,6 +941,125 @@ exports[`standalone should generate only \`woff\` and \`woff2\` fonts with build
   font-weight: 400;
   
   src: url(\\"./webfont.woff2?test\\") format(\\"woff2\\"), url(\\"./webfont.woff?test\\") format(\\"woff\\"); 
+}
+
+.webfont {
+  display: inline-block;
+  font-family: \\"webfont\\";
+  font-weight: 400;
+  font-style: normal;
+  font-variant: normal;
+  text-rendering: auto;
+  line-height: 1;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+.webfont-lg {
+  font-size: 1.33333em;
+  line-height: 0.75em;
+  vertical-align: -0.0667em;
+}
+
+.webfont-xs {
+  font-size: 0.75em;
+}
+
+.webfont-sm {
+  font-size: 0.875em;
+}
+
+.webfont-1x {
+  font-size: 1em;
+}
+
+.webfont-2x {
+  font-size: 2em;
+}
+
+.webfont-3x {
+  font-size: 3em;
+}
+
+.webfont-4x {
+  font-size: 4em;
+}
+
+.webfont-5x {
+  font-size: 5em;
+}
+
+.webfont-6x {
+  font-size: 6em;
+}
+
+.webfont-7x {
+  font-size: 7em;
+}
+
+.webfont-8x {
+  font-size: 8em;
+}
+
+.webfont-9x {
+  font-size: 9em;
+}
+
+.webfont-10x {
+  font-size: 10em;
+}
+
+.webfont-fw {
+  text-align: center;
+  width: 1.25em;
+}
+
+.webfont-border {
+  border: solid 0.08em #eee;
+  border-radius: 0.1em;
+  padding: 0.2em 0.25em 0.15em;
+}
+
+.webfont-pull-left {
+  float: left;
+}
+
+.webfont-pull-right {
+  float: right;
+}
+
+.webfont.webfont-pull-left {
+  margin-right: 0.3em;
+}
+
+.webfont.webfont-pull-right {
+  margin-left: 0.3em;
+}
+
+
+.webfont-avatar::before {
+  content: \\"\\\\ea01\\";
+}
+
+.webfont-envelope::before {
+  content: \\"\\\\ea02\\";
+}
+
+.webfont-phone-call::before {
+  content: \\"\\\\ea03\\";
+}
+
+"
+`;
+
+exports[`standalone should include font hash in template URLs when addHashInFontUrl is enabled 1`] = `
+"@font-face {
+  font-display: auto;
+  font-family: \\"webfont\\";
+  font-style: normal;
+  font-weight: 400;
+  
+  src: url(\\"./webfont.woff2?test&v=1154313a3843c5f5ec70890715e8a527\\") format(\\"woff2\\"); 
 }
 
 .webfont {

--- a/src/standalone/index.test.ts
+++ b/src/standalone/index.test.ts
@@ -409,6 +409,55 @@ describe("standalone", () => {
     expect(result.template).toMatchSnapshot();
   });
 
+  it("should generate built-in html template", async () => {
+    const result = await standalone({
+      files: `${fixturesGlob}/svg-icons/**/*`,
+      template: "html",
+      templateCacheString: "test",
+    });
+
+    expect(result.usedBuildInTemplate).toBe(true);
+    expect(result.template).toContain("<!doctype html>");
+    expect(result.template).toMatchSnapshot();
+  });
+
+  it("should generate built-in json template", async () => {
+    const result = await standalone({
+      files: `${fixturesGlob}/svg-icons/**/*`,
+      template: "json",
+      templateCacheString: "test",
+    });
+
+    expect(result.usedBuildInTemplate).toBe(true);
+    expect(JSON.parse(result.template)).toMatchSnapshot();
+    expect(result.template).toMatchSnapshot();
+  });
+
+  it("should generate built-in styl template", async () => {
+    const result = await standalone({
+      files: `${fixturesGlob}/svg-icons/**/*`,
+      template: "styl",
+      templateCacheString: "test",
+    });
+
+    expect(result.usedBuildInTemplate).toBe(true);
+    expect(result.template).toMatchSnapshot();
+  });
+
+  it("should include font hash in template URLs when addHashInFontUrl is enabled", async () => {
+    const result = await standalone({
+      files: `${fixturesGlob}/svg-icons/**/*`,
+      template: "css",
+      templateCacheString: "test",
+      addHashInFontUrl: true,
+      formats: ["woff2"],
+    });
+
+    expect(result.hash).toBeTruthy();
+    expect(result.template).toContain(`&v=${result.hash}`);
+    expect(result.template).toMatchSnapshot();
+  });
+
   it("should export `glyphsData` in `result`", async () => {
     const result = await standalone({
       files: `${fixturesGlob}/svg-icons/**/*`,


### PR DESCRIPTION
## Summary
- Adds integration tests for Nunjucks built-in templates not previously covered: `html`, `json`, and `styl`
- Adds coverage for `addHashInFontUrl` in both `standalone()` and the CLI (template URLs include `&v=<hash>`)
- Prepares the test suite for the nunjucks 3.2.3 → 3.2.4 security upgrade ([#616](https://github.com/itgalaxy/webfont/pull/616))

## Test plan
- [x] `npm test` passes (54 tests, 20 snapshots)
- [x] Merge this PR before or together with #616
- [ ] After #616 lands, confirm snapshots still pass (escape filter change in 3.2.4)


Made with [Cursor](https://cursor.com)