### PR TITLE
fix(deps): upgrade nunjucks to 3.2.4

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,9 +51,11 @@ This project uses [Biome](https://biomejs.dev/) for linting and formatting (`bio
 
 ### Dependencies
 
-- Pin exact versions in `package.json` (no `^`, `~`, or `latest` ranges).
+- Pin exact versions in `package.json` (no `^`, `~`, or `latest` ranges), including `@types/*` packages.
 - The repository sets `save-exact=true` in `.npmrc`, so `npm install <package>` records exact versions automatically.
-- When upgrading a dependency, update both `package.json` and `package-lock.json` in the same pull request.
+- When upgrading a dependency, pin its `@types/<package>` counterpart in the same pull request when one exists.
+- Update both `package.json` and `package-lock.json` in the same pull request.
+- [Dependabot](.github/dependabot.yml) opens upgrade PRs for pinned dependencies; do not use open ranges to get updates.
 
 ### CI changes
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,7 @@
         "@rollup/plugin-typescript": "latest",
         "@types/jest": "26.0.24",
         "@types/node": "^22.15.0",
-        "@types/nunjucks": "latest",
+        "@types/nunjucks": "3.2.6",
         "@types/rimraf": "latest",
         "babel-jest": "27.1.0",
         "husky": "latest",
@@ -2783,10 +2783,11 @@
       "integrity": "sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw=="
     },
     "node_modules/@types/nunjucks": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/@types/nunjucks/-/nunjucks-3.1.5.tgz",
-      "integrity": "sha512-0zEdmQNNvQ+xyV9kqQvAV93UVroTwhE78toVUDT0GBnGcW2jQBZnB4al9qq2LqI5qHOqROy/DvvAY/UwrbvV1A==",
-      "dev": true
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@types/nunjucks/-/nunjucks-3.2.6.tgz",
+      "integrity": "sha512-pHiGtf83na1nCzliuAdq8GowYiXvH5l931xZ0YEHaLMNFgynpEqx+IPStlu7UaDkehfvl01e4x/9Tpwhy7Ue3w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/parse-json": {
       "version": "4.0.0",
@@ -13340,9 +13341,9 @@
       "integrity": "sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw=="
     },
     "@types/nunjucks": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/@types/nunjucks/-/nunjucks-3.1.5.tgz",
-      "integrity": "sha512-0zEdmQNNvQ+xyV9kqQvAV93UVroTwhE78toVUDT0GBnGcW2jQBZnB4al9qq2LqI5qHOqROy/DvvAY/UwrbvV1A==",
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@types/nunjucks/-/nunjucks-3.2.6.tgz",
+      "integrity": "sha512-pHiGtf83na1nCzliuAdq8GowYiXvH5l931xZ0YEHaLMNFgynpEqx+IPStlu7UaDkehfvl01e4x/9Tpwhy7Ue3w==",
       "dev": true
     },
     "@types/parse-json": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "deepmerge": "^4.2.2",
         "globby": "^11.0.0",
         "meow": "^9.0.0",
-        "nunjucks": "^3.2.3",
+        "nunjucks": "3.2.4",
         "p-limit": "7.3.0",
         "parse-json": "^5.2.0",
         "resolve-from": "^5.0.0",
@@ -9132,9 +9132,10 @@
       }
     },
     "node_modules/nunjucks": {
-      "version": "3.2.3",
-      "resolved": "https://registry.npmjs.org/nunjucks/-/nunjucks-3.2.3.tgz",
-      "integrity": "sha512-psb6xjLj47+fE76JdZwskvwG4MYsQKXUtMsPh6U0YMvmyjRtKRFcxnlXGWglNybtNTNVmGdp94K62/+NjF5FDQ==",
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/nunjucks/-/nunjucks-3.2.4.tgz",
+      "integrity": "sha512-26XRV6BhkgK0VOxfbU5cQI+ICFUtMLixv1noZn1tGU38kQH5A5nmmbk/O45xdyBhD1esk47nKrY0mvQpZIhRjQ==",
+      "license": "BSD-2-Clause",
       "dependencies": {
         "a-sync-waterfall": "^1.0.0",
         "asap": "^2.0.3",
@@ -18145,9 +18146,9 @@
       "dev": true
     },
     "nunjucks": {
-      "version": "3.2.3",
-      "resolved": "https://registry.npmjs.org/nunjucks/-/nunjucks-3.2.3.tgz",
-      "integrity": "sha512-psb6xjLj47+fE76JdZwskvwG4MYsQKXUtMsPh6U0YMvmyjRtKRFcxnlXGWglNybtNTNVmGdp94K62/+NjF5FDQ==",
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/nunjucks/-/nunjucks-3.2.4.tgz",
+      "integrity": "sha512-26XRV6BhkgK0VOxfbU5cQI+ICFUtMLixv1noZn1tGU38kQH5A5nmmbk/O45xdyBhD1esk47nKrY0mvQpZIhRjQ==",
       "requires": {
         "a-sync-waterfall": "^1.0.0",
         "asap": "^2.0.3",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "deepmerge": "^4.2.2",
     "globby": "^11.0.0",
     "meow": "^9.0.0",
-    "nunjucks": "^3.2.3",
+    "nunjucks": "3.2.4",
     "p-limit": "7.3.0",
     "parse-json": "^5.2.0",
     "resolve-from": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "@rollup/plugin-typescript": "latest",
     "@types/jest": "26.0.24",
     "@types/node": "^22.15.0",
-    "@types/nunjucks": "latest",
+    "@types/nunjucks": "3.2.6",
     "@types/rimraf": "latest",
     "babel-jest": "27.1.0",
     "husky": "latest",


### PR DESCRIPTION
## Summary
- Upgrades `nunjucks` from `3.2.3` to `3.2.4` (pinned exact version)
- Pins `@types/nunjucks` to `3.2.6` (replacing `latest`)
- Documents `@types/*` pinning in `CONTRIBUTING.md`; Dependabot handles upgrade PRs
- Fixes [SNYK-JS-NUNJUCKS-5431309](https://snyk.io/vuln/SNYK-JS-NUNJUCKS-5431309) — XSS when using the `escape` filter or autoescape (backslash encoding)
- Supersedes stale Snyk PR #616 (conflicts with current `master`)

## Context
PR #651 added Nunjucks template coverage (`html`, `json`, `styl`, `addHashInFontUrl`) before this upgrade. All **54 tests** and **20 snapshots** pass with no changes after bumping to 3.2.4.

## Test plan
- [x] `npm test` passes locally
- [x] CI green
- [ ] Close #616 after merge