### PR TITLE
test: add font output contract tests for is-svg and svg2ttf

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -102,11 +102,29 @@ See also [CONTRIBUTING.md](./CONTRIBUTING.md) — “User-facing changes and doc
 
 When a task produces branch changes intended for review (features, fixes, CI, docs, refactors):
 
-1. **Create a branch** from `master` (for example `docs/pr-workflow`, `test/xml2js-guards`, `fix/cli-formats`).
-2. **Read** [`.github/pull_request_template.md`](./.github/pull_request_template.md) and use it as the PR body structure (do not substitute a shorter custom format).
-3. **Push** the branch to `origin` (`git push -u origin HEAD`) without asking first.
-4. **Open a PR** with `gh pr create` (title + body in English, base `master`) without asking first. Pass the body via HEREDOC so headings and checklists match the template.
-5. **Return the PR URL** in the final response.
+1. **Check whether the current branch is already merged** (see [Merged branches](#merged-branches) below). If it is, create a **new branch from `master`** — do not push follow-up commits to a merged PR branch.
+2. **Create a branch** from `master` (for example `docs/pr-workflow`, `test/xml2js-guards`, `fix/cli-formats`).
+3. **Read** [`.github/pull_request_template.md`](./.github/pull_request_template.md) and use it as the PR body structure (do not substitute a shorter custom format).
+4. **Push** the branch to `origin` (`git push -u origin HEAD`) without asking first.
+5. **Open a PR** with `gh pr create` (title + body in English, base `master`) without asking first. Pass the body via HEREDOC so headings and checklists match the template.
+6. **Return the PR URL** in the final response.
+
+### Merged branches
+
+**Before every push**, confirm the target branch is still the right vehicle for the work:
+
+| Check | Command / action |
+|-------|------------------|
+| PR state | `gh pr view --head <branch> --json state,mergedAt,url` (or `gh pr list --head <branch>`) |
+| Branch contained in `master` | `git fetch origin master && git log --oneline origin/master..origin/<branch>` — if empty after your last merge, or PR `state` is `MERGED`, stop using that branch |
+
+**If the PR is merged (or the branch is obsolete):**
+
+1. **Do not** push new commits to that branch expecting them to land via the old PR.
+2. **Do** `git fetch origin master`, branch from `origin/master` (e.g. `test/font-output-contracts`), cherry-pick or re-apply only the commits not yet on `master`, then push and **`gh pr create`** a **new** PR.
+3. **Prefer one focused PR per follow-up** after merge — tests, docs, and unrelated fixes on top of merged work belong on a new branch, not on `fix/...` or `feat/...` branches whose PRs are already closed.
+
+Example mistake to avoid: pushing `test: add is-svg coverage` to `fix/cli-missing-dest` after PR #626 merged — those commits stay orphaned until opened on a fresh branch.
 
 ### Template sections (be selective)
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,6 +44,8 @@ Example: `glyphsData.test.ts` — `describe("svg xml validation via xml2js")` do
 
 Example: `isSvgOutput.test.ts` — documents the `is-svg` dev-dependency contract (via `fast-xml-parser`), negative fixtures, and when `result.svg` is absent (`toBeUndefined`) vs validated (`isSvg(result.svg)`).
 
+Example: `svg2ttfOutput.test.ts` — documents the `svg2ttf` production contract (via `@xmldom/xmldom`), invalid version options, early pipeline rejection before conversion, and when `result.ttf` is absent vs validated (`isTtf(result.ttf)`).
+
 Prefer `await expect(fn()).rejects.toThrow(...)` for async failures. Use spies on the next pipeline step to prove early exit.
 
 ### CLI integration tests (`execCLI`)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,6 +42,8 @@ When production code works around a library quirk or adds a defensive guard, add
 
 Example: `glyphsData.test.ts` — `describe("svg xml validation via xml2js")` documents that `xml2js` accepts empty input without error, then unit-tests the empty-file guard and malformed-xml rejection before metadata lookup.
 
+Example: `isSvgOutput.test.ts` — documents the `is-svg` dev-dependency contract (via `fast-xml-parser`), negative fixtures, and when `result.svg` is absent (`toBeUndefined`) vs validated (`isSvg(result.svg)`).
+
 Prefer `await expect(fn()).rejects.toThrow(...)` for async failures. Use spies on the next pipeline step to prove early exit.
 
 ### CLI integration tests (`execCLI`)

--- a/src/standalone/isSvgOutput.test.ts
+++ b/src/standalone/isSvgOutput.test.ts
@@ -1,0 +1,102 @@
+import isSvg from "is-svg";
+import standalone from "../standalone";
+
+const fixturesGlob = "src/fixtures/svg-icons";
+
+describe("is-svg output validation", () => {
+  describe("is-svg library contract (dev dependency)", () => {
+    it("documents that is-svg returns false for null, undefined, and empty input", () => {
+      expect(isSvg(null)).toBe(false);
+      expect(isSvg(undefined)).toBe(false);
+      expect(isSvg("")).toBe(false);
+      expect(isSvg("   ")).toBe(false);
+      expect(isSvg(Buffer.from(""))).toBe(false);
+    });
+
+    it("documents that is-svg returns false for non-xml text", () => {
+      expect(isSvg("not xml")).toBe(false);
+      expect(isSvg(Buffer.from("plain text"))).toBe(false);
+    });
+
+    it("documents that is-svg returns false for well-formed xml without an svg root element", () => {
+      expect(isSvg("<root><item /></root>")).toBe(false);
+      expect(isSvg("<html><body>page</body></html>")).toBe(false);
+    });
+
+    it("documents that is-svg returns false for malformed xml", () => {
+      expect(isSvg("<svg><unclosed>")).toBe(false);
+    });
+
+    it("documents that is-svg returns true when the parsed document has an svg root element", () => {
+      expect(isSvg('<svg xmlns="http://www.w3.org/2000/svg"><path /></svg>')).toBe(true);
+      expect(isSvg(Buffer.from('<svg xmlns="http://www.w3.org/2000/svg"><path /></svg>'))).toBe(true);
+    });
+
+    it("documents that is-svg depends on fast-xml-parser for validate and parse", () => {
+      const isSvgPackage = jest.requireActual<{ dependencies: Record<string, string> }>("is-svg/package.json");
+
+      expect(isSvgPackage.dependencies["fast-xml-parser"]).toBeDefined();
+    });
+
+    it("rejects binary font buffers that are not svg documents", async () => {
+      const { woff2 } = await standalone({
+        files: `${fixturesGlob}/avatar.svg`,
+        formats: ["woff2"],
+      });
+
+      expect(woff2).toBeDefined();
+      expect(isSvg(woff2)).toBe(false);
+    });
+  });
+
+  describe("webfont result.svg validation", () => {
+    it("accepts svg font output from standalone as valid svg", async () => {
+      const result = await standalone({
+        files: `${fixturesGlob}/avatar.svg`,
+        formats: ["svg"],
+      });
+
+      expect(result.svg).toBeDefined();
+      expect(isSvg(result.svg)).toBe(true);
+    });
+
+    it("does not emit result.svg when only woff2 is requested", async () => {
+      const result = await standalone({
+        files: `${fixturesGlob}/avatar.svg`,
+        formats: ["woff2"],
+      });
+
+      expect(result.svg).toBeUndefined();
+      expect(result.woff2).toBeDefined();
+    });
+
+    it("does not emit result.svg when only woff and woff2 are requested", async () => {
+      const result = await standalone({
+        files: `${fixturesGlob}/avatar.svg`,
+        formats: ["woff", "woff2"],
+      });
+
+      expect(result.svg).toBeUndefined();
+      expect(result.woff).toBeDefined();
+      expect(result.woff2).toBeDefined();
+    });
+
+    it("does not emit result.svg when template output is generated without svg format", async () => {
+      const result = await standalone({
+        files: `${fixturesGlob}/avatar.svg`,
+        formats: ["woff2"],
+        template: "css",
+        templateCacheString: "test",
+      });
+
+      expect(result.svg).toBeUndefined();
+      expect(result.template).toBeDefined();
+    });
+
+    it("documents that absent result.svg must be asserted with toBeUndefined, not is-svg", () => {
+      // is-svg coerces missing values to false, which cannot distinguish "not generated" from "invalid".
+      expect(isSvg(undefined)).toBe(false);
+      expect(undefined).toBeUndefined();
+    });
+  });
+});

--- a/src/standalone/svg2ttfOutput.test.ts
+++ b/src/standalone/svg2ttfOutput.test.ts
@@ -1,0 +1,150 @@
+import isTtf from "is-ttf";
+import isWoff2 from "is-woff2";
+import svg2ttf from "svg2ttf";
+import standalone from "../standalone";
+
+jest.mock("svg2ttf", () => jest.fn(jest.requireActual("svg2ttf")));
+
+const mockedSvg2ttf = svg2ttf as jest.MockedFunction<typeof svg2ttf>;
+
+const fixturesGlob = "src/fixtures";
+const svgIconsGlob = `${fixturesGlob}/svg-icons`;
+const badSvgFile = `${fixturesGlob}/bad-svg-icons/avatar.svg`;
+
+const getSvgFontString = async (): Promise<string> => {
+  const result = await standalone({
+    files: `${svgIconsGlob}/avatar.svg`,
+    formats: ["svg"],
+  });
+
+  if (!result.svg) {
+    throw new Error("Expected svg font output from standalone");
+  }
+
+  return result.svg.toString();
+};
+
+describe("svg2ttf output validation", () => {
+  beforeEach(() => {
+    mockedSvg2ttf.mockClear();
+    mockedSvg2ttf.mockImplementation(jest.requireActual("svg2ttf"));
+  });
+
+  describe("svg2ttf library contract (production dependency)", () => {
+    it("documents that svg2ttf depends on @xmldom/xmldom for svg font parsing", () => {
+      const svg2ttfPackage = jest.requireActual<{ dependencies: Record<string, string> }>("svg2ttf/package.json");
+
+      expect(svg2ttfPackage.dependencies["@xmldom/xmldom"]).toBeDefined();
+    });
+
+    it("documents that svg2ttf rejects empty svg font input", () => {
+      expect(() => svg2ttf("", {})).toThrow();
+    });
+
+    it("documents that svg2ttf rejects regular svg images without a font element", () => {
+      expect(() => svg2ttf('<svg xmlns="http://www.w3.org/2000/svg"><path /></svg>', {})).toThrow(
+        /Can't find <font> tag/u,
+      );
+    });
+
+    it("documents that svg2ttf rejects malformed svg font markup", () => {
+      expect(() => svg2ttf("<font><unclosed>", {})).toThrow();
+    });
+
+    it("documents that svg2ttf rejects non-string version options", async () => {
+      const svgFont = await getSvgFontString();
+
+      expect(() => svg2ttf(svgFont, { version: 1 })).toThrow(/version option should be a string/u);
+    });
+
+    it("documents that svg2ttf rejects invalid version strings", async () => {
+      const svgFont = await getSvgFontString();
+
+      expect(() => svg2ttf(svgFont, { version: "bad" })).toThrow(/invalid option, version/u);
+    });
+
+    it("accepts a webfont-generated svg font and returns a ttf buffer", async () => {
+      const svgFont = await getSvgFontString();
+      const ttf = svg2ttf(svgFont, { version: "1.0" });
+
+      expect(ttf.buffer.byteLength).toBeGreaterThan(0);
+      expect(isTtf(Buffer.from(ttf.buffer))).toBe(true);
+    });
+  });
+
+  describe("webfont result.ttf validation", () => {
+    it("accepts ttf font output from standalone as valid ttf", async () => {
+      const result = await standalone({
+        files: `${svgIconsGlob}/avatar.svg`,
+        formats: ["ttf"],
+      });
+
+      expect(result.ttf).toBeDefined();
+      expect(isTtf(result.ttf)).toBe(true);
+      expect(mockedSvg2ttf).toHaveBeenCalled();
+    });
+
+    it("forwards formatsOptions.ttf to svg2ttf", async () => {
+      await standalone({
+        files: `${svgIconsGlob}/avatar.svg`,
+        formats: ["ttf"],
+        formatsOptions: {
+          ttf: {
+            copyright: "test copyright",
+            ts: 1457357570,
+            version: "2.0",
+          },
+        },
+      });
+
+      expect(mockedSvg2ttf).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({
+          copyright: "test copyright",
+          ts: 1457357570,
+          version: "2.0",
+        }),
+      );
+    });
+
+    it("runs svg2ttf internally even when ttf is omitted from formats", async () => {
+      const result = await standalone({
+        files: `${svgIconsGlob}/avatar.svg`,
+        formats: ["woff2"],
+      });
+
+      expect(result.ttf).toBeUndefined();
+      expect(result.woff2).toBeDefined();
+      expect(isWoff2(result.woff2)).toBe(true);
+      expect(mockedSvg2ttf).toHaveBeenCalled();
+    });
+
+    it("does not emit result.ttf when only woff and woff2 are requested", async () => {
+      const result = await standalone({
+        files: `${svgIconsGlob}/avatar.svg`,
+        formats: ["woff", "woff2"],
+      });
+
+      expect(result.ttf).toBeUndefined();
+      expect(result.woff).toBeDefined();
+      expect(result.woff2).toBeDefined();
+      expect(mockedSvg2ttf).toHaveBeenCalled();
+    });
+
+    it("documents that absent result.ttf must be asserted with toBeUndefined, not is-ttf", () => {
+      // is-ttf coerces missing values to false, which cannot distinguish "not generated" from "invalid".
+      expect(isTtf(undefined)).toBe(false);
+      expect(undefined).toBeUndefined();
+    });
+
+    it("rejects invalid input svg before svg2ttf is called", async () => {
+      await expect(
+        standalone({
+          files: badSvgFile,
+        }),
+      ).rejects.toThrow(/Unclosed root tag/u);
+
+      expect(mockedSvg2ttf).not.toHaveBeenCalled();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

### Proposed changes

This PR brings the following changes:

- Add `src/standalone/isSvgOutput.test.ts` — documents the `is-svg` dev-dependency contract (via `fast-xml-parser`), negative fixtures, absent `result.svg` scenarios, and when to use `toBeUndefined` vs `isSvg`.
- Add `src/standalone/svg2ttfOutput.test.ts` — documents the `svg2ttf` production contract (via `@xmldom/xmldom`), invalid version options, `formatsOptions.ttf` forwarding, internal conversion when `ttf` is omitted from formats, and early pipeline rejection before conversion.
- Update `AGENTS.md` with examples for both test files and a **Merged branches** rule: verify the PR branch is not already merged before pushing; open a new branch and PR for follow-up work.

### Related issue

N/A — follow-up work that was accidentally pushed to the already-merged branch of PR #626.

### Dependencies added/removed (if applicable)

N/A

---

### Testing

- [x] I have added or updated tests that prove my fix is effective or that my feature works (if applicable)
  - [x] Unit test

#### How to test

1. Run `npm test` — 171 tests pass.
2. Review `src/standalone/isSvgOutput.test.ts` and `src/standalone/svg2ttfOutput.test.ts` for contract documentation and negative cases.

#### Test configuration

N/A

---

## Checklist

- [ ] I have added corresponding labels to this PR (like bug, enhancement...);
- [x] My commits follow the [Conventional Commits 1.0 Guidelines](https://www.conventionalcommits.org/en/v1.0.0/);
- [x] My code follows the style guidelines of this project;
- [x] I have performed a self-review of my own code;
- [ ] I have mapped technical debts found on my changes;
- [x] I have made changes to the documentation (if applicable);
- [x] My changes generate no new warnings or errors;


Made with [Cursor](https://cursor.com)