### PR TITLE
docs: forbid direct commits and pushes to master

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,6 +67,7 @@ See also [CONTRIBUTING.md](./CONTRIBUTING.md) — “User-facing changes and doc
 - Releases are handled by Release Please on `master`; do not bump `package.json` version in feature PRs (see [ADR 0004](docs/adr/0004-release-please-instead-of-standard-version.md)).
 - Keep changes focused; match surrounding code style and tooling (Biome, Jest, Lefthook).
 - Do not commit unless explicitly asked.
+- **Never push to `master`.** Use a branch and open a PR (see [Pull requests](#pull-requests) below).
 
 ### Lint and type hygiene
 
@@ -81,12 +82,15 @@ See also [CONTRIBUTING.md](./CONTRIBUTING.md) — “User-facing changes and doc
 
 ## Pull requests
 
+**Never push commits directly to `master`.** All changes — including docs, tests, and chores — go through a feature branch and a pull request. Only merge to `master` after review (or explicit maintainer approval on the PR). Do not use `git push origin master` for routine work.
+
 When a task produces branch changes intended for review (features, fixes, CI, docs, refactors):
 
-1. **Read** [`.github/pull_request_template.md`](./.github/pull_request_template.md) and use it as the PR body structure (do not substitute a shorter custom format).
-2. **Push** the branch to `origin` (`git push -u origin HEAD`) without asking first.
-3. **Open a PR** with `gh pr create` (title + body in English, base `master`) without asking first. Pass the body via HEREDOC so headings and checklists match the template.
-4. **Return the PR URL** in the final response.
+1. **Create a branch** from `master` (for example `docs/pr-workflow`, `test/xml2js-guards`, `fix/cli-formats`).
+2. **Read** [`.github/pull_request_template.md`](./.github/pull_request_template.md) and use it as the PR body structure (do not substitute a shorter custom format).
+3. **Push** the branch to `origin` (`git push -u origin HEAD`) without asking first.
+4. **Open a PR** with `gh pr create` (title + body in English, base `master`) without asking first. Pass the body via HEREDOC so headings and checklists match the template.
+5. **Return the PR URL** in the final response.
 
 ### Template sections (be selective)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,6 +36,7 @@ And, if you’re raising an issue, please understand that people involved with t
 
 ## Submitting a pull request
 
+- **Never commit or push directly to `master`.** Create a branch, open a pull request, and merge through GitHub — even for documentation-only or test-only changes. Maintainers merge; contributors and automation do not bypass review with `git push origin master`.
 - Non-trivial changes are often best discussed in an issue first, to prevent you from doing unnecessary work;
 - For ambitious tasks, you should try to get your work in front of the community for feedback as soon as possible;
 - New features should be accompanied with tests and documentation;


### PR DESCRIPTION
## Summary

### Proposed changes

This PR documents that **all changes must go through a feature branch and pull request** — never `git push origin master` for routine work.

- **AGENTS.md:** Add a prominent rule at the top of “Pull requests”; require creating a branch before push/PR; repeat in General.
- **CONTRIBUTING.md:** Add the same rule as the first bullet under “Submitting a pull request”.

### Related issue

N/A

### Dependencies added/removed (if applicable)

N/A

---

### Testing

- [x] I have added or updated tests that prove my fix is effective or that my feature works (if applicable)
  - Documentation-only change — verified by review; `npm test` still passes on the branch.

#### How to test

1. Read `AGENTS.md` (“Pull requests”) and `CONTRIBUTING.md` (“Submitting a pull request”).
2. Confirm both state that direct pushes to `master` are not allowed.

#### Test configuration

N/A

---

## Checklist

- [ ] I have added corresponding labels to this PR (like bug, enhancement...);
- [x] My commits follow the [Conventional Commits 1.0 Guidelines](https://www.conventionalcommits.org/en/v1.0.0/);
- [x] My code follows the style guidelines of this project;
- [x] I have performed a self-review of my own code;
- [x] I have mapped technical debts found on my changes;
- [x] I have made changes to the documentation (if applicable);
- [x] My changes generate no new warnings or errors;

Made with [Cursor](https://cursor.com)