### PR TITLE
fix(cli): support files glob from config without CLI input (#2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ See **[FEATURES.md](./FEATURES.md)** for the canonical capability list (what is 
 
 **Legal / licensing:** [NOTICE.md](./NOTICE.md) — font copyright, disclaimers, attribution guidelines, and third-party library notices.
 
+**Troubleshooting:** [TROUBLESHOOTING.md](./TROUBLESHOOTING.md) — common errors, why they happen, and steps to fix them.
+
 ## Features
 
 - **SVG icon pipeline** (default): `.svg` icons → `svg`, `ttf`, `eot`, `woff`, `woff2` (not `otf`);

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -143,3 +143,72 @@ If the path contains `cursor-sandbox-cache` (or similar), the IDE injected it �
 4. **CI and plain shells** outside Cursor are unaffected; no change is required there.
 
 This warning does not indicate a broken install or a webfont bug.
+
+---
+
+## Config `files` ignored when using `--config`
+
+### What error appeared
+
+You pass `--config webfont.config.json` with a `files` array in the config, but webfont only processes SVG paths from the command line — or shows help when you omit positional arguments.
+
+Example config:
+
+```json
+{
+  "files": ["src/icons/a.svg", "src/icons/b.svg"],
+  "dest": "dist/icons",
+  "fontName": "my-icons"
+}
+```
+
+**Older releases (before the fix in [#696](https://github.com/itgalaxy/webfont/pull/696)):**
+
+```shell
+webfont --config webfont.config.json -d dist/icons
+# Shows help or does not pick up both files from config
+```
+
+If you also pass SVG paths on the CLI while `files` is set in the config, older releases may silently prefer CLI input only.
+
+**After the fix ships** (upgrade required), combining both causes a clear error:
+
+```text
+Error: Cannot specify input files on the command line when `files` is set in the config file
+```
+
+### Why it usually happens
+
+- **The CLI treated positional arguments as the only input source.** Config `files` was merged inside `webfont()`, but the CLI required at least one path on the command line before running.
+- **`files` in config and CLI input are mutually exclusive by design** — use one or the other to avoid ambiguity about which globs win.
+
+### Steps to try to resolve
+
+1. **Upgrade webfont** to a version that includes the fix for [#2](https://github.com/itgalaxy/webfont/issues/2) (see release notes / [#696](https://github.com/itgalaxy/webfont/pull/696)). Then run **without** positional SVG arguments:
+
+   ```shell
+   webfont --config webfont.config.json -d dist/icons
+   ```
+
+2. **Until you upgrade**, pass all globs on the command line and use the config only for other options (`fontName`, `dest`, `formats`, etc.):
+
+   ```shell
+   webfont "src/icons/a.svg" "src/icons/b.svg" --config webfont.config.json -d dist/icons
+   ```
+
+   Ensure the config file does **not** contain a `files` key in this mode.
+
+3. **Programmatic API** — pass `files` directly (config discovery still merges other keys):
+
+   ```js
+   import { webfont } from "webfont";
+
+   await webfont({
+     files: ["src/icons/a.svg", "src/icons/b.svg"],
+     configFile: "webfont.config.json",
+   });
+   ```
+
+4. **Do not mix** CLI positional paths with `files` in the config after upgrading — pick one source of truth.
+
+If the problem persists after upgrading, open an issue with your config file, full command, and webfont version (`webfont --version` or `npm ls webfont`).

--- a/src/cli/index.test.ts
+++ b/src/cli/index.test.ts
@@ -327,6 +327,26 @@ describe("cli", () => {
     expect(output.stderr).toBe("");
   });
 
+  it("should use files from config when no CLI input is provided (#2)", async () => {
+    const configPath = `${fixturesGlob}/configs/.webfontrc-files.json`;
+    const output = await execCLI(`-d ${destination} --config ${configPath}`);
+
+    expect(output.files).toEqual(["config-files-font.hash", "config-files-font.woff2"]);
+    expect(output.code).toBe(0);
+    expect(output.stderr).toBe("");
+  });
+
+  it("should reject CLI input when config defines files (#2)", async () => {
+    const configPath = `${fixturesGlob}/configs/.webfontrc-files.json`;
+    const output = await execCLI(`${source}/envelope.svg -d ${destination} --config ${configPath}`);
+
+    expect(output.code).toBe(1);
+    expect(output.stderr).toBe("");
+    expect(output.stdout).toMatch(
+      /Cannot specify input files on the command line when `files` is set in the config file/u,
+    );
+  });
+
   it("should generate built-in html template", async () => {
     const output = await execCLI(`${source} -d ${destination} --template html --templateCacheString test`);
 

--- a/src/cli/program.meow.integration.test.ts
+++ b/src/cli/program.meow.integration.test.ts
@@ -4,9 +4,14 @@ import { webfont } from "../standalone";
 import { createMeowCli } from "./meow/createMeowCli";
 import { runCli } from "./program";
 
-vi.mock("../standalone", () => ({
-  webfont: vi.fn(),
-}));
+vi.mock("../standalone", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../standalone")>();
+
+  return {
+    ...actual,
+    webfont: vi.fn(),
+  };
+});
 
 const mockedWebfont = vi.mocked(webfont);
 

--- a/src/cli/program.test.ts
+++ b/src/cli/program.test.ts
@@ -18,9 +18,14 @@ import {
   writeResultFiles,
 } from "./program";
 
-vi.mock("../standalone", () => ({
-  webfont: vi.fn(),
-}));
+vi.mock("../standalone", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../standalone")>();
+
+  return {
+    ...actual,
+    webfont: vi.fn(),
+  };
+});
 
 const mockedWebfont = vi.mocked(webfont);
 

--- a/src/cli/program.ts
+++ b/src/cli/program.ts
@@ -9,6 +9,7 @@ import type { OptionsBase } from "../types/OptionsBase";
 import type { Result } from "../types/Result";
 import type { ResultConfig } from "../types/ResultConfig";
 import { parseFormatsFlag } from "./parseFormatsFlag";
+import { resolveCliFiles } from "./resolveCliFiles";
 
 export type CliLike = {
   flags: {
@@ -356,11 +357,13 @@ export const runCli = async (cli: CliLike): Promise<Result> => {
   }
 
   const optionsBase = buildOptionsBase(cli);
-  const options = { ...optionsBase, files: cli.input };
+  const files = await resolveCliFiles(cli, optionsBase);
 
-  if (options.files.length === 0) {
+  if (files.length === 0) {
     cli.showHelp();
   }
+
+  const options = { ...optionsBase, files };
 
   const result = await webfont(options);
   mergeCliDestIntoConfig(result, options);

--- a/src/cli/resolveCliFiles.test.ts
+++ b/src/cli/resolveCliFiles.test.ts
@@ -1,0 +1,81 @@
+import { loadWebfontConfig } from "../standalone";
+import type { CliLike } from "./program";
+import { resolveCliFiles } from "./resolveCliFiles";
+
+vi.mock("../standalone", () => ({
+  loadWebfontConfig: vi.fn(),
+}));
+
+const mockedLoadWebfontConfig = vi.mocked(loadWebfontConfig);
+
+const createCli = (overrides: Partial<CliLike> = {}): CliLike => ({
+  flags: {},
+  input: [],
+  showHelp: vi.fn(),
+  showVersion: vi.fn(),
+  ...overrides,
+});
+
+describe("resolveCliFiles", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should return CLI positional input when no config files are set", async () => {
+    mockedLoadWebfontConfig.mockResolvedValue({});
+
+    const files = await resolveCliFiles(createCli({ input: ["icons/*.svg"] }), {});
+
+    expect(files).toEqual(["icons/*.svg"]);
+  });
+
+  it("should return files from config when CLI input is empty", async () => {
+    mockedLoadWebfontConfig.mockResolvedValue({
+      config: {
+        files: ["a.svg", "b.svg"],
+      },
+      filepath: "/tmp/webfont.config.json",
+      isEmpty: false,
+    });
+
+    const files = await resolveCliFiles(createCli(), { configFile: "/tmp/webfont.config.json" });
+
+    expect(files).toEqual(["a.svg", "b.svg"]);
+  });
+
+  it("should normalize a single config files string to an array", async () => {
+    mockedLoadWebfontConfig.mockResolvedValue({
+      config: {
+        files: "icons/*.svg",
+      },
+      filepath: "/tmp/webfont.config.json",
+      isEmpty: false,
+    });
+
+    const files = await resolveCliFiles(createCli(), { configFile: "/tmp/webfont.config.json" });
+
+    expect(files).toEqual(["icons/*.svg"]);
+  });
+
+  it("should throw when CLI input and config files are both provided", async () => {
+    mockedLoadWebfontConfig.mockResolvedValue({
+      config: {
+        files: ["a.svg", "b.svg"],
+      },
+      filepath: "/tmp/webfont.config.json",
+      isEmpty: false,
+    });
+
+    await expect(
+      resolveCliFiles(createCli({ input: ["only.svg"] }), { configFile: "/tmp/webfont.config.json" }),
+    ).rejects.toThrow("Cannot specify input files on the command line when `files` is set in the config file");
+  });
+
+  it("should return an empty array when neither CLI input nor config files are set", async () => {
+    mockedLoadWebfontConfig.mockResolvedValue({});
+
+    const files = await resolveCliFiles(createCli(), {});
+
+    expect(files).toEqual([]);
+  });
+});

--- a/src/cli/resolveCliFiles.ts
+++ b/src/cli/resolveCliFiles.ts
@@ -1,0 +1,36 @@
+import { loadWebfontConfig } from "../standalone";
+import type { OptionsBase } from "../types/OptionsBase";
+import type { CliLike } from "./program";
+
+type LoadedConfig = Awaited<ReturnType<typeof loadWebfontConfig>>;
+
+const getFilesFromLoadedConfig = (loaded: LoadedConfig): string[] | undefined => {
+  if (!("config" in loaded) || loaded.config?.files === undefined) {
+    return undefined;
+  }
+
+  if (Array.isArray(loaded.config.files)) {
+    return loaded.config.files;
+  }
+
+  return [loaded.config.files];
+};
+
+export const resolveCliFiles = async (cli: CliLike, optionsBase: OptionsBase): Promise<string[]> => {
+  const loaded = await loadWebfontConfig({ configFile: optionsBase.configFile });
+  const configFiles = getFilesFromLoadedConfig(loaded);
+
+  if (cli.input.length > 0 && configFiles !== undefined) {
+    throw new Error("Cannot specify input files on the command line when `files` is set in the config file");
+  }
+
+  if (cli.input.length > 0) {
+    return cli.input;
+  }
+
+  if (configFiles !== undefined) {
+    return configFiles;
+  }
+
+  return [];
+};

--- a/src/fixtures/configs/.webfontrc-files.json
+++ b/src/fixtures/configs/.webfontrc-files.json
@@ -1,0 +1,5 @@
+{
+  "fontName": "config-files-font",
+  "formats": ["woff2"],
+  "files": ["src/fixtures/svg-icons/envelope.svg", "src/fixtures/svg-icons/avatar.svg"]
+}

--- a/src/standalone/index.ts
+++ b/src/standalone/index.ts
@@ -45,6 +45,8 @@ const buildConfig = async (options: {
   return config ?? {};
 };
 
+export const loadWebfontConfig = buildConfig;
+
 type GlyphReadable = Readable & { metadata: GlyphMetadata };
 
 const toSvg = (glyphsData: GlyphData[], options: WebfontOptions) => {


### PR DESCRIPTION
## Summary

### Proposed changes

Fixes #2.

- **`resolveCliFiles`:** when the CLI has no positional input, load `files` from the cosmiconfig file (`--config` or discovered `.webfontrc`).
- **Mutual exclusion:** throw a clear error if both CLI positional paths and config `files` are provided (as discussed in the original thread).
- **Tests:** unit tests for `resolveCliFiles`; CLI integration tests for config-only `files` and the conflict case.
- **TROUBLESHOOTING:** new entry for config `files` (#2) — workarounds on older releases and steps after upgrade.
- **Export `loadWebfontConfig`** from the standalone entry so the CLI can peek at config before calling `webfont()`.

### Related issue

Closes #2 when released (issue stays open until the fix ships in a published version).

### Dependencies added/removed (if applicable)

N/A

---

### Testing

- [x] I have added or updated tests that prove my fix is effective or that my feature works (if applicable)
  - [x] Unit test (`resolveCliFiles.test.ts`)
  - [x] Manual test via CLI integration (`index.test.ts`)

#### How to test

1. `npm test` — 278 tests pass.
2. `node dist/cli.mjs -d temp/out --config src/fixtures/configs/.webfontrc-files.json` (no positional SVG args) — should build `config-files-font.woff2`.
3. Same command with an extra SVG path on the CLI — should exit 1 with the mutual-exclusion message.

#### Test configuration

N/A

---

## Checklist

- [x] I have added corresponding labels to this PR (like bug, enhancement...);
- [x] My commits follow the [Conventional Commits 1.0 Guidelines](https://www.conventionalcommits.org/en/v1.0.0/);
- [x] My code follows the style guidelines of this project;
- [x] I have performed a self-review of my own code;
- [ ] I have mapped technical debts found on my changes;
- [ ] I have made changes to the documentation (if applicable);
- [x] My changes generate no new warnings or errors;

Made with [Cursor](https://cursor.com)