### PR TITLE
chore: remove legacy ESLint suppressions and @ts-expect-error

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,6 +37,16 @@ When a dependency only exposes callbacks (`rimraf`, legacy `fs.mkdir`), extract 
 - Keep changes focused; match surrounding code style and tooling (Biome, Jest, Lefthook).
 - Do not commit unless explicitly asked.
 
+### Lint and type hygiene
+
+- **No `eslint-disable*` comments.** ESLint is not used; Biome is the linter ([ADR 0001](docs/adr/0001-eslint-vs-biome-linting.md)). Delete stale ESLint suppressions; use `biome-ignore` only when a rule cannot be satisfied by a small code change.
+- **No `@ts-expect-error` or `@ts-ignore`.** Resolve types properly:
+  - Config fixtures with extra keys: `ResultConfig & { key: Type }` + cast in tests.
+  - Mocks: import the `__mocks__` module for assertions, or a small helper type when a cast is unavoidable (`as unknown as MockType`).
+  - Expected rejections: `await expect(fn()).rejects.toThrow(...)` (not `try/catch` + conditional expects).
+  - Unused parameters: `_name` prefix on the parameter or property.
+- After edits, run `npm test` and confirm `rg 'eslint-disable|@ts-expect-error|@ts-ignore'` returns no matches.
+
 ## Pull requests
 
 When a task produces branch changes intended for review (features, fixes, CI, docs, refactors):

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,6 +49,20 @@ And, if you’re raising an issue, please understand that people involved with t
 
 This project uses [Biome](https://biomejs.dev/) for linting and formatting (`biome.json`). Use `npm run lint` to check and `npm run prettify` to auto-fix.
 
+**Do not add legacy ESLint suppressions.** This repository no longer uses ESLint (see [ADR 0001](docs/adr/0001-eslint-vs-biome-linting.md)). Remove `eslint-disable` / `eslint-enable` comments instead of carrying them forward. When a rule must be suppressed, use a targeted `biome-ignore` comment with a short reason.
+
+**Do not suppress TypeScript with `@ts-expect-error` or `@ts-ignore`.** Fix the underlying type issue instead:
+
+| Situation | Prefer |
+|-----------|--------|
+| Extra keys from a loaded config file in tests | `type LoadedConfig = ResultConfig & { foo: string }` and cast `result.config as LoadedConfig` |
+| Untyped or partial mocks (e.g. CLI `meow`) | Import from `__mocks__/` for assertions; if a cast is needed, use `as unknown as MockType` |
+| Async code that should reject | `await expect(promise).rejects.toThrow(...)` or `.rejects.toMatchObject(...)` instead of `try/catch` + conditional `expect` |
+| Intentionally unused parameters | Prefix with `_` (e.g. `_options`) so Biome and TypeScript accept them |
+| Regex style rules | Rewrite the pattern (e.g. `/\s/gu` instead of a capture group only used for whitespace) |
+
+Only use `biome-ignore` when there is no reasonable code change; never use it to paper over type errors—adjust types or test helpers instead.
+
 ### Git hooks
 
 Git hooks are managed by [Lefthook](https://github.com/evilmartians/lefthook) (`lefthook.yml`). They install automatically when you run `npm install` (`prepare` → `lefthook install`).

--- a/src/cli/index.test.ts
+++ b/src/cli/index.test.ts
@@ -3,7 +3,7 @@ import * as fsPromise from "fs/promises";
 import path from "path";
 import rimraf from "rimraf";
 import { execCLI } from "../lib/execCLI";
-import cli from "./meow";
+import meowMock from "./meow/__mocks__/index";
 
 const timeout = 10000;
 jest.mock("./meow");
@@ -74,7 +74,7 @@ describe("cli", () => {
     const output = await execCLI();
 
     expect(output.code).toBe(2);
-    expect(output.stdout).toBe(cli.showHelp());
+    expect(output.stdout).toBe(meowMock.showHelp());
     expect(output.stderr).toBe("");
   });
 
@@ -82,7 +82,7 @@ describe("cli", () => {
     const output = await execCLI("--help");
 
     expect(output.code).toBe(2);
-    expect(output.stdout).toBe(cli.showHelp());
+    expect(output.stdout).toBe(meowMock.showHelp());
     expect(output.stderr).toBe("");
   });
 
@@ -90,18 +90,15 @@ describe("cli", () => {
     const output = await execCLI("--version");
 
     expect(output.code).toBe(0);
-    expect(output.stdout).toBe(cli.showVersion());
+    expect(output.stdout).toBe(meowMock.showVersion());
     expect(output.stderr).toBe("");
   });
 
   it("should throw error `files glob patterns specified did not match any files` if not found files", async () => {
-    // eslint-disable-next-line max-len
     const output = await execCLI(`${fixturesGlob}/not-found-svg-icons/**/* -d ${destination}`);
 
     expect(output.code).toBe(1);
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-expect-error
-    expect(output.stdout).toContain(cli.error());
+    expect(output.stdout).toContain(meowMock.error());
     expect(output.stderr).toBe("");
   });
 
@@ -129,7 +126,6 @@ describe("cli", () => {
   });
 
   it("should generate all fonts with build-in template", async () => {
-    // eslint-disable-next-line max-len
     const output = await execCLI(`${source} -d ${destination} --template css --templateCacheString test`);
 
     expect(output.files).toEqual([
@@ -147,7 +143,6 @@ describe("cli", () => {
   });
 
   it("should respect `template` options", async () => {
-    // eslint-disable-next-line max-len
     const output = await execCLI(
       `${source} -d ${destination} --template css --templateClassName foo --templateCacheString test --templateFontPath test/path --templateFontName testname`,
     );
@@ -246,7 +241,6 @@ describe("cli", () => {
   });
 
   it("should respect `font` options", async () => {
-    // eslint-disable-next-line max-len
     const output = await execCLI(
       `${source} -d ${destination} --fontId testId --fontStyle italic --fontWeight 500 --fontHeight 15`,
     );
@@ -266,7 +260,6 @@ describe("cli", () => {
   });
 
   it("can be verbose", async () => {
-    // eslint-disable-next-line max-lines
     const output = await execCLI(`${source} -d ${destination} --verbose`);
 
     expect(output.files).toEqual([
@@ -277,9 +270,7 @@ describe("cli", () => {
       "webfont.woff",
       "webfont.woff2",
     ]);
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-expect-error
-    expect(output.stdout).toBe(cli.verbose());
+    expect(output.stdout).toBe(meowMock.verbose());
     expect(output.code).toBe(0);
     expect(output.stderr).toBe("");
   });

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -214,7 +214,6 @@ Promise.resolve()
       .then(() => Promise.resolve(result));
   })
   .catch((error) => {
-    // eslint-disable-next-line no-console
     console.log(error.stack);
 
     let exitCode = 1;

--- a/src/cli/meow/__mocks__/index.ts
+++ b/src/cli/meow/__mocks__/index.ts
@@ -1,4 +1,3 @@
-/* eslint-disable max-len, max-lines-per-function */
 import { version } from "../../../../package.json";
 
 const meowMock = Object.create(null);

--- a/src/cli/meow/index.ts
+++ b/src/cli/meow/index.ts
@@ -1,4 +1,3 @@
-/* eslint-disable max-len, sort-keys */
 import meow from "meow";
 
 const meowCLI = meow(

--- a/src/lib/execCLI/index.ts
+++ b/src/lib/execCLI/index.ts
@@ -9,8 +9,7 @@ export type Output = {
   stdout?: string;
 };
 
-// eslint-disable-next-line no-unused-vars
-export type ExecCLI = (args?: string, destination?: string) => Promise<Output>;
+export type ExecCLI = (_args?: string, _destination?: string) => Promise<Output>;
 
 /**
  * @name execCLI

--- a/src/lib/svgicons2svgfont/index.ts
+++ b/src/lib/svgicons2svgfont/index.ts
@@ -1,8 +1,5 @@
-/* eslint-disable sort-imports, no-duplicate-imports -- type and value imports from svgicons2svgfont */
-
 import type { SVGIcons2SVGFontStreamOptions } from "svgicons2svgfont";
 import { fileSorter, getMetadataService, SVGIcons2SVGFontStream } from "svgicons2svgfont";
-/* eslint-enable sort-imports, no-duplicate-imports */
 import type { WebfontOptions } from "../../types";
 
 export { fileSorter, getMetadataService, SVGIcons2SVGFontStream };

--- a/src/standalone/cosmiconfig.test.ts
+++ b/src/standalone/cosmiconfig.test.ts
@@ -3,6 +3,9 @@ import isWoff2 from "is-woff2";
 import path from "path";
 import standalone from "../standalone";
 import type { InitialOptions } from "../types";
+import type { ResultConfig } from "../types/ResultConfig";
+
+type DiscoveredRcConfig = ResultConfig & { foo: string };
 
 const fixturesRoot = path.join(__dirname, "../fixtures");
 const svgFiles = path.join(fixturesRoot, "svg-icons/*.svg");
@@ -130,9 +133,7 @@ describe("cosmiconfig", () => {
       });
 
       expect(result.config?.filePath).toBe(path.resolve(configFile));
-      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-      // @ts-expect-error
-      expect(result.config?.foo).toBe("bar");
+      expect((result.config as DiscoveredRcConfig).foo).toBe("bar");
     });
   });
 });

--- a/src/standalone/glyphsData.ts
+++ b/src/standalone/glyphsData.ts
@@ -1,8 +1,6 @@
 import { createReadStream } from "fs";
-/* eslint-enable sort-imports */
 import xml2js from "xml2js";
 import pLimit from "../lib/p-limit";
-/* eslint-disable sort-imports -- default and named imports from lib adapters */
 import { fileSorter, getMetadataService, getMetadataServiceOptions } from "../lib/svgicons2svgfont";
 import type { GlyphData, GlyphMetadata, WebfontOptions } from "../types";
 
@@ -22,8 +20,7 @@ const toGlyphMetadata = (metadata: {
   unicode: normalizeUnicode(metadata.unicode as GlyphMetadata["unicode"]),
 });
 
-// eslint-disable-next-line no-unused-vars
-type GlyphsDataGetter = (files: Array<GlyphData["srcPath"]>, options: WebfontOptions) => unknown;
+type GlyphsDataGetter = (_files: Array<GlyphData["srcPath"]>, _options: WebfontOptions) => unknown;
 
 export const getGlyphsData: GlyphsDataGetter = (files, options) => {
   const metadataProvider = options.metadataProvider || getMetadataService(getMetadataServiceOptions(options));
@@ -39,8 +36,7 @@ export const getGlyphsData: GlyphsDataGetter = (files, options) => {
             const glyph = createReadStream(srcPath);
             let glyphContents = "";
 
-            // eslint-disable-next-line no-promise-executor-return
-            return glyph
+            glyph
               .on("error", (glyphError) => reject(glyphError))
               .on("data", (data) => {
                 glyphContents += data.toString();

--- a/src/standalone/index.test.ts
+++ b/src/standalone/index.test.ts
@@ -7,29 +7,23 @@ import isWoff2 from "is-woff2";
 import path from "path";
 import standalone from "../standalone";
 import type { GlyphMetadata, GlyphTransformFn } from "../types";
+import type { ResultConfig } from "../types/ResultConfig";
+
+type DiscoveredRcConfig = ResultConfig & { foo: string };
 
 const fixturesGlob = "src/fixtures";
 
 describe("standalone", () => {
   it("should throw error if `files` not passed", async () => {
-    try {
-      await standalone();
-    } catch (error) {
-      expect(error.message).toMatch("You must pass webfont a `files` glob");
-    }
+    await expect(standalone()).rejects.toThrow("You must pass webfont a `files` glob");
   });
 
   it("should throw error `files glob patterns specified did not match any files` if not found files", async () => {
-    expect.assertions(1);
-
-    try {
-      await standalone({
+    await expect(
+      standalone({
         files: `${fixturesGlob}/not-found-svg-icons/**/*`,
-      });
-    } catch (error) {
-      // eslint-disable-next-line jest/no-conditional-expect
-      expect(error.message).toMatch("Files glob patterns specified did not match any files");
-    }
+      }),
+    ).rejects.toThrow("Files glob patterns specified did not match any files");
   });
 
   it("should generate all fonts", async () => {
@@ -168,9 +162,7 @@ describe("standalone", () => {
     expect(isEot(result.eot)).toBe(true);
     expect(isWoff(result.woff)).toBe(true);
     expect(isWoff2(result.woff2)).toBe(true);
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-expect-error
-    expect(result.config.foo).toBe("bar");
+    expect((result.config as DiscoveredRcConfig).foo).toBe("bar");
     expect(result.config.filePath).toBe(path.resolve(configFile));
   });
 
@@ -239,92 +231,65 @@ describe("standalone", () => {
       template: path.join(fixturesGlob, "templates/template-ordered.css"),
     });
 
-    // eslint-disable-next-line prefer-named-capture-group
-    const actual = templateOutput.replace(/(\s)/gu, "");
-    // eslint-disable-next-line prefer-named-capture-group
-    const expected = result.template.replace(/(\s)/gu, "");
+    const actual = templateOutput.replace(/\s/gu, "");
+    const expected = result.template.replace(/\s/gu, "");
 
     expect(actual).toBe(expected);
   });
 
   it("should throw error on bad svg images - `Unclosed root tag`", async () => {
-    expect.assertions(1);
-
     const configFile = path.join(fixturesGlob, "configs/.webfontrc");
 
-    try {
-      await standalone({
+    await expect(
+      standalone({
         configFile,
         files: `${fixturesGlob}/bad-svg-icons/avatar.svg`,
-      });
-    } catch (error) {
-      // eslint-disable-next-line jest/no-conditional-expect
-      expect(error.message).toMatch(/Unclosed root tag/u);
-    }
+      }),
+    ).rejects.toThrow(/Unclosed root tag/u);
   });
 
   it("should throw error on bad svg images - `Unterminated command at index`", async () => {
-    expect.assertions(1);
-
     const configFile = path.join(fixturesGlob, "configs/.webfontrc");
 
-    try {
-      await standalone({
+    await expect(
+      standalone({
         configFile,
         files: `${fixturesGlob}/bad-svg-icons/avatar-1.svg`,
-      });
-    } catch (error) {
-      // eslint-disable-next-line jest/no-conditional-expect
-      expect(error.message).toMatch(/Unterminated command at index/u);
-    }
+      }),
+    ).rejects.toThrow(/Unterminated command at index/u);
   });
 
   it('should throw error on bad svg images - `Unexpected character "N"`', async () => {
-    expect.assertions(1);
-
     const configFile = path.join(fixturesGlob, "configs/.webfontrc");
 
-    try {
-      await standalone({
+    await expect(
+      standalone({
         configFile,
         files: `${fixturesGlob}/bad-svg-icons/avatar-2.svg`,
-      });
-    } catch (error) {
-      // eslint-disable-next-line jest/no-conditional-expect
-      expect(error.message).toMatch(/Unexpected character "N"/u);
-    }
+      }),
+    ).rejects.toThrow(/Unexpected character "N"/u);
   });
 
   it("should throw error on bad svg images - empty file", async () => {
-    expect.assertions(1);
-
     const configFile = path.join(fixturesGlob, "configs/.webfontrc");
 
-    try {
-      await standalone({
+    await expect(
+      standalone({
         configFile,
         files: `${fixturesGlob}/bad-svg-icons/avatar-3.svg`,
-      });
-    } catch (error) {
-      // eslint-disable-next-line jest/no-conditional-expect
-      expect(error.message).toMatch(/Empty file/u);
-    }
+      }),
+    ).rejects.toThrow(/Empty file/u);
   });
 
   it("should throw error of config file not found", async () => {
-    expect.assertions(1);
-
     const configFile = path.join(fixturesGlob, "configs/.not-exist-webfontrc");
 
-    try {
-      await standalone({
+    await expect(
+      standalone({
         configFile,
         files: `${fixturesGlob}/svg-icons/**/*`,
-      });
-    } catch (error) {
-      // eslint-disable-next-line jest/no-conditional-expect
-      expect(error.code).toBe("ENOENT");
-    }
+      }),
+    ).rejects.toMatchObject({ code: "ENOENT" });
   });
 
   it("should create css selectors with transform titles through function", async () => {

--- a/src/standalone/index.ts
+++ b/src/standalone/index.ts
@@ -10,9 +10,8 @@ import ttf2woff from "ttf2woff";
 import wawoff2 from "wawoff2";
 import { getBuiltInTemplates, getTemplateFilePath } from "../../templates";
 import { getFontStreamOptions, SVGIcons2SVGFontStream } from "../lib/svgicons2svgfont";
-// eslint-disable-next-line sort-imports -- keep ttf2eot adapter beside font converter imports
 import convertTtfToEot from "../lib/ttf2eot";
-import type { Format, GlyphData, InitialOptions } from "../types";
+import type { Format, GlyphData, GlyphMetadata, InitialOptions } from "../types";
 import type { Result } from "../types/Result";
 import type { ResultConfig } from "../types/ResultConfig";
 import { getGlyphsData } from "./glyphsData";
@@ -40,12 +39,13 @@ const buildConfig = async (options: {
   return config ?? {};
 };
 
+type GlyphReadable = Readable & { metadata: GlyphMetadata };
+
 const toSvg = (glyphsData, options) => {
   let result = "";
 
   return new Promise((resolve, reject) => {
     if (options.verbose) {
-      // eslint-disable-next-line no-console
       console.log("Generating SVG font...");
     }
 
@@ -57,13 +57,10 @@ const toSvg = (glyphsData, options) => {
       .on("error", (error) => reject(error));
 
     glyphsData.forEach((glyphData) => {
-      const glyphStream: Readable = new Readable();
+      const glyphStream: GlyphReadable = new Readable() as GlyphReadable;
 
       glyphStream.push(glyphData.contents);
       glyphStream.push(null);
-
-      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-      // @ts-expect-error
       glyphStream.metadata = glyphData.metadata;
 
       fontStream.write(glyphStream);
@@ -81,8 +78,7 @@ const toWoff = (buffer, options) => Buffer.from(ttf2woff(buffer, options).buffer
 
 const toWoff2 = (buffer) => wawoff2.compress(buffer);
 
-// eslint-disable-next-line no-unused-vars
-type Webfont = (initialOptions?: InitialOptions) => Promise<Result>;
+type Webfont = (_initialOptions?: InitialOptions) => Promise<Result>;
 
 export const webfont: Webfont = async (initialOptions) => {
   let options = getOptions(initialOptions);

--- a/src/standalone/options.ts
+++ b/src/standalone/options.ts
@@ -1,8 +1,7 @@
 import type { InitialOptions } from "../types/InitialOptions";
 import type { WebfontOptions } from "../types/WebfontOptions";
 
-// eslint-disable-next-line no-unused-vars
-type OptionsGetter = (initialOptions?: InitialOptions) => WebfontOptions;
+type OptionsGetter = (_initialOptions?: InitialOptions) => WebfontOptions;
 
 export const getOptions: OptionsGetter = (initialOptions) => {
   if (!initialOptions?.files) {

--- a/src/types/GlyphTransformFn.ts
+++ b/src/types/GlyphTransformFn.ts
@@ -1,4 +1,3 @@
 import type { GlyphMetadata } from "./GlyphMetadata";
 
-// eslint-disable-next-line no-unused-vars
-export type GlyphTransformFn = (obj: GlyphMetadata) => GlyphMetadata | Promise<GlyphMetadata>;
+export type GlyphTransformFn = (_obj: GlyphMetadata) => GlyphMetadata | Promise<GlyphMetadata>;


### PR DESCRIPTION
## Summary

### Proposed changes

This PR brings the following changes:

- Remove all legacy `eslint-disable` / `eslint-enable` comments left over from the ESLint era (Biome is the linter since ADR 0001).
- Remove all `@ts-expect-error` suppressions and replace them with proper typing patterns:
  - `ResultConfig & { foo: string }` casts for extra keys in loaded config fixtures.
  - `await expect(...).rejects.toThrow()` / `.rejects.toMatchObject()` instead of `try/catch` + conditional expects.
  - Direct imports from `__mocks__/` for CLI assertions instead of unsafe casts on the mocked module.
  - `_`-prefixed parameters/properties for intentionally unused values.
  - `/\s/gu` instead of capture groups used only for whitespace stripping.
- Document these conventions in `CONTRIBUTING.md` (for humans) and `AGENTS.md` (for AI agents).

### Related issue

N/A — hygiene / follow-up to Biome migration (ADR 0001).

### Dependencies added/removed (if applicable)

N/A

---

#### How to test

Describe the tests that you ran to verify your changes:

1. Run `npm test` (build + Biome lint + 66 Jest tests).
2. Confirm `rg 'eslint-disable|@ts-expect-error|@ts-ignore' src` returns no matches in source files.

#### Test configuration

- Node.js version (if applicable): project default
- NPM version (if applicable): project default

---

## Checklist

- [x] I have added corresponding labels to this PR (like bug, enhancement...);
- [x] My commits follow the [Conventional Commits 1.0 Guidelines](https://www.conventionalcommits.org/en/v1.0.0/);
- [x] My code follows the style guidelines of this project;
- [x] I have performed a self-review of my own code;
- [x] I have mapped technical debts found on my changes;
- [x] I have made changes to the documentation (if applicable);
- [x] My changes generate no new warnings or errors;

Made with [Cursor](https://cursor.com)