### PR TITLE
chore(deps): upgrade cosmiconfig from 8.3.6 to 9.0.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "11.5.21",
       "license": "MIT",
       "dependencies": {
-        "cosmiconfig": "8.3.6",
+        "cosmiconfig": "9.0.2",
         "deepmerge": "^4.2.2",
         "globby": "16.2.0",
         "meow": "^9.0.0",
@@ -2668,15 +2668,15 @@
       }
     },
     "node_modules/cosmiconfig": {
-      "version": "8.3.6",
-      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-8.3.6.tgz",
-      "integrity": "sha512-kcZ6+W5QzcJ3P1Mt+83OUv/oHFqZHIx8DuxG6eZ5RGMERoLqp4BuGjhHLYGK+Kf5XVkQvqBSmAy/nGWN3qDgEA==",
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-9.0.2.tgz",
+      "integrity": "sha512-gtTZxTDau1wL7Y7zifc2dd8jHSK/k6BTx/2Xp/BpdlAdnlYWFVt7qhJqgwi7637yRwRQ3qL4ZidbB4I8tA5VOg==",
       "license": "MIT",
       "dependencies": {
+        "env-paths": "^2.2.1",
         "import-fresh": "^3.3.0",
         "js-yaml": "^4.1.0",
-        "parse-json": "^5.2.0",
-        "path-type": "^4.0.0"
+        "parse-json": "^5.2.0"
       },
       "engines": {
         "node": ">=14"
@@ -2935,6 +2935,15 @@
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "dev": true
+    },
+    "node_modules/env-paths": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
+      "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/error-ex": {
       "version": "1.3.2",
@@ -6797,14 +6806,6 @@
         "node": "20 || >=22"
       }
     },
-    "node_modules/path-type": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
-      "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/picomatch": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.0.tgz",
@@ -10040,14 +10041,14 @@
       }
     },
     "cosmiconfig": {
-      "version": "8.3.6",
-      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-8.3.6.tgz",
-      "integrity": "sha512-kcZ6+W5QzcJ3P1Mt+83OUv/oHFqZHIx8DuxG6eZ5RGMERoLqp4BuGjhHLYGK+Kf5XVkQvqBSmAy/nGWN3qDgEA==",
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-9.0.2.tgz",
+      "integrity": "sha512-gtTZxTDau1wL7Y7zifc2dd8jHSK/k6BTx/2Xp/BpdlAdnlYWFVt7qhJqgwi7637yRwRQ3qL4ZidbB4I8tA5VOg==",
       "requires": {
+        "env-paths": "^2.2.1",
         "import-fresh": "^3.3.0",
         "js-yaml": "^4.1.0",
-        "parse-json": "^5.2.0",
-        "path-type": "^4.0.0"
+        "parse-json": "^5.2.0"
       },
       "dependencies": {
         "argparse": {
@@ -10231,6 +10232,11 @@
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "dev": true
+    },
+    "env-paths": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
+      "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A=="
     },
     "error-ex": {
       "version": "1.3.2",
@@ -13042,11 +13048,6 @@
           "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A=="
         }
       }
-    },
-    "path-type": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
-      "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw=="
     },
     "picomatch": {
       "version": "2.3.0",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "testu": "npm test -- -u"
   },
   "dependencies": {
-    "cosmiconfig": "8.3.6",
+    "cosmiconfig": "9.0.2",
     "deepmerge": "^4.2.2",
     "globby": "16.2.0",
     "meow": "^9.0.0",

--- a/src/standalone/index.ts
+++ b/src/standalone/index.ts
@@ -25,7 +25,10 @@ const isCosmiconfigLoaded = (value: CosmiconfigLoaded | Record<string, never>): 
 const buildConfig = async (options: {
   configFile?: string;
 }): Promise<CosmiconfigLoaded | Record<string, never>> => {
-  const configExplorer = cosmiconfig("webfont");
+  const configExplorer = cosmiconfig("webfont", {
+    // v9 defaults to `none` (cwd only); keep walking up to home/stopDir like v8.
+    searchStrategy: "global",
+  });
 
   if (options.configFile) {
     const configPath = path.resolve(process.cwd(), options.configFile);


### PR DESCRIPTION
## Summary

### Proposed changes

This PR brings the following changes:

- Upgrade `cosmiconfig` from `8.3.6` to `9.0.2` (latest stable release).
- Set `searchStrategy: "global"` when creating the explorer so config discovery still walks up parent directories (v9 defaults to `none`, cwd-only).

### Related issue

N/A — dependency maintenance (follow-up to #666).

### Dependencies added/removed (if applicable)

- Update: `cosmiconfig` `8.3.6` → `9.0.2`.

---

### Testing

- [x] I have added or updated tests that prove my fix is effective or that my feature works (if applicable)
  - [x] Unit test — existing `cosmiconfig.test.ts` suite (10 tests) passes unchanged

#### How to test

Describe the tests that you ran to verify your changes:

1. Run `npm test` — build, lint, and all 67 Jest tests pass.
2. Confirm parent-directory discovery (`walkup` fixture) still resolves `.webfontrc.json` from a nested cwd.

#### Test configuration

- Node.js version (if applicable): 26.4.0
- NPM version (if applicable): (project default)

---

## Checklist

- [x] I have added corresponding labels to this PR (like bug, enhancement...);
- [x] My commits follow the [Conventional Commits 1.0 Guidelines](https://www.conventionalcommits.org/en/v1.0.0/);
- [x] My code follows the style guidelines of this project;
- [x] I have performed a self-review of my own code;
- [x] I have mapped technical debts found on my changes;
- [x] I have made changes to the documentation (if applicable);
- [x] My changes generate no new warnings or errors;

Made with [Cursor](https://cursor.com)