### PR TITLE
docs(release): use v{semver} tags without package prefix

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -23,3 +23,4 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
+          include-component-in-tag: false

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -124,7 +124,7 @@ See also [CONTRIBUTING.md](./CONTRIBUTING.md) — “User-facing changes and doc
 - Follow [CONTRIBUTING.md](./CONTRIBUTING.md) and existing ADRs under `docs/adr/`.
 - Run `npm run depcheck` (Knip) when changing imports or `package.json` dependencies; see [ADR 0008](docs/adr/0008-knip-instead-of-depcheck.md).
 - Use conventional commits (`feat`, `fix`, `test`, `docs`, `chore`, `refactor`, `ci`).
-- Releases are handled by Release Please on `master`; do not bump `package.json` version in feature PRs (see [ADR 0004](docs/adr/0004-release-please-instead-of-standard-version.md)).
+- Releases are handled by Release Please on `master`; do not bump `package.json` version in feature PRs (see [ADR 0004](docs/adr/0004-release-please-instead-of-standard-version.md)). Release git tags use **`v{semver}`** (`v12.0.0`); `release-please-config.json` sets `include-component-in-tag: false` — do not use `webfont-v*` tags.
 - Keep changes focused; match surrounding code style and tooling (Biome, Vitest, Lefthook).
 - Do not commit unless explicitly asked.
 - **Never push to `master`.** Use a branch and open a PR (see [Pull requests](#pull-requests) below).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file. See [Conventional Commits](https://www.conventionalcommits.org/) and [Release Please](https://github.com/googleapis/release-please) (ADR [0004](docs/adr/0004-release-please-instead-of-standard-version.md)).
 
-## [12.0.0](https://github.com/itgalaxy/webfont/compare/webfont-v11.5.21...webfont-v12.0.0) (2026-07-02)
+## [12.0.0](https://github.com/itgalaxy/webfont/compare/v11.5.21...v12.0.0) (2026-07-02)
 
 
 ### ⚠ BREAKING CHANGES

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -159,6 +159,8 @@ Versioning is automated with [Release Please](https://github.com/googleapis/rele
 3. Review and merge the Release PR to create the git tag and GitHub Release on GitHub.
 4. Publish to npm (see **npm publishing** below). The [`npm-publish`](.github/workflows/npm-publish.yml) workflow listens for `release: published`, but releases created with the default `GITHUB_TOKEN` usually **do not** trigger downstream workflows — use manual publish or re-run the workflow from the Actions tab if needed.
 
+**Git tags** created by Release Please follow **`v{semver}`** (for example `v12.0.0`). The config sets `include-component-in-tag: false` so tags are not prefixed with the package name (`webfont-v12.0.0`). See [ADR 0004](docs/adr/0004-release-please-instead-of-standard-version.md).
+
 Do not run local `npm version` or push version tags manually unless coordinating an emergency release with maintainers.
 
 #### npm publishing

--- a/docs/adr/0004-release-please-instead-of-standard-version.md
+++ b/docs/adr/0004-release-please-instead-of-standard-version.md
@@ -46,6 +46,7 @@ The project already uses [Conventional Commits](https://www.conventionalcommits.
 ```json
 // release-please-config.json
 {
+  "include-component-in-tag": false,
   "packages": {
     ".": {
       "release-type": "node",
@@ -54,6 +55,14 @@ The project already uses [Conventional Commits](https://www.conventionalcommits.
   }
 }
 ```
+
+### Git tag format
+
+Release tags use the **`v{semver}`** pattern (for example `v12.0.0`), matching tags created before Release Please (`v11.5.21`, `v11.2.26`, …).
+
+Release Please defaults to prefixing the package name in tags (`webfont-v12.0.0`) when `package-name` is set. For this single-package repo, **`include-component-in-tag: false`** in `release-please-config.json` (and the same flag on `release-please-action`) keeps tags and GitHub Releases aligned with the historical `v*` convention.
+
+Do not rename release tags casually: npm publish, `npm-publish.yml`, and changelog compare links all reference the tag name.
 
 ```json
 // .release-please-manifest.json

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
+  "include-component-in-tag": false,
   "packages": {
     ".": {
       "release-type": "node",


### PR DESCRIPTION
## Summary

### Proposed changes

This PR brings the following changes:

- Set `include-component-in-tag: false` in `release-please-config.json` and `release-please.yml` so Release Please creates tags like `v12.0.0` (not `webfont-v12.0.0`).
- Document the `v{semver}` tag convention in ADR 0004, `CONTRIBUTING.md`, and `AGENTS.md`.
- Fix the 12.0.0 changelog compare link to `v11.5.21...v12.0.0`.

The GitHub release and tag were already renamed on the remote: `webfont-v12.0.0` → `v12.0.0`.

### Related issue

N/A

### Dependencies added/removed (if applicable)

N/A

---

### Testing

- [x] I have added or updated tests that prove my fix is effective or that my feature works (if applicable)
  - Docs and release config only; no runtime code changes.

#### How to test

1. Review `release-please-config.json` and `.github/workflows/release-please.yml` for `include-component-in-tag: false`.
2. Confirm https://github.com/itgalaxy/webfont/releases/tag/v12.0.0 exists and `webfont-v12.0.0` is gone.
3. Run `npm test` (passes locally).

#### Test configuration

N/A

---

## Checklist

- [ ] I have added corresponding labels to this PR (like bug, enhancement...);
- [x] My commits follow the [Conventional Commits 1.0 Guidelines](https://www.conventionalcommits.org/en/v1.0.0/);
- [x] My code follows the style guidelines of this project;
- [x] I have performed a self-review of my own code;
- [ ] I have mapped technical debts found on my changes;
- [x] I have made changes to the documentation (if applicable);
- [x] My changes generate no new warnings or errors;

Made with [Cursor](https://cursor.com)