### PR TITLE
docs: forbid ignoreDeprecations in TypeScript config

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,7 +45,8 @@ When a dependency only exposes callbacks (`rimraf`, legacy `fs.mkdir`), extract 
   - Mocks: import the `__mocks__` module for assertions, or a small helper type when a cast is unavoidable (`as unknown as MockType`).
   - Expected rejections: `await expect(fn()).rejects.toThrow(...)` (not `try/catch` + conditional expects).
   - Unused parameters: `_name` prefix on the parameter or property.
-- After edits, run `npm test` and confirm `rg 'eslint-disable|@ts-expect-error|@ts-ignore'` returns no matches.
+- **No `ignoreDeprecations` in `tsconfig.json` (or any tsconfig).** On TypeScript upgrades, migrate deprecated compiler options and fix type errors instead of silencing warnings (see [CONTRIBUTING.md](./CONTRIBUTING.md)).
+- After edits, run `npm test` and confirm `rg 'eslint-disable|@ts-expect-error|@ts-ignore|ignoreDeprecations'` returns no matches.
 
 ## Pull requests
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,6 +63,8 @@ This project uses [Biome](https://biomejs.dev/) for linting and formatting (`bio
 
 Only use `biome-ignore` when there is no reasonable code change; never use it to paper over type errors—adjust types or test helpers instead.
 
+**Do not use `ignoreDeprecations` in TypeScript config.** When upgrading TypeScript or hitting deprecated compiler options, migrate `tsconfig.json` (for example, replace deprecated `moduleResolution` values) and fix resulting type errors. Do not silence deprecations with `ignoreDeprecations`.
+
 ### Git hooks
 
 Git hooks are managed by [Lefthook](https://github.com/evilmartians/lefthook) (`lefthook.yml`). They install automatically when you run `npm install` (`prepare` → `lefthook install`).


### PR DESCRIPTION
## Summary

### Proposed changes

This PR brings the following changes:

- Document in `CONTRIBUTING.md` that `ignoreDeprecations` must not be used in TypeScript config; migrate deprecated compiler options and fix type errors instead.
- Add the same rule to `AGENTS.md` for AI agents, and extend the post-edit `rg` check to include `ignoreDeprecations`.

### Related issue

N/A

### Dependencies added/removed (if applicable)

N/A

---

### Testing

- [x] I have added or updated tests that prove my fix is effective or that my feature works (if applicable)
  - Docs-only change; no runtime or test updates required.

#### How to test

Describe the tests that you ran to verify your changes:

1. Review `CONTRIBUTING.md` and `AGENTS.md` for the new guidance.
2. Confirm `rg 'ignoreDeprecations'` returns no matches in the repository.

#### Test configuration

N/A

---

## Checklist

- [ ] I have added corresponding labels to this PR (like bug, enhancement...);
- [x] My commits follow the [Conventional Commits 1.0 Guidelines](https://www.conventionalcommits.org/en/v1.0.0/);
- [x] My code follows the style guidelines of this project;
- [x] I have performed a self-review of my own code;
- [x] I have mapped technical debts found on my changes;
- [x] I have made changes to the documentation (if applicable);
- [x] My changes generate no new warnings or errors;

Made with [Cursor](https://cursor.com)