### PR TITLE
test: add toTtf unit tests before svg2ttf upgrade

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,6 +64,8 @@ Example: `isSvgOutput.test.ts` — documents the `is-svg` dev-dependency contrac
 
 Example: `svg2ttfOutput.test.ts` — documents the `svg2ttf` production contract (via `@xmldom/xmldom`), invalid version options, early pipeline rejection before conversion, and when `result.ttf` is absent vs validated (`isTtf(result.ttf)`).
 
+Example: `toTtf.test.ts` — unit-tests the `toTtf` wrapper with a `svg2ttf` spy and asserts every `formatsOptions.ttf` field is forwarded.
+
 Prefer `await expect(fn()).rejects.toThrow(...)` for async failures. Use spies on the next pipeline step to prove early exit.
 
 ### Dependency error assertions
@@ -144,6 +146,8 @@ When a task produces branch changes intended for review (features, fixes, CI, do
 5. **Open a PR** with `gh pr create` (title + body in English, base `master`) without asking first. Pass the body via HEREDOC so headings and checklists match the template.
 6. **Return the PR URL** in the final response.
 
+**Do not ask the user for permission** to push or open a PR when the task produces reviewable branch changes. Push, `gh pr create`, and returning the PR URL are part of finishing the task — not optional follow-ups to confirm. Only skip push/PR when the user explicitly says to keep work local, or when the task is question-only with no code changes.
+
 ### Merged branches
 
 **Before every push**, confirm the target branch is still the right vehicle for the work:
@@ -180,5 +184,3 @@ Keep the template **headings and order**, but write each section critically — 
 - **Re-read the PR title and body whenever the branch scope changes.** After adding commits, update the title and **Proposed changes** section so reviewers see the full picture — not just the first commit message.
 - **Split when it grows too much.** If a branch picks up unrelated fixes, large test extractions, or docs on top of the original goal, prefer **separate PRs** for follow-up work rather than one ever-growing branch. This PR accumulated extra scope before that rule was written; use smaller PRs from here on.
 - **Explain why when closing a PR.** Leave an English comment (superseded, obsolete, duplicate, out of scope, etc.) — do not close without context. See [CONTRIBUTING.md](./CONTRIBUTING.md) (“Closing pull requests”).
-
-Only skip push/PR when the user explicitly says to keep work local, or when the task is question-only / no code changes.

--- a/src/standalone/index.ts
+++ b/src/standalone/index.ts
@@ -5,7 +5,6 @@ import { globby } from "globby";
 import nunjucks from "nunjucks";
 import path from "path";
 import { Readable } from "stream";
-import svg2ttf from "svg2ttf";
 import ttf2woff from "ttf2woff";
 import wawoff2 from "wawoff2";
 import { getBuiltInTemplates, getTemplateFilePath } from "../../templates";
@@ -17,6 +16,7 @@ import type { ResultConfig } from "../types/ResultConfig";
 import { getGlyphsData } from "./glyphsData";
 import { getOptions } from "./options";
 import { getTemplateFontBase64 } from "./templateFonts";
+import toTtf from "./toTtf";
 
 type CosmiconfigLoaded = NonNullable<Awaited<ReturnType<ReturnType<typeof cosmiconfig>["search"]>>>;
 
@@ -73,8 +73,6 @@ const toSvg = (glyphsData: GlyphData[], options: WebfontOptions) => {
     fontStream.end();
   });
 };
-
-const toTtf = (buffer: string, options: Record<string, unknown>) => Buffer.from(svg2ttf(buffer, options).buffer);
 
 const toEot = (buffer: Buffer) => convertTtfToEot(buffer);
 

--- a/src/standalone/svg2ttfOutput.test.ts
+++ b/src/standalone/svg2ttfOutput.test.ts
@@ -84,27 +84,24 @@ describe("svg2ttf output validation", () => {
       expect(mockedSvg2ttf).toHaveBeenCalled();
     });
 
-    it("should forward formatsOptions.ttf to svg2ttf", async () => {
+    it("should forward every formatsOptions.ttf field to svg2ttf", async () => {
+      const ttfOptions = {
+        copyright: "test copyright",
+        description: "test description",
+        ts: 1457357570,
+        url: "https://example.com/fonts",
+        version: "2.0",
+      };
+
       await standalone({
         files: `${svgIconsGlob}/avatar.svg`,
         formats: ["ttf"],
         formatsOptions: {
-          ttf: {
-            copyright: "test copyright",
-            ts: 1457357570,
-            version: "2.0",
-          },
+          ttf: ttfOptions,
         },
       });
 
-      expect(mockedSvg2ttf).toHaveBeenCalledWith(
-        expect.any(String),
-        expect.objectContaining({
-          copyright: "test copyright",
-          ts: 1457357570,
-          version: "2.0",
-        }),
-      );
+      expect(mockedSvg2ttf).toHaveBeenCalledWith(expect.any(String), ttfOptions);
     });
 
     it("should run svg2ttf internally even when ttf is omitted from formats", async () => {

--- a/src/standalone/toTtf.test.ts
+++ b/src/standalone/toTtf.test.ts
@@ -1,0 +1,70 @@
+jest.mock("svg2ttf", () => jest.fn(() => ({ buffer: new Uint8Array([0x74, 0x74, 0x66]) })));
+
+import svg2ttf from "svg2ttf";
+import toTtf from "./toTtf";
+
+const mockedSvg2ttf = svg2ttf as jest.MockedFunction<typeof svg2ttf>;
+
+const sampleSvgFont = '<font><font-face font-family="icons"/></font>';
+const sampleTtfBytes = new Uint8Array([0x74, 0x74, 0x66]);
+
+describe("toTtf", () => {
+  beforeEach(() => {
+    mockedSvg2ttf.mockClear();
+    mockedSvg2ttf.mockReturnValue({ buffer: sampleTtfBytes });
+  });
+
+  it("should call svg2ttf with the svg font string and default options", () => {
+    const result = toTtf(sampleSvgFont);
+
+    expect(mockedSvg2ttf).toHaveBeenCalledTimes(1);
+    expect(mockedSvg2ttf).toHaveBeenCalledWith(sampleSvgFont, {});
+    expect(result).toEqual(Buffer.from(sampleTtfBytes));
+  });
+
+  it("should return a Buffer copy of the svg2ttf micro buffer", () => {
+    const returnedBuffer = new Uint8Array([1, 2, 3]);
+    mockedSvg2ttf.mockReturnValueOnce({ buffer: returnedBuffer });
+
+    const result = toTtf(sampleSvgFont);
+
+    expect(result).toEqual(Buffer.from(returnedBuffer));
+    expect(result).not.toBe(returnedBuffer);
+  });
+
+  describe("formatsOptions.ttf forwarding", () => {
+    it.each([
+      ["copyright", { copyright: "© Example Corp" }],
+      ["description", { description: "Icon font" }],
+      ["ts", { ts: 1457357570 }],
+      ["url", { url: "https://example.com/fonts" }],
+      ["version", { version: "Version 2.0" }],
+    ] as const)("should forward %s to svg2ttf", (_name, option) => {
+      toTtf(sampleSvgFont, option);
+
+      expect(mockedSvg2ttf).toHaveBeenCalledWith(sampleSvgFont, option);
+    });
+
+    it("should forward every formatsOptions.ttf field to svg2ttf together", () => {
+      const ttfOptions = {
+        copyright: "© Example Corp",
+        description: "Icon font",
+        ts: 1457357570,
+        url: "https://example.com/fonts",
+        version: "Version 2.0",
+      };
+
+      toTtf(sampleSvgFont, ttfOptions);
+
+      expect(mockedSvg2ttf).toHaveBeenCalledWith(sampleSvgFont, ttfOptions);
+    });
+  });
+
+  it("should propagate svg2ttf conversion errors", () => {
+    mockedSvg2ttf.mockImplementation(() => {
+      throw new Error("svg2ttf failed");
+    });
+
+    expect(() => toTtf(sampleSvgFont)).toThrow("svg2ttf failed");
+  });
+});

--- a/src/standalone/toTtf.ts
+++ b/src/standalone/toTtf.ts
@@ -1,0 +1,8 @@
+import svg2ttf from "svg2ttf";
+
+export type ToTtfOptions = Parameters<typeof svg2ttf>[1];
+
+const toTtf = (svgFontString: string, options: ToTtfOptions = {}): Buffer =>
+  Buffer.from(svg2ttf(svgFontString, options).buffer);
+
+export default toTtf;


### PR DESCRIPTION
## Summary

### Proposed changes

- Extract `toTtf` from `standalone/index.ts` into `src/standalone/toTtf.ts`.
- Add `src/standalone/toTtf.test.ts` with a `svg2ttf` spy: default call, buffer copy, each `formatsOptions.ttf` field (`copyright`, `description`, `ts`, `url`, `version`), combined options, and error propagation.
- Extend `svg2ttfOutput.test.ts` so the standalone integration test forwards every `formatsOptions.ttf` field to `svg2ttf`.
- Document `toTtf.test.ts` as an example in `AGENTS.md` and clarify that agents must push and open a PR without asking when work is reviewable.

### Related issue

N/A

### Dependencies added/removed (if applicable)

N/A

---

### Testing

- [x] I have added or updated tests that prove my fix is effective or that my feature works (if applicable)
  - [x] Unit test

#### How to test

1. Run `npm test`.
2. Confirm `toTtf` and `svg2ttf output validation` suites pass (181 tests total).

#### Test configuration

N/A

---

## Checklist

- [ ] I have added corresponding labels to this PR (like bug, enhancement...);
- [x] My commits follow the [Conventional Commits 1.0 Guidelines](https://www.conventionalcommits.org/en/v1.0.0/);
- [x] My code follows the style guidelines of this project;
- [x] I have performed a self-review of my own code;
- [ ] I have mapped technical debts found on my changes;
- [x] I have made changes to the documentation (if applicable);
- [x] My changes generate no new warnings or errors;

Made with [Cursor](https://cursor.com)