### PR TITLE
test: rename it() titles to use should or should not

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,6 +29,24 @@ Calling `fs.mkdirSync` / `fs.rmSync` directly in an `async` `it(...)` block is a
 
 When a dependency only exposes callbacks (`rimraf`, legacy `fs.mkdir`), extract a small `promisify` helper and use it from `async` hooks instead of nesting callbacks.
 
+### `it` descriptions must use `should` or `should not`
+
+Every `it("...")` title in this repo must read as a behavior statement with **`should`** or **`should not`**. This keeps Jest output scannable and consistent across unit, contract, and CLI integration tests.
+
+```ts
+// Good
+it("should return default webfont options", () => { ... });
+it("should not emit result.svg when only woff2 is requested", async () => { ... });
+it("should document that is-svg throws TypeError for non-string input", () => { ... });
+
+// Avoid
+it("returns default webfont options", () => { ... });
+it("documents that is-svg throws TypeError for non-string input", () => { ... });
+it("throws when given binary font buffers", async () => { ... });
+```
+
+When adding or renaming tests, follow this rule even in contract-style `describe` blocks that document library behavior.
+
 ### Document guards and error paths with explicit unit tests
 
 When production code works around a library quirk or adds a defensive guard, add **unit tests that name the reason** — not only integration tests through the full pipeline.
@@ -42,7 +60,7 @@ When production code works around a library quirk or adds a defensive guard, add
 
 Example: `glyphsData.test.ts` — `describe("svg xml validation via xml2js")` documents that `xml2js` accepts empty input without error, then unit-tests the empty-file guard and malformed-xml rejection before metadata lookup.
 
-Example: `isSvgOutput.test.ts` — documents the `is-svg` dev-dependency contract (via `fast-xml-parser`), negative fixtures, and when `result.svg` is absent (`toBeUndefined`) vs validated (`isSvg(result.svg)`).
+Example: `isSvgOutput.test.ts` — documents the `is-svg` dev-dependency contract, negative fixtures, and when `result.svg` is absent (`toBeUndefined`) vs validated (`isSvg(result.svg)`).
 
 Example: `svg2ttfOutput.test.ts` — documents the `svg2ttf` production contract (via `@xmldom/xmldom`), invalid version options, early pipeline rejection before conversion, and when `result.ttf` is absent vs validated (`isTtf(result.ttf)`).
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -81,6 +81,7 @@ New behavior and bug fixes should include tests. Follow [AGENTS.md](./AGENTS.md)
 | **Explicit, not implicit** | Name tests after the invariant they protect (for example, why a guard exists). If a dependency quirk motivated the code, add a small test that documents the quirk. |
 | **Pipeline ordering** | When step B must not run if step A fails, assert B was not called (spy/mock), not only that the final promise rejected. |
 | **Fixtures** | Reuse fixtures under `src/fixtures/` for file-based cases; add a fixture when the scenario is stable and reusable. |
+| **Test titles** | Every `it(...)` description must include **`should`** or **`should not`** (for example, `should return default options`, `should not call metadataProvider when parse fails`). Avoid bare verbs (`returns`, `throws`, `accepts`) or prefixes like `documents that` without `should`. |
 
 Run `npm test` before pushing. Integration-only coverage for a localized guard is incomplete.
 

--- a/src/cli/__snapshots__/index.test.ts.snap
+++ b/src/cli/__snapshots__/index.test.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`cli short options can set destTemplate with -s 1`] = `
+exports[`cli short options should set destTemplate with -s 1`] = `
 "@font-face {
   font-display: auto;
   font-family: \\"webfont\\";

--- a/src/cli/index.test.ts
+++ b/src/cli/index.test.ts
@@ -70,7 +70,7 @@ describe("cli", () => {
     }
   });
 
-  it("exits with code 2 and displays --help if no argument parameters are passed", async () => {
+  it("should exit with code 2 and displays --help if no argument parameters are passed", async () => {
     const output = await execCLI();
 
     expect(output.code).toBe(2);
@@ -78,7 +78,7 @@ describe("cli", () => {
     expect(output.stderr).toBe("");
   });
 
-  it("can show help", async () => {
+  it("should show help", async () => {
     const output = await execCLI("--help");
 
     expect(output.code).toBe(2);
@@ -86,7 +86,7 @@ describe("cli", () => {
     expect(output.stderr).toBe("");
   });
 
-  it("can show version with --version", async () => {
+  it("should show version with --version", async () => {
     const output = await execCLI("--version");
 
     expect(output.code).toBe(0);
@@ -95,7 +95,7 @@ describe("cli", () => {
   });
 
   describe("short options", () => {
-    it("can show help with -h", async () => {
+    it("should show help with -h", async () => {
       const output = await execCLI("-h");
 
       expect(output.code).toBe(2);
@@ -103,7 +103,7 @@ describe("cli", () => {
       expect(output.stderr).toBe("");
     });
 
-    it("can show version with -v", async () => {
+    it("should show version with -v", async () => {
       const output = await execCLI("-v");
 
       expect(output.code).toBe(0);
@@ -111,7 +111,7 @@ describe("cli", () => {
       expect(output.stderr).toBe("");
     });
 
-    it("can set destination with -d", async () => {
+    it("should set destination with -d", async () => {
       const output = await execCLI(`${source} -d ${destination}`);
 
       expect(output.files).toEqual([
@@ -126,7 +126,7 @@ describe("cli", () => {
       expect(output.stderr).toBe("");
     });
 
-    it("can create destination with -m", async () => {
+    it("should create destination with -m", async () => {
       const nonExistentDestination = `${destination}/short-option/missing-dest`;
       const output = await execCLI(`${source} -d ${nonExistentDestination} -m`);
 
@@ -141,7 +141,7 @@ describe("cli", () => {
       expect(output.stderr).toBe("");
     });
 
-    it("can set destTemplate with -s", async () => {
+    it("should set destTemplate with -s", async () => {
       const templateDest = `${destination}/template-output`;
       await fsPromise.mkdir(templateDest, { recursive: true });
 
@@ -158,7 +158,7 @@ describe("cli", () => {
       expect(css).toMatchSnapshot();
     });
 
-    it("can set font name with -u", async () => {
+    it("should set font name with -u", async () => {
       const output = await execCLI(`${source} -d ${destination} -u foobar`);
 
       expect(output.files).toEqual([
@@ -173,7 +173,7 @@ describe("cli", () => {
       expect(output.stderr).toBe("");
     });
 
-    it("can set formats with -f", async () => {
+    it("should set formats with -f", async () => {
       const output = await execCLI(`${source} -d ${destination} -f '["woff2"]'`);
 
       expect(output.files).toEqual(["webfont.hash", "webfont.woff2"]);
@@ -181,7 +181,7 @@ describe("cli", () => {
       expect(output.stderr).toBe("");
     });
 
-    it("can set template with -t", async () => {
+    it("should set template with -t", async () => {
       const output = await execCLI(`${source} -d ${destination} -t css --templateCacheString test`);
 
       expect(output.files).toEqual([
@@ -196,7 +196,7 @@ describe("cli", () => {
       expect(output.stderr).toBe("");
     });
 
-    it("can set templateClassName with -c", async () => {
+    it("should set templateClassName with -c", async () => {
       const output = await execCLI(
         `${source} -d ${destination} -t css -c short-option-class --templateCacheString test`,
       );
@@ -208,7 +208,7 @@ describe("cli", () => {
       expect(css).toContain(".short-option-class");
     });
 
-    it("can set templateFontName with -n", async () => {
+    it("should set templateFontName with -n", async () => {
       const output = await execCLI(
         `${source} -d ${destination} -t css -n short-option-font --templateCacheString test`,
       );
@@ -220,7 +220,7 @@ describe("cli", () => {
       expect(css).toContain("short-option-font");
     });
 
-    it("can set templateFontPath with -p", async () => {
+    it("should set templateFontPath with -p", async () => {
       const output = await execCLI(`${source} -d ${destination} -t css -p short/path --templateCacheString test`);
 
       expect(output.code).toBe(0);
@@ -362,7 +362,7 @@ describe("cli", () => {
     expect(css).toMatchSnapshot();
   });
 
-  it("can set font name", async () => {
+  it("should set font name", async () => {
     const output = await execCLI(`${source} -d ${destination} --fontName foobar`);
 
     expect(output.files).toEqual([
@@ -396,7 +396,7 @@ describe("cli", () => {
     expect(data).toMatchSnapshot();
   });
 
-  it("can be verbose", async () => {
+  it("should run in verbose mode", async () => {
     const output = await execCLI(`${source} -d ${destination} --verbose`);
 
     expect(output.files).toEqual([

--- a/src/standalone/glyphsData.test.ts
+++ b/src/standalone/glyphsData.test.ts
@@ -215,21 +215,21 @@ describe("glyphsData", () => {
   });
 
   describe("svg xml validation via xml2js", () => {
-    it("documents that xml2js accepts empty input without error (requires explicit empty-file guard)", async () => {
+    it("should document that xml2js accepts empty input without error (requires explicit empty-file guard)", async () => {
       const { error, result } = await parseWithXml2js("");
 
       expect(error).toBeNull();
       expect(result).toBeNull();
     });
 
-    it("documents that xml2js rejects malformed xml", async () => {
+    it("should document that xml2js rejects malformed xml", async () => {
       const contents = await fsPromise.readFile(malformedXmlFile, "utf8");
       const { error } = await parseWithXml2js(contents);
 
       expect(error?.message).toMatch(/Unclosed root tag/u);
     });
 
-    it("documents that xml2js accepts well-formed xml used by later pipeline errors", async () => {
+    it("should document that xml2js accepts well-formed xml used by later pipeline errors", async () => {
       const contents = await fsPromise.readFile(wellFormedXmlFile, "utf8");
       const { error, result } = await parseWithXml2js(contents);
 
@@ -237,11 +237,11 @@ describe("glyphsData", () => {
       expect(result).not.toBeNull();
     });
 
-    it("rejects empty svg files before xml2js can treat them as valid", async () => {
+    it("should reject empty svg files before xml2js can treat them as valid", async () => {
       await expect(getGlyphsData([emptySvgFile], getTestOptions(1))).rejects.toThrow(`Empty file ${emptySvgFile}`);
     });
 
-    it("rejects empty svg files without calling parseString", async () => {
+    it("should reject empty svg files without calling parseString", async () => {
       const parseStringSpy = jest.spyOn(xml2js.Parser.prototype, "parseString");
 
       try {
@@ -252,7 +252,7 @@ describe("glyphsData", () => {
       }
     });
 
-    it("rejects empty svg files without calling metadataProvider", async () => {
+    it("should reject empty svg files without calling metadataProvider", async () => {
       const metadataProvider = jest.fn();
 
       await expect(
@@ -264,11 +264,11 @@ describe("glyphsData", () => {
       expect(metadataProvider).not.toHaveBeenCalled();
     });
 
-    it("rejects malformed xml via xml2js parse errors", async () => {
+    it("should reject malformed xml via xml2js parse errors", async () => {
       await expect(getGlyphsData([malformedXmlFile], getTestOptions(1))).rejects.toThrow(/Unclosed root tag/u);
     });
 
-    it("rejects malformed xml without calling metadataProvider", async () => {
+    it("should reject malformed xml without calling metadataProvider", async () => {
       const metadataProvider = jest.fn();
 
       await expect(
@@ -290,13 +290,13 @@ describe("glyphsData", () => {
       deletePollutionMarker();
     });
 
-    it("requires xml2js >= 0.5.0 so assignOrPush uses defineProperty instead of obj[key] assignment", () => {
+    it("should require xml2js >= 0.5.0 so assignOrPush uses defineProperty instead of obj[key] assignment", () => {
       const { version } = jest.requireActual<{ version: string }>("xml2js/package.json");
 
       expect(version).not.toMatch(/^0\.4\./u);
     });
 
-    it("documents the null-prototype PropertyDescriptor pattern that replaces direct obj[key] assignment", () => {
+    it("should document the null-prototype PropertyDescriptor pattern that replaces direct obj[key] assignment", () => {
       const target: Record<string, unknown> = {};
       const descriptor = Object.create(null) as PropertyDescriptor & Record<string, unknown>;
 
@@ -312,7 +312,7 @@ describe("glyphsData", () => {
       expect(({} as Record<string, unknown>)[pollutionMarker]).toBeUndefined();
     });
 
-    it("stores __proto__ elements as own properties without polluting Object.prototype when parsing xml", async () => {
+    it("should store __proto__ elements as own properties without polluting Object.prototype when parsing xml", async () => {
       const { error, result } = await parseWithXml2js(
         `<root><__proto__><${pollutionMarker}>polluted</${pollutionMarker}></__proto__></root>`,
       );
@@ -323,7 +323,7 @@ describe("glyphsData", () => {
       expect(({} as Record<string, unknown>)[pollutionMarker]).toBeUndefined();
     });
 
-    it("does not pollute Object.prototype when getGlyphsData parses svg with a __proto__ element", async () => {
+    it("should not pollute Object.prototype when getGlyphsData parses svg with a __proto__ element", async () => {
       await getGlyphsData([protoElementSvgFile], {
         ...getTestOptions(1),
         metadataProvider: (_srcPath, callback) => {
@@ -334,7 +334,7 @@ describe("glyphsData", () => {
       expect(({} as Record<string, unknown>)[pollutionMarker]).toBeUndefined();
     });
 
-    it("does not pollute Object.prototype when getGlyphsData rejects malformed xml", async () => {
+    it("should not pollute Object.prototype when getGlyphsData rejects malformed xml", async () => {
       await expect(getGlyphsData([malformedXmlFile], getTestOptions(1))).rejects.toThrow(/Unclosed root tag/u);
 
       expect(({} as Record<string, unknown>)[pollutionMarker]).toBeUndefined();

--- a/src/standalone/isSvgOutput.test.ts
+++ b/src/standalone/isSvgOutput.test.ts
@@ -5,7 +5,7 @@ const fixturesGlob = "src/fixtures/svg-icons";
 
 describe("is-svg output validation", () => {
   describe("is-svg library contract (dev dependency)", () => {
-    it("documents that is-svg returns false for null, undefined, and empty input", () => {
+    it("should document that is-svg returns false for null, undefined, and empty input", () => {
       expect(isSvg(null)).toBe(false);
       expect(isSvg(undefined)).toBe(false);
       expect(isSvg("")).toBe(false);
@@ -13,32 +13,32 @@ describe("is-svg output validation", () => {
       expect(isSvg(Buffer.from(""))).toBe(false);
     });
 
-    it("documents that is-svg returns false for non-xml text", () => {
+    it("should document that is-svg returns false for non-xml text", () => {
       expect(isSvg("not xml")).toBe(false);
       expect(isSvg(Buffer.from("plain text"))).toBe(false);
     });
 
-    it("documents that is-svg returns false for well-formed xml without an svg root element", () => {
+    it("should document that is-svg returns false for well-formed xml without an svg root element", () => {
       expect(isSvg("<root><item /></root>")).toBe(false);
       expect(isSvg("<html><body>page</body></html>")).toBe(false);
     });
 
-    it("documents that is-svg returns false for malformed xml", () => {
+    it("should document that is-svg returns false for malformed xml", () => {
       expect(isSvg("<svg><unclosed>")).toBe(false);
     });
 
-    it("documents that is-svg returns true when the parsed document has an svg root element", () => {
+    it("should document that is-svg returns true when the parsed document has an svg root element", () => {
       expect(isSvg('<svg xmlns="http://www.w3.org/2000/svg"><path /></svg>')).toBe(true);
       expect(isSvg(Buffer.from('<svg xmlns="http://www.w3.org/2000/svg"><path /></svg>'))).toBe(true);
     });
 
-    it("documents that is-svg depends on fast-xml-parser for validate and parse", () => {
+    it("should document that is-svg depends on fast-xml-parser for validate and parse", () => {
       const isSvgPackage = jest.requireActual<{ dependencies: Record<string, string> }>("is-svg/package.json");
 
       expect(isSvgPackage.dependencies["fast-xml-parser"]).toBeDefined();
     });
 
-    it("rejects binary font buffers that are not svg documents", async () => {
+    it("should reject binary font buffers that are not svg documents", async () => {
       const { woff2 } = await standalone({
         files: `${fixturesGlob}/avatar.svg`,
         formats: ["woff2"],
@@ -50,7 +50,7 @@ describe("is-svg output validation", () => {
   });
 
   describe("webfont result.svg validation", () => {
-    it("accepts svg font output from standalone as valid svg", async () => {
+    it("should accept svg font output from standalone as valid svg", async () => {
       const result = await standalone({
         files: `${fixturesGlob}/avatar.svg`,
         formats: ["svg"],
@@ -60,7 +60,7 @@ describe("is-svg output validation", () => {
       expect(isSvg(result.svg)).toBe(true);
     });
 
-    it("does not emit result.svg when only woff2 is requested", async () => {
+    it("should not emit result.svg when only woff2 is requested", async () => {
       const result = await standalone({
         files: `${fixturesGlob}/avatar.svg`,
         formats: ["woff2"],
@@ -70,7 +70,7 @@ describe("is-svg output validation", () => {
       expect(result.woff2).toBeDefined();
     });
 
-    it("does not emit result.svg when only woff and woff2 are requested", async () => {
+    it("should not emit result.svg when only woff and woff2 are requested", async () => {
       const result = await standalone({
         files: `${fixturesGlob}/avatar.svg`,
         formats: ["woff", "woff2"],
@@ -81,7 +81,7 @@ describe("is-svg output validation", () => {
       expect(result.woff2).toBeDefined();
     });
 
-    it("does not emit result.svg when template output is generated without svg format", async () => {
+    it("should not emit result.svg when template output is generated without svg format", async () => {
       const result = await standalone({
         files: `${fixturesGlob}/avatar.svg`,
         formats: ["woff2"],
@@ -93,7 +93,7 @@ describe("is-svg output validation", () => {
       expect(result.template).toBeDefined();
     });
 
-    it("documents that absent result.svg must be asserted with toBeUndefined, not is-svg", () => {
+    it("should document that absent result.svg must be asserted with toBeUndefined, not is-svg", () => {
       // is-svg coerces missing values to false, which cannot distinguish "not generated" from "invalid".
       expect(isSvg(undefined)).toBe(false);
       expect(undefined).toBeUndefined();

--- a/src/standalone/svg2ttfOutput.test.ts
+++ b/src/standalone/svg2ttfOutput.test.ts
@@ -31,39 +31,39 @@ describe("svg2ttf output validation", () => {
   });
 
   describe("svg2ttf library contract (production dependency)", () => {
-    it("documents that svg2ttf depends on @xmldom/xmldom for svg font parsing", () => {
+    it("should document that svg2ttf depends on @xmldom/xmldom for svg font parsing", () => {
       const svg2ttfPackage = jest.requireActual<{ dependencies: Record<string, string> }>("svg2ttf/package.json");
 
       expect(svg2ttfPackage.dependencies["@xmldom/xmldom"]).toBeDefined();
     });
 
-    it("documents that svg2ttf rejects empty svg font input", () => {
+    it("should document that svg2ttf rejects empty svg font input", () => {
       expect(() => svg2ttf("", {})).toThrow();
     });
 
-    it("documents that svg2ttf rejects regular svg images without a font element", () => {
+    it("should document that svg2ttf rejects regular svg images without a font element", () => {
       expect(() => svg2ttf('<svg xmlns="http://www.w3.org/2000/svg"><path /></svg>', {})).toThrow(
         /Can't find <font> tag/u,
       );
     });
 
-    it("documents that svg2ttf rejects malformed svg font markup", () => {
+    it("should document that svg2ttf rejects malformed svg font markup", () => {
       expect(() => svg2ttf("<font><unclosed>", {})).toThrow();
     });
 
-    it("documents that svg2ttf rejects non-string version options", async () => {
+    it("should document that svg2ttf rejects non-string version options", async () => {
       const svgFont = await getSvgFontString();
 
       expect(() => svg2ttf(svgFont, { version: 1 })).toThrow(/version option should be a string/u);
     });
 
-    it("documents that svg2ttf rejects invalid version strings", async () => {
+    it("should document that svg2ttf rejects invalid version strings", async () => {
       const svgFont = await getSvgFontString();
 
       expect(() => svg2ttf(svgFont, { version: "bad" })).toThrow(/invalid option, version/u);
     });
 
-    it("accepts a webfont-generated svg font and returns a ttf buffer", async () => {
+    it("should accept a webfont-generated svg font and returns a ttf buffer", async () => {
       const svgFont = await getSvgFontString();
       const ttf = svg2ttf(svgFont, { version: "1.0" });
 
@@ -73,7 +73,7 @@ describe("svg2ttf output validation", () => {
   });
 
   describe("webfont result.ttf validation", () => {
-    it("accepts ttf font output from standalone as valid ttf", async () => {
+    it("should accept ttf font output from standalone as valid ttf", async () => {
       const result = await standalone({
         files: `${svgIconsGlob}/avatar.svg`,
         formats: ["ttf"],
@@ -84,7 +84,7 @@ describe("svg2ttf output validation", () => {
       expect(mockedSvg2ttf).toHaveBeenCalled();
     });
 
-    it("forwards formatsOptions.ttf to svg2ttf", async () => {
+    it("should forward formatsOptions.ttf to svg2ttf", async () => {
       await standalone({
         files: `${svgIconsGlob}/avatar.svg`,
         formats: ["ttf"],
@@ -107,7 +107,7 @@ describe("svg2ttf output validation", () => {
       );
     });
 
-    it("runs svg2ttf internally even when ttf is omitted from formats", async () => {
+    it("should run svg2ttf internally even when ttf is omitted from formats", async () => {
       const result = await standalone({
         files: `${svgIconsGlob}/avatar.svg`,
         formats: ["woff2"],
@@ -119,7 +119,7 @@ describe("svg2ttf output validation", () => {
       expect(mockedSvg2ttf).toHaveBeenCalled();
     });
 
-    it("does not emit result.ttf when only woff and woff2 are requested", async () => {
+    it("should not emit result.ttf when only woff and woff2 are requested", async () => {
       const result = await standalone({
         files: `${svgIconsGlob}/avatar.svg`,
         formats: ["woff", "woff2"],
@@ -131,13 +131,13 @@ describe("svg2ttf output validation", () => {
       expect(mockedSvg2ttf).toHaveBeenCalled();
     });
 
-    it("documents that absent result.ttf must be asserted with toBeUndefined, not is-ttf", () => {
+    it("should document that absent result.ttf must be asserted with toBeUndefined, not is-ttf", () => {
       // is-ttf coerces missing values to false, which cannot distinguish "not generated" from "invalid".
       expect(isTtf(undefined)).toBe(false);
       expect(undefined).toBeUndefined();
     });
 
-    it("rejects invalid input svg before svg2ttf is called", async () => {
+    it("should reject invalid input svg before svg2ttf is called", async () => {
       await expect(
         standalone({
           files: badSvgFile,


### PR DESCRIPTION
## Summary

### Proposed changes

- Document the `should` / `should not` convention for every Jest `it()` title in `AGENTS.md` and `CONTRIBUTING.md`.
- Rename all existing `it()` descriptions across the test suite to follow that convention (contract tests, CLI integration tests, and snapshots).

### Related issue

N/A

### Dependencies added/removed (if applicable)

N/A

---

### Testing

- [x] I have added or updated tests that prove my fix is effective or that my feature works (if applicable)
  - [x] Unit test

#### How to test

1. Run `npm test`.
2. Confirm all 171 tests pass and snapshot labels match the renamed CLI short-option tests.

#### Test configuration

N/A

---

## Checklist

- [x] I have added corresponding labels to this PR (like bug, enhancement...);
- [x] My commits follow the [Conventional Commits 1.0 Guidelines](https://www.conventionalcommits.org/en/v1.0.0/);
- [x] My code follows the style guidelines of this project;
- [x] I have performed a self-review of my own code;
- [x] I have mapped technical debts found on my changes;
- [x] I have made changes to the documentation (if applicable);
- [x] My changes generate no new warnings or errors;

Made with [Cursor](https://cursor.com)