### PR TITLE
feat: batch decompress and URL input for WOFF/WOFF2

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -35,10 +35,14 @@ Canonical list of product capabilities. **Update this file in the same PR** when
 ### WOFF / WOFF2 container decompression
 
 - **Stability**: in-progress
-- **Description**: Decompress a single `.woff` or `.woff2` webfont file to the **SFNT payload inside** (TTF or OTF), not arbitrary format transcoding.
+- **Description**: Decompress one or more `.woff` / `.woff2` inputs (local paths, globs, or `http(s)` URLs) to the **SFNT payload inside** each file (TTF or OTF), not arbitrary format transcoding or font merging.
 - **Properties**:
-  - Input: exactly **one** `.woff` or `.woff2` file per run.
-  - Output: `ttf` and/or `otf` only — whichever matches the decompressed SFNT flavor (`0x00010000` / `true` → TTF, `OTTO` → OTF).
+  - Input: one or more `.woff` / `.woff2` sources per run (paths, globs, and/or URLs).
+  - Output: `ttf` and/or `otf` per input — whichever matches each decompressed SFNT flavor (`0x00010000` / `true` → TTF, `OTTO` → OTF).
+  - Batch results are exposed on `result.decompressedFonts` (`{ source, ttf?, otf? }[]`). A single input still sets `result.ttf` / `result.otf` at the top level for backward compatibility.
+  - CLI writes `{basename}.ttf` / `.otf` per input; colliding basenames (e.g. `iconfont.woff` + `iconfont.woff2`) use `-woff` / `-woff2` suffixes. A single input still honors `-u` / `fontName`.
+  - URLs must end in `.woff` or `.woff2` (query strings allowed). Response must be a valid WOFF/WOFF2 container.
+  - Does **not** merge multiple weights into one SFNT file (see [NOTICE.md](./NOTICE.md)).
   - Does **not** convert TrueType outlines to PostScript/CFF (TTF → OTF) or the reverse; use an external tool (e.g. FontForge) for that.
   - Does **not** re-encode to `eot`, `woff`, or `woff2` in this mode.
   - Default `formats` when SVG-pipeline defaults are still configured: `['ttf']`.
@@ -47,9 +51,10 @@ Canonical list of product capabilities. **Update this file in the same PR** when
 - **Test Criteria**:
   - [x] `.woff2` input with `formats: ['ttf']` yields a valid TTF when the container holds TrueType
   - [x] `.woff` input with `formats: ['ttf']` yields a valid TTF when the container holds TrueType
+  - [x] Multiple webfont files decompress in one run (`decompressedFonts`)
+  - [x] HTTPS URL input decompresses when fetch returns a valid WOFF2
   - [x] Requesting `ttf` when the SFNT flavor is OTF rejects with a flavor hint
   - [x] Requesting `otf` when the SFNT flavor is TTF rejects with a flavor hint
-  - [x] Multiple webfont files in one run reject
   - [x] Template option in webfont conversion mode rejects
 
 ### Supported input file classification

--- a/NOTICE.md
+++ b/NOTICE.md
@@ -45,13 +45,14 @@ Generated font files may be subject to the same restrictions as the source icons
 
 ### 3.2 WOFF / WOFF2 decompression
 
-If you **decompress** a `.woff` or `.woff2` file to `.ttf` or `.otf`, you are extracting the **SFNT payload** inside the container. That operation:
+If you **decompress** one or more `.woff` or `.woff2` files (from disk or from an `http(s)` URL) to `.ttf` or `.otf`, you are extracting the **SFNT payload** inside each container. That operation:
 
 - does **not** make a restricted or commercial font free to use or share;
-- does **not** bypass foundry EULAs, app terms of service, or site download policies;
-- may produce a file that is **easier to reuse** than the original webfont — compliance with the **original font license** remains your obligation.
+- does **not** bypass foundry EULAs, app terms of service, CDN hotlinking policies, or site download terms;
+- may produce files that are **easier to reuse** than the original webfonts — compliance with the **original font license** remains your obligation;
+- does **not** merge multiple weights into one font file — each input yields a separate output.
 
-**Only process fonts you are authorized to use** under their license. Examples that often require explicit permission or a valid license include commercial desktop/web fonts, fonts bundled inside applications or websites (e.g. product UIs), and subscription or OEM font offerings.
+**Only process fonts you are authorized to use and download** under their license. For remote URLs, you must also have permission to fetch and store those bytes.
 
 ### 3.3 Redistribution of output
 

--- a/README.md
+++ b/README.md
@@ -26,13 +26,13 @@ webfont runs one of two pipelines depending on matched input files. They cannot 
 | Mode | Input | Outputs | Notes |
 |------|--------|---------|--------|
 | **SVG icons** | One or more `.svg` files | `svg`, `ttf`, `eot`, `woff`, `woff2` | Default. Builds TrueType via `svg2ttf`. **`otf` is rejected** — use `ttf`. |
-| **Webfont decompress** | Exactly one `.woff` or `.woff2` | `ttf` and/or `otf` | Exposes the SFNT inside the container. Request the format that matches the payload (TrueType vs `OTTO`). **Does not** transcode TTF to OTF. |
+| **Webfont decompress** | One or more `.woff` / `.woff2` paths, globs, or `http(s)` URLs | `ttf` and/or `otf` per input | One output file per source (basename from filename; collisions get `-woff`/`-woff2`). Not a single merged font. |
 
 **Not supported today**
 
 - Renaming or re-wrapping without matching the real outline format (e.g. requesting `otf` when the WOFF2 holds TrueType).
 - Converting TTF to OTF (or OTF to TTF) — use [FontForge](https://fontforge.org/) or similar.
-- Templates, `glyphTransformFn`, or multiple font files in webfont decompress mode.
+- Templates, `glyphTransformFn`, or merged multi-weight SFNT output in webfont decompress mode.
 - Globs that match extension-less or unsupported files together with fonts (the run fails instead of silently ignoring extras).
 
 Every matched path must end in `.svg`, `.woff`, or `.woff2`. See [FEATURES.md](./FEATURES.md) for test-backed criteria.
@@ -113,17 +113,29 @@ webfont({
   });
 ```
 
-### Webfont decompress example
+### Webfont decompress examples
 
 ```js
 import webfont from "webfont";
 
-const result = await webfont({
+// Single local file
+const one = await webfont({
   files: "path/to/font.woff2",
-  formats: ["ttf"], // use ["otf"] only when the WOFF2 holds OpenType (OTTO)
+  formats: ["ttf"],
 });
 
-// result.ttf → Buffer (TrueType SFNT from inside the container)
+// Batch: multiple files in one run (one TTF/OTF output per input)
+const batch = await webfont({
+  files: ["fonts/Inter-Regular.woff2", "fonts/Inter-Bold.woff2"],
+  formats: ["ttf"],
+});
+// batch.decompressedFonts → [{ source, ttf }, …]
+
+// Remote URL (http or https)
+const remote = await webfont({
+  files: "https://cdn.example.com/fonts/Inter-Medium.woff2",
+  formats: ["ttf"],
+});
 ```
 
 ### Options
@@ -133,7 +145,7 @@ const result = await webfont({
 - Type: `string` | `array`
 - Description: A file glob, or array of file globs. Ultimately passed to [fast-glob](https://github.com/mrmlnc/fast-glob) to figure out what files you want to get.
 - **SVG mode**: one or more `.svg` icon paths or globs (default pipeline).
-- **Webfont decompress mode**: exactly one `.woff` or `.woff2` file (see [`formats`](#formats) and [Input modes](#input-modes)).
+- **Webfont decompress mode**: one or more `.woff` / `.woff2` paths, globs, or `https://…` URLs (see [`formats`](#formats) and [Input modes](#input-modes)).
 - Do not mix `.svg` with `.woff` / `.woff2` in the same run.
 - Every matched file must have a supported extension (`.svg`, `.woff`, `.woff2`); extension-less files such as `LICENSE` are not ignored when matched by a broad glob.
 - `node_modules` and `bower_components` are always ignored.

--- a/src/cli/index.test.ts
+++ b/src/cli/index.test.ts
@@ -526,4 +526,16 @@ describe("cli", () => {
     const ttf = await fsPromise.readFile(`${conversionDest}/iconfont.ttf`);
     expect(ttf.length).toBeGreaterThan(0);
   });
+
+  it("should batch-decompress multiple webfont files via the CLI", async () => {
+    const conversionDest = "temp/cli-batch-decompress";
+    const output = await execCLI(
+      `src/fixtures/fonts/iconfont.woff src/fixtures/fonts/iconfont.woff2 -d ${conversionDest} -f ttf --dest-create`,
+      conversionDest,
+    );
+
+    expect(output.code).toBe(0);
+    expect(output.stderr).toBe("");
+    expect(output.files).toEqual(expect.arrayContaining(["iconfont-woff.ttf", "iconfont-woff2.ttf"]));
+  });
 });

--- a/src/cli/meow/cliOptions.ts
+++ b/src/cli/meow/cliOptions.ts
@@ -15,7 +15,7 @@ export const webfontCliHelpText = `
     Input: File(s) or glob(s).
 
         SVG icons: one or more \`.svg\` files (default pipeline).
-        Webfont conversion: a single \`.woff\` or \`.woff2\` file to decompress to TTF/OTF.
+        Webfont decompression: one or more \`.woff\` / \`.woff2\` paths, globs, or http(s) URLs.
             You must have rights to any font file you process (see NOTICE.md).
 
         If an input argument is wrapped in quotation marks, it will be passed to "fast-glob"

--- a/src/cli/program.test.ts
+++ b/src/cli/program.test.ts
@@ -7,12 +7,14 @@ import {
   buildOptionsBase,
   type CliLike,
   ensureResultConfig,
+  getDecompressedFontOutputBasename,
   getExitCode,
   getResultOutputPath,
   mergeCliDestIntoConfig,
   resolveDestTemplate,
   runCli,
   startCli,
+  writeDecompressedFontFiles,
   writeResultFiles,
 } from "./program";
 
@@ -259,6 +261,50 @@ describe("cli program", () => {
     });
   });
 
+  describe("getDecompressedFontOutputBasename", () => {
+    it("should use fontName for a single decompressed font", () => {
+      const fonts = [{ source: "fonts/Inter.woff2", ttf: Buffer.from("ttf") }];
+
+      expect(getDecompressedFontOutputBasename(fonts, fonts[0], { fontName: "my-font" } as never)).toBe("my-font");
+    });
+
+    it("should disambiguate basenames for batch decompression", () => {
+      const fonts = [
+        { source: "src/fixtures/fonts/iconfont.woff", ttf: Buffer.from("a") },
+        { source: "src/fixtures/fonts/iconfont.woff2", ttf: Buffer.from("b") },
+      ];
+
+      expect(getDecompressedFontOutputBasename(fonts, fonts[0], { fontName: "webfont" } as never)).toBe(
+        "iconfont-woff",
+      );
+      expect(getDecompressedFontOutputBasename(fonts, fonts[1], { fontName: "webfont" } as never)).toBe(
+        "iconfont-woff2",
+      );
+    });
+  });
+
+  describe("writeDecompressedFontFiles", () => {
+    it("should write one ttf per decompressed font", async () => {
+      const destination = "temp/cli-program-batch";
+      await fsPromise.mkdir(destination, { recursive: true });
+
+      await writeDecompressedFontFiles(
+        [
+          { source: "src/fixtures/fonts/iconfont.woff", ttf: Buffer.from("woff-ttf") },
+          { source: "src/fixtures/fonts/iconfont.woff2", ttf: Buffer.from("woff2-ttf") },
+        ],
+        {
+          dest: destination,
+          fontName: "webfont",
+        } as never,
+        destination,
+      );
+
+      expect(await fsPromise.readFile(path.join(destination, "iconfont-woff.ttf"), "utf8")).toBe("woff-ttf");
+      expect(await fsPromise.readFile(path.join(destination, "iconfont-woff2.ttf"), "utf8")).toBe("woff2-ttf");
+    });
+  });
+
   describe("writeResultFiles", () => {
     const destination = "temp/cli-program";
 
@@ -266,6 +312,28 @@ describe("cli program", () => {
       await fsPromise.mkdir(destination, { recursive: true });
       await fsPromise.rm(destination, { recursive: true, force: true });
       await fsPromise.mkdir(destination, { recursive: true });
+    });
+
+    it("should write batch decompressed fonts without using fontName for every file", async () => {
+      const result: Result = {
+        config: {
+          dest: destination,
+          files: ["src/fixtures/fonts/iconfont.woff", "src/fixtures/fonts/iconfont.woff2"],
+          fontName: "webfont",
+          formats: ["ttf"],
+          formatsOptions: {},
+          maxConcurrency: 1,
+        },
+        decompressedFonts: [
+          { source: "src/fixtures/fonts/iconfont.woff", ttf: Buffer.from("woff-ttf") },
+          { source: "src/fixtures/fonts/iconfont.woff2", ttf: Buffer.from("woff2-ttf") },
+        ],
+      };
+
+      await writeResultFiles(result);
+
+      const files = await fsPromise.readdir(destination);
+      expect(files).toEqual(expect.arrayContaining(["iconfont-woff.ttf", "iconfont-woff2.ttf"]));
     });
 
     it("should write font outputs and hash files", async () => {

--- a/src/cli/program.ts
+++ b/src/cli/program.ts
@@ -1,7 +1,9 @@
 import * as fs from "fs";
 import * as path from "path";
 import resolveFrom from "resolve-from";
+import { resolveDecompressedFontBasenames } from "../lib/inputSource";
 import { webfont } from "../standalone";
+import type { DecompressedFont } from "../types/DecompressedFont";
 import type { InitialOptions } from "../types/InitialOptions";
 import type { OptionsBase } from "../types/OptionsBase";
 import type { Result } from "../types/Result";
@@ -253,6 +255,44 @@ export const ensureDestExists = async (dest: string, destCreate?: boolean): Prom
   }
 };
 
+export const getDecompressedFontOutputBasename = (
+  fonts: readonly DecompressedFont[],
+  font: DecompressedFont,
+  config: ResultConfig,
+): string => {
+  if (fonts.length === 1 && config.fontName) {
+    return config.fontName;
+  }
+
+  const basenames = resolveDecompressedFontBasenames(fonts.map((entry) => entry.source));
+  const index = fonts.indexOf(font);
+
+  return basenames[index] ?? config.fontName;
+};
+
+export const writeDecompressedFontFiles = async (
+  fonts: readonly DecompressedFont[],
+  config: ResultConfig,
+  dest: string,
+): Promise<void> => {
+  await Promise.all(
+    fonts.flatMap((font) => {
+      const basename = getDecompressedFontOutputBasename(fonts, font, config);
+      const writes: Promise<void>[] = [];
+
+      if (font.ttf) {
+        writes.push(fs.promises.writeFile(path.resolve(path.join(dest, `${basename}.ttf`)), font.ttf));
+      }
+
+      if (font.otf) {
+        writes.push(fs.promises.writeFile(path.resolve(path.join(dest, `${basename}.otf`)), font.otf));
+      }
+
+      return writes;
+    }),
+  );
+};
+
 export const writeResultFiles = async (result: Result): Promise<Result> => {
   const config = ensureResultConfig(result);
   const dest = config.dest ?? process.cwd();
@@ -263,6 +303,11 @@ export const writeResultFiles = async (result: Result): Promise<Result> => {
   }
 
   await ensureDestExists(dest, config.destCreate);
+
+  if (result.decompressedFonts && result.decompressedFonts.length > 1) {
+    await writeDecompressedFontFiles(result.decompressedFonts, config, dest);
+    return result;
+  }
 
   await Promise.all(
     resultFileKeys

--- a/src/lib/inputSource.test.ts
+++ b/src/lib/inputSource.test.ts
@@ -1,0 +1,53 @@
+import {
+  getInputExtension,
+  getWebfontSourceBasename,
+  isHttpUrl,
+  resolveDecompressedFontBasenames,
+} from "./inputSource";
+
+describe("isHttpUrl", () => {
+  it("should detect http and https URLs", () => {
+    expect(isHttpUrl("https://example.com/font.woff2")).toBe(true);
+    expect(isHttpUrl("http://example.com/font.woff")).toBe(true);
+    expect(isHttpUrl("src/fixtures/fonts/iconfont.woff2")).toBe(false);
+  });
+});
+
+describe("getInputExtension", () => {
+  it("should read extensions from local paths", () => {
+    expect(getInputExtension("src/fixtures/fonts/iconfont.woff2")).toBe(".woff2");
+    expect(getInputExtension("src/fixtures/svg-icons/avatar.svg")).toBe(".svg");
+  });
+
+  it("should ignore query strings in URLs", () => {
+    expect(getInputExtension("https://cdn.example/fonts/Inter.woff2?v=1")).toBe(".woff2");
+    expect(getInputExtension("https://cdn.example/fonts/Inter.woff?token=abc")).toBe(".woff");
+  });
+
+  it("should return empty for extension-less URLs", () => {
+    expect(getInputExtension("https://cdn.example/download")).toBe("");
+  });
+});
+
+describe("getWebfontSourceBasename", () => {
+  it("should strip webfont container extensions from filenames", () => {
+    expect(getWebfontSourceBasename("fonts/Inter-Medium.woff2")).toBe("Inter-Medium");
+    expect(getWebfontSourceBasename("fonts/Inter-Medium.woff")).toBe("Inter-Medium");
+    expect(getWebfontSourceBasename("https://cdn.example/Inter-Bold.woff2")).toBe("Inter-Bold");
+  });
+});
+
+describe("resolveDecompressedFontBasenames", () => {
+  it("should keep unique basenames unchanged", () => {
+    expect(resolveDecompressedFontBasenames(["fonts/Inter-Regular.woff2", "fonts/Inter-Bold.woff2"])).toEqual([
+      "Inter-Regular",
+      "Inter-Bold",
+    ]);
+  });
+
+  it("should disambiguate colliding basenames using container suffixes", () => {
+    expect(
+      resolveDecompressedFontBasenames(["src/fixtures/fonts/iconfont.woff", "src/fixtures/fonts/iconfont.woff2"]),
+    ).toEqual(["iconfont-woff", "iconfont-woff2"]);
+  });
+});

--- a/src/lib/inputSource.ts
+++ b/src/lib/inputSource.ts
@@ -1,0 +1,79 @@
+import { globby } from "globby";
+import path from "path";
+
+const HTTP_URL_PATTERN = /^https?:\/\//iu;
+
+export const isHttpUrl = (value: string): boolean => HTTP_URL_PATTERN.test(value);
+
+export const getInputExtension = (source: string): string => {
+  if (isHttpUrl(source)) {
+    try {
+      return path.extname(new URL(source).pathname).toLowerCase();
+    } catch {
+      return "";
+    }
+  }
+
+  return path.extname(source).toLowerCase();
+};
+
+export const resolveInputSources = async (patterns: readonly string[]): Promise<string[]> => {
+  const resolved = await Promise.all(
+    patterns.map((pattern) => {
+      if (isHttpUrl(pattern)) {
+        return Promise.resolve([pattern]);
+      }
+
+      return globby(pattern);
+    }),
+  );
+
+  return resolved.flat();
+};
+
+export const getWebfontSourceBasename = (source: string): string => {
+  let pathname = source;
+
+  if (isHttpUrl(source)) {
+    pathname = new URL(source).pathname;
+  }
+
+  const filename = path.basename(pathname);
+  const extension = getInputExtension(source);
+
+  if (extension === ".woff2") {
+    return filename.slice(0, -".woff2".length);
+  }
+
+  if (extension === ".woff") {
+    return filename.slice(0, -".woff".length);
+  }
+
+  return filename.replace(/\.[^.]+$/u, "");
+};
+
+const WEBFONT_CONTAINER_SUFFIX: Record<string, string> = {
+  ".woff": "-woff",
+  ".woff2": "-woff2",
+};
+
+export const resolveDecompressedFontBasenames = (sources: readonly string[]): string[] => {
+  const stripped = sources.map((source) => getWebfontSourceBasename(source));
+  const basenameCounts = new Map<string, number>();
+
+  for (const basename of stripped) {
+    basenameCounts.set(basename, (basenameCounts.get(basename) ?? 0) + 1);
+  }
+
+  return sources.map((source, index) => {
+    const basename = stripped[index];
+    const isDuplicate = (basenameCounts.get(basename) ?? 0) > 1;
+    const extension = getInputExtension(source);
+
+    if (!isDuplicate) {
+      return basename;
+    }
+
+    return `${basename}${WEBFONT_CONTAINER_SUFFIX[extension] ?? `-${index + 1}`}`;
+  });
+};

--- a/src/standalone/convertWebfontInput.test.ts
+++ b/src/standalone/convertWebfontInput.test.ts
@@ -67,7 +67,7 @@ describe("convertWebfontInput", () => {
     mockedConvert.mockResolvedValue(otto);
 
     await expect(convertWebfontInput([fixtureWoff2], getConversionOptions({ formats: ["ttf"] }))).rejects.toThrow(
-      'Input decompresses to OpenType (OTF). Request "otf" format instead of "ttf".',
+      'Input decompresses to OpenType (OTF). Request "otf" format instead of "ttf" for src/fixtures/fonts/iconfont.woff2.',
     );
   });
 
@@ -76,7 +76,7 @@ describe("convertWebfontInput", () => {
     mockedConvert.mockResolvedValue(sfnt);
 
     await expect(convertWebfontInput([fixtureWoff2], getConversionOptions({ formats: ["otf"] }))).rejects.toThrow(
-      'Input decompresses to TrueType (TTF). Request "ttf" format instead of "otf".',
+      'Input decompresses to TrueType (TTF). Request "ttf" format instead of "otf" for src/fixtures/fonts/iconfont.woff2.',
     );
   });
 
@@ -86,10 +86,29 @@ describe("convertWebfontInput", () => {
     );
   });
 
-  it("should reject multiple font files in one conversion run", async () => {
-    await expect(convertWebfontInput([fixtureWoff, fixtureWoff2], getConversionOptions())).rejects.toThrow(
-      "WOFF/WOFF2 conversion supports one font file at a time",
-    );
+  it("should decompress multiple webfont files in one conversion run", async () => {
+    const sfnt = await fsPromise.readFile(fixtureTtf);
+    mockedConvert.mockResolvedValue(sfnt);
+
+    const result = await convertWebfontInput([fixtureWoff, fixtureWoff2], getConversionOptions());
+
+    expect(result.decompressedFonts).toHaveLength(2);
+    expect(result.decompressedFonts?.[0].source).toBe(fixtureWoff);
+    expect(result.decompressedFonts?.[1].source).toBe(fixtureWoff2);
+    expect(result.decompressedFonts?.[0].ttf).toBeDefined();
+    expect(result.decompressedFonts?.[1].ttf).toBeDefined();
+    expect(result.ttf).toBeUndefined();
+    expect(result.otf).toBeUndefined();
+  });
+
+  it("should keep single-file ttf and otf on the result root for backward compatibility", async () => {
+    const sfnt = await fsPromise.readFile(fixtureTtf);
+    mockedConvert.mockResolvedValue(sfnt);
+
+    const result = await convertWebfontInput([fixtureWoff2], getConversionOptions());
+
+    expect(result.decompressedFonts).toHaveLength(1);
+    expect(result.ttf).toEqual(sfnt);
   });
 
   it("should reject template rendering for webfont conversion", async () => {

--- a/src/standalone/convertWebfontInput.ts
+++ b/src/standalone/convertWebfontInput.ts
@@ -1,20 +1,17 @@
 import fontverter from "fontverter";
 import * as fsPromise from "fs/promises";
+import { isHttpUrl } from "../lib/inputSource";
 import { getSfntFlavor } from "../lib/sfnt/flavor";
+import type { DecompressedFont } from "../types/DecompressedFont";
 import type { Result } from "../types/Result";
 import type { WebfontOptions } from "../types/WebfontOptions";
+import { fetchWebfontFromUrl } from "./fetchWebfontUrl";
 import { type ConversionFormat, resolveWebfontConversionFormats } from "./inputMode";
 
-const assertSingleFontFile = (fontFiles: readonly string[]): string => {
+const assertNonEmptyFontFiles = (fontFiles: readonly string[]): void => {
   if (fontFiles.length === 0) {
     throw new Error("No WOFF or WOFF2 files matched");
   }
-
-  if (fontFiles.length > 1) {
-    throw new Error("WOFF/WOFF2 conversion supports one font file at a time");
-  }
-
-  return fontFiles[0];
 };
 
 const assertConversionOptions = (options: WebfontOptions): void => {
@@ -27,26 +24,61 @@ const assertConversionOptions = (options: WebfontOptions): void => {
   }
 };
 
-const assignSfntOutput = (
-  result: Result,
-  sfnt: Buffer,
-  format: ConversionFormat,
-  flavor: ReturnType<typeof getSfntFlavor>,
-): void => {
+type AssignSfntOutputOptions = {
+  decompressed: DecompressedFont;
+  sfnt: Buffer;
+  format: ConversionFormat;
+  flavor: ReturnType<typeof getSfntFlavor>;
+  source: string;
+};
+
+const assignSfntOutput = (options: AssignSfntOutputOptions): void => {
+  const { decompressed, sfnt, format, flavor, source } = options;
+
   if (format === "ttf" && flavor !== "ttf") {
-    throw new Error('Input decompresses to OpenType (OTF). Request "otf" format instead of "ttf".');
+    throw new Error(`Input decompresses to OpenType (OTF). Request "otf" format instead of "ttf" for ${source}.`);
   }
 
   if (format === "otf" && flavor !== "otf") {
-    throw new Error('Input decompresses to TrueType (TTF). Request "ttf" format instead of "otf".');
+    throw new Error(`Input decompresses to TrueType (TTF). Request "ttf" format instead of "otf" for ${source}.`);
   }
 
   if (format === "ttf") {
-    result.ttf = sfnt;
+    decompressed.ttf = sfnt;
     return;
   }
 
-  result.otf = sfnt;
+  decompressed.otf = sfnt;
+};
+
+const readWebfontInput = (source: string): Promise<Buffer> => {
+  if (isHttpUrl(source)) {
+    return fetchWebfontFromUrl(source);
+  }
+
+  return fsPromise.readFile(source);
+};
+
+const decompressWebfontSource = async (
+  source: string,
+  formats: ConversionFormat[],
+  verbose?: boolean,
+): Promise<DecompressedFont> => {
+  if (verbose) {
+    // biome-ignore lint/suspicious/noConsole: verbose conversion progress
+    console.log(`Decompressing ${source}...`);
+  }
+
+  const inputBuffer = await readWebfontInput(source);
+  const sfnt = Buffer.from(await fontverter.convert(inputBuffer, "sfnt"));
+  const flavor = getSfntFlavor(sfnt);
+  const decompressed: DecompressedFont = { source };
+
+  for (const format of formats) {
+    assignSfntOutput({ decompressed, sfnt, format, flavor, source });
+  }
+
+  return decompressed;
 };
 
 export const convertWebfontInput = async (
@@ -54,24 +86,21 @@ export const convertWebfontInput = async (
   options: WebfontOptions,
 ): Promise<Result> => {
   assertConversionOptions(options);
+  assertNonEmptyFontFiles(fontFiles);
 
-  const fontPath = assertSingleFontFile(fontFiles);
-  const inputBuffer = await fsPromise.readFile(fontPath);
-
-  if (options.verbose) {
-    // biome-ignore lint/suspicious/noConsole: verbose conversion progress
-    console.log(`Decompressing ${fontPath}...`);
-  }
-
-  const sfnt = Buffer.from(await fontverter.convert(inputBuffer, "sfnt"));
-  const flavor = getSfntFlavor(sfnt);
   const formats = resolveWebfontConversionFormats(options.formats);
+  const decompressedFonts = await Promise.all(
+    fontFiles.map((source) => decompressWebfontSource(source, formats, options.verbose)),
+  );
+
   const result: Result = {
     config: { ...options },
+    decompressedFonts,
   };
 
-  for (const format of formats) {
-    assignSfntOutput(result, sfnt, format, flavor);
+  if (decompressedFonts.length === 1) {
+    result.ttf = decompressedFonts[0].ttf;
+    result.otf = decompressedFonts[0].otf;
   }
 
   return result;

--- a/src/standalone/fetchWebfontUrl.test.ts
+++ b/src/standalone/fetchWebfontUrl.test.ts
@@ -1,0 +1,61 @@
+import * as fsPromise from "fs/promises";
+import isWoff2 from "is-woff2";
+import { fetchWebfontFromUrl } from "./fetchWebfontUrl";
+
+const fixtureWoff2 = "src/fixtures/fonts/iconfont.woff2";
+
+describe("fetchWebfontFromUrl", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("should fetch and return a valid woff2 buffer", async () => {
+    const fixture = await fsPromise.readFile(fixtureWoff2);
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        statusText: "OK",
+        arrayBuffer: async () => fixture.buffer.slice(fixture.byteOffset, fixture.byteOffset + fixture.byteLength),
+      }),
+    );
+
+    const buffer = await fetchWebfontFromUrl("https://example.com/iconfont.woff2");
+
+    expect(isWoff2(buffer)).toBe(true);
+  });
+
+  it("should reject non-success HTTP responses", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: false,
+        status: 404,
+        statusText: "Not Found",
+        arrayBuffer: async () => new ArrayBuffer(0),
+      }),
+    );
+
+    await expect(fetchWebfontFromUrl("https://example.com/missing.woff2")).rejects.toThrow(
+      "Failed to fetch font URL https://example.com/missing.woff2: HTTP 404 Not Found",
+    );
+  });
+
+  it("should reject responses that are not valid webfont containers", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        statusText: "OK",
+        arrayBuffer: async () => Buffer.from("not a font").buffer,
+      }),
+    );
+
+    await expect(fetchWebfontFromUrl("https://example.com/bad.woff2")).rejects.toThrow(
+      "URL did not return a valid WOFF2 font",
+    );
+  });
+});

--- a/src/standalone/fetchWebfontUrl.ts
+++ b/src/standalone/fetchWebfontUrl.ts
@@ -1,0 +1,46 @@
+import isWoff from "is-woff";
+import isWoff2 from "is-woff2";
+import { getInputExtension } from "../lib/inputSource";
+
+const assertWebfontContainer = (buffer: Buffer, source: string): void => {
+  const extension = getInputExtension(source);
+
+  if (extension === ".woff2" && !isWoff2(buffer)) {
+    throw new Error(`URL did not return a valid WOFF2 font: ${source}`);
+  }
+
+  if (extension === ".woff" && !isWoff(buffer)) {
+    throw new Error(`URL did not return a valid WOFF font: ${source}`);
+  }
+
+  if (buffer.length === 0) {
+    throw new Error(`URL returned an empty response: ${source}`);
+  }
+};
+
+export const fetchWebfontFromUrl = async (url: string): Promise<Buffer> => {
+  let response: Response;
+
+  try {
+    response = await fetch(url);
+  } catch (error) {
+    let message = String(error);
+
+    if (error instanceof Error) {
+      message = error.message;
+    }
+
+    throw new Error(`Failed to fetch font URL ${url}: ${message}`);
+  }
+
+  if (!response.ok) {
+    throw new Error(`Failed to fetch font URL ${url}: HTTP ${response.status} ${response.statusText}`);
+  }
+
+  const arrayBuffer = await response.arrayBuffer();
+  const buffer = Buffer.from(arrayBuffer);
+
+  assertWebfontContainer(buffer, url);
+
+  return buffer;
+};

--- a/src/standalone/index.ts
+++ b/src/standalone/index.ts
@@ -1,13 +1,13 @@
 import { cosmiconfig } from "cosmiconfig";
 import crypto from "crypto";
 import deepmerge from "deepmerge";
-import { globby } from "globby";
 import nunjucks from "nunjucks";
 import path from "path";
 import { Readable } from "stream";
 import ttf2woff from "ttf2woff";
 import wawoff2 from "wawoff2";
 import { getBuiltInTemplates, getTemplateFilePath } from "../../templates";
+import { resolveInputSources } from "../lib/inputSource";
 import { getFontStreamOptions, SVGIcons2SVGFontStream } from "../lib/svgicons2svgfont";
 import convertTtfToEot from "../lib/ttf2eot";
 import type { Format, GlyphData, GlyphMetadata, InitialOptions, WebfontOptions } from "../types";
@@ -109,7 +109,7 @@ export const webfont: Webfont = async (initialOptions) => {
     filePatterns = [options.files];
   }
 
-  const foundFiles = await globby(filePatterns);
+  const foundFiles = await resolveInputSources(filePatterns);
   const inputMode = classifyInputFiles(foundFiles);
 
   if (inputMode === "mixed") {

--- a/src/standalone/inputMode.ts
+++ b/src/standalone/inputMode.ts
@@ -1,4 +1,4 @@
-import path from "path";
+import { getInputExtension } from "../lib/inputSource";
 import type { Format } from "../types/Format";
 
 export type InputMode = "empty" | "mixed" | "svg" | "webfont";
@@ -17,7 +17,7 @@ export const classifyInputFiles = (filePaths: readonly string[]): InputMode => {
     return "empty";
   }
 
-  const extensions = filePaths.map((filePath) => path.extname(filePath).toLowerCase());
+  const extensions = filePaths.map((filePath) => getInputExtension(filePath));
 
   if (!extensions.every(isSupportedInputExtension)) {
     return "empty";
@@ -51,11 +51,11 @@ export const assertSvgPipelineFormats = (formats: readonly Format[]): void => {
 
 export const filterInputFilesByMode = (filePaths: readonly string[], mode: InputMode): string[] => {
   if (mode === "svg") {
-    return filePaths.filter((filePath) => path.extname(filePath).toLowerCase() === SVG_EXTENSION);
+    return filePaths.filter((filePath) => getInputExtension(filePath) === SVG_EXTENSION);
   }
 
   if (mode === "webfont") {
-    return filePaths.filter((filePath) => WEBFONT_EXTENSIONS.has(path.extname(filePath).toLowerCase()));
+    return filePaths.filter((filePath) => WEBFONT_EXTENSIONS.has(getInputExtension(filePath)));
   }
 
   return [];

--- a/src/standalone/webfontConversion.integration.test.ts
+++ b/src/standalone/webfontConversion.integration.test.ts
@@ -83,13 +83,42 @@ describe("webfont WOFF/WOFF2 conversion", () => {
     ).rejects.toThrow("did not match any supported files");
   });
 
-  it("should reject multiple webfont files in one run", async () => {
-    await expect(
-      standalone({
-        files: [fixtureWoff, fixtureWoff2],
-        formats: ["ttf"],
+  it("should decompress multiple webfont files in one run", async () => {
+    const result = await standalone({
+      files: [fixtureWoff, fixtureWoff2],
+      formats: ["ttf"],
+    });
+
+    expect(result.decompressedFonts).toHaveLength(2);
+    expect(result.ttf).toBeUndefined();
+    expect(result.decompressedFonts?.every((font) => isTtf(font.ttf))).toBe(true);
+  });
+
+  it("should decompress a webfont from an https URL", async () => {
+    const fixture = fs.readFileSync(fixtureWoff2);
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        statusText: "OK",
+        arrayBuffer: async () => fixture.buffer.slice(fixture.byteOffset, fixture.byteOffset + fixture.byteLength),
       }),
-    ).rejects.toThrow("WOFF/WOFF2 conversion supports one font file at a time");
+    );
+
+    try {
+      const result = await standalone({
+        files: "https://cdn.example.com/iconfont.woff2",
+        formats: ["ttf"],
+      });
+
+      expect(result.ttf).toBeDefined();
+      expect(isTtf(result.ttf)).toBe(true);
+      expect(result.decompressedFonts?.[0].source).toBe("https://cdn.example.com/iconfont.woff2");
+    } finally {
+      vi.unstubAllGlobals();
+    }
   });
 
   it("should attach discovered config filePath when converting woff2 input", async () => {
@@ -110,7 +139,9 @@ describe("webfont WOFF/WOFF2 conversion", () => {
         files: fixtureWoff2,
         formats: ["ttf", "otf"],
       }),
-    ).rejects.toThrow('Input decompresses to TrueType (TTF). Request "ttf" format instead of "otf".');
+    ).rejects.toThrow(
+      'Input decompresses to TrueType (TTF). Request "ttf" format instead of "otf" for src/fixtures/fonts/iconfont.woff2.',
+    );
   });
 
   it("should document that input fixtures are valid webfont containers", () => {

--- a/src/types/DecompressedFont.ts
+++ b/src/types/DecompressedFont.ts
@@ -1,0 +1,5 @@
+export type DecompressedFont = {
+  source: string;
+  ttf?: Buffer;
+  otf?: Buffer;
+};

--- a/src/types/Result.ts
+++ b/src/types/Result.ts
@@ -1,8 +1,12 @@
+import type { DecompressedFont } from "./DecompressedFont";
 import type { GlyphData } from "./GlyphData";
 import type { ResultConfig } from "./ResultConfig";
 
+export type { DecompressedFont } from "./DecompressedFont";
+
 export type Result = {
   config?: ResultConfig;
+  decompressedFonts?: DecompressedFont[];
   eot?: Buffer;
   glyphsData?: Array<GlyphData>;
   hash?: string;

--- a/types/is-woff.d.ts
+++ b/types/is-woff.d.ts
@@ -1,0 +1,7 @@
+declare module "is-woff" {
+  export default function isWoff(buffer: Buffer): boolean;
+}
+
+declare module "is-woff2" {
+  export default function isWoff2(buffer: Buffer): boolean;
+}


### PR DESCRIPTION
## Summary

### Proposed changes

This PR brings the following changes:

- Allow **multiple** `.woff` / `.woff2` inputs in one webfont decompress run (paths, globs, and/or `http(s)` URLs).
- Expose per-input results on `result.decompressedFonts` (`{ source, ttf?, otf? }[]`); a single input still sets `result.ttf` / `result.otf` at the top level for backward compatibility.
- Add `fetchWebfontFromUrl` with WOFF/WOFF2 validation for remote sources (query strings in URLs supported).
- CLI writes `{basename}.ttf` / `.otf` per input; colliding basenames get `-woff` / `-woff2` suffixes. Single-input runs still honor `-u` / `fontName`.
- Update `FEATURES.md`, `README.md`, `NOTICE.md`, and CLI help for batch + URL behavior.

### Related issue

N/A

### Dependencies added/removed (if applicable)

N/A

---

### Testing

- [x] I have added or updated tests that prove my fix is effective or that my feature works (if applicable)
  - [x] Unit test
  - [x] Manual test

#### How to test

1. Run `npm test` — 271 tests pass.
2. Batch: `node dist/cli.mjs "src/fixtures/fonts/*.woff2" -f ttf` — one `.ttf` per matched file.
3. URL (with mock or real CDN): `webfont({ files: "https://…/font.woff2", formats: ["ttf"] })`.

#### Test configuration

N/A

---

## Checklist

- [x] I have added corresponding labels to this PR (like bug, enhancement...);
- [x] My commits follow the [Conventional Commits 1.0 Guidelines](https://www.conventionalcommits.org/en/v1.0.0/);
- [x] My code follows the style guidelines of this project;
- [x] I have performed a self-review of my own code;
- [x] I have mapped technical debts found on my changes;
- [x] I have made changes to the documentation (if applicable);
- [x] My changes generate no new warnings or errors;

Made with [Cursor](https://cursor.com)