### PR TITLE
docs: document issue loop with TROUBLESHOOTING and release replies

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -115,7 +115,8 @@ When a task changes **how users interact with webfont** (CLI flags, programmatic
 2. **Update README.md** when behavior, accepted input formats, or public options change. Keep CLI flag names and short aliases aligned with `meow` (`-f` / `--formats`, `-u` / `--fontName`, etc.).
 3. **Update [FEATURES.md](./FEATURES.md)** when capabilities, stability, properties, or test criteria change. Mark features `stable`, `in-progress`, or `planned`; tick test criteria when coverage exists.
 4. **Update [NOTICE.md](./NOTICE.md)** when legal notices, font licensing guidance, attribution rules, or runtime dependency licenses change.
-5. **Do not rely on CHANGELOG alone** for unreleased work; Release Please updates `CHANGELOG.md` at release time.
+5. **Update [TROUBLESHOOTING.md](./TROUBLESHOOTING.md)** when fixing bugs or recurring errors (issue-driven fixes): document symptoms, cause, and resolution steps; update again when the fix version ships on npm.
+6. **Do not rely on CHANGELOG alone** for unreleased work; Release Please updates `CHANGELOG.md` at release time.
 
 See also [CONTRIBUTING.md](./CONTRIBUTING.md) — “User-facing changes and documentation”.
 
@@ -140,6 +141,40 @@ See also [CONTRIBUTING.md](./CONTRIBUTING.md) — “User-facing changes and doc
   - Unused parameters: `_name` prefix on the parameter or property.
 - **No `ignoreDeprecations` in `tsconfig.json` (or any tsconfig).** On TypeScript upgrades, migrate deprecated compiler options and fix type errors instead of silencing warnings (see [CONTRIBUTING.md](./CONTRIBUTING.md)).
 - After edits, run `npm test` and confirm `rg 'eslint-disable|@ts-expect-error|@ts-ignore|ignoreDeprecations'` returns no matches.
+
+## GitHub issues workflow
+
+Process open issues **oldest to newest** (`gh issue list --state open`, sort by number). For each issue:
+
+### Triage (every issue)
+
+1. Read the report and comments.
+2. Assign **`jimmyandrade`** (`gh issue edit <n> --add-assignee jimmyandrade`).
+3. Set milestone **`next`** (`--milestone next`).
+4. Add one type label: `bug`, `enhancement`, `security`, `ci`, or `question` (match the report; do not duplicate `enhancement` + `bug`).
+
+### Fix PR (when a code or docs change is needed)
+
+1. Comment on the issue **in English**: investigation is in progress; link the PR when it exists.
+2. **Tests first:** check coverage for the affected area. Add or extend tests that name the failure **before** changing production code when coverage is missing.
+3. Implement the fix; run `npm test`.
+4. **Bugs and user-facing errors:** add or update an entry in [TROUBLESHOOTING.md](./TROUBLESHOOTING.md) using the existing structure (*What error appeared* → *Why it usually happens* → *Steps to try to resolve*). Link the GitHub issue. Document workarounds on current releases and the steps after the fix ships.
+5. Open a PR (English title/body, Conventional Commits). Link the issue in **Related issue**; do **not** use `Closes #n` if the issue should stay open until npm publish.
+6. Wait for CI; wait for maintainer merge.
+
+### After merge (before release)
+
+1. Comment on the issue **in English**: the fix is on `master`, planned for the **next** npm release, with a link to the merged PR.
+2. **Keep the issue open** until the fix is published on npm.
+3. Point reporters to [TROUBLESHOOTING.md](./TROUBLESHOOTING.md) for interim workarounds when applicable.
+
+### On release (when the version containing the fix ships)
+
+1. Comment on the issue **in English** with the **released version** (e.g. `12.1.0`), npm install command, and **concrete steps** from TROUBLESHOOTING (or README) — not only “upgrade”.
+2. **Close the issue** with a short note referencing the release tag / CHANGELOG entry.
+3. If TROUBLESHOOTING still says “after the fix ships (upgrade required)”, update that section to name the minimum version and trim obsolete workarounds.
+
+Skip PRs for duplicates, `wontfix`, or issues that only need a comment (already fixed in a recent release — verify with tests or changelog before closing).
 
 ## Pull requests
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -115,8 +115,9 @@ When a task changes **how users interact with webfont** (CLI flags, programmatic
 2. **Update README.md** when behavior, accepted input formats, or public options change. Keep CLI flag names and short aliases aligned with `meow` (`-f` / `--formats`, `-u` / `--fontName`, etc.).
 3. **Update [FEATURES.md](./FEATURES.md)** when capabilities, stability, properties, or test criteria change. Mark features `stable`, `in-progress`, or `planned`; tick test criteria when coverage exists.
 4. **Update [NOTICE.md](./NOTICE.md)** when legal notices, font licensing guidance, attribution rules, or runtime dependency licenses change.
-5. **Update [TROUBLESHOOTING.md](./TROUBLESHOOTING.md)** when fixing bugs or recurring errors (issue-driven fixes): document symptoms, cause, and resolution steps; update again when the fix version ships on npm.
-6. **Do not rely on CHANGELOG alone** for unreleased work; Release Please updates `CHANGELOG.md` at release time.
+5. **Update [TROUBLESHOOTING.md](./TROUBLESHOOTING.md)** for operational errors (symptoms and fixes on the **current** release, not version-to-version deltas).
+6. **Update [MIGRATION.md](./MIGRATION.md)** when a fix or change alters behavior across releases: document *before* / *after*, workarounds on older versions, and steps after upgrading. Link the GitHub issue; set the **minimum fixed version** when the release ships.
+7. **Do not rely on CHANGELOG alone** for unreleased work; Release Please updates `CHANGELOG.md` at release time.
 
 See also [CONTRIBUTING.md](./CONTRIBUTING.md) — “User-facing changes and documentation”.
 
@@ -158,7 +159,7 @@ Process open issues **oldest to newest** (`gh issue list --state open`, sort by 
 1. Comment on the issue **in English**: investigation is in progress; link the PR when it exists.
 2. **Tests first:** check coverage for the affected area. Add or extend tests that name the failure **before** changing production code when coverage is missing.
 3. Implement the fix; run `npm test`.
-4. **Bugs and user-facing errors:** add or update an entry in [TROUBLESHOOTING.md](./TROUBLESHOOTING.md) using the existing structure (*What error appeared* → *Why it usually happens* → *Steps to try to resolve*). Link the GitHub issue. Document workarounds on current releases and the steps after the fix ships.
+4. **Bugs and behavior changes across releases:** add or update [MIGRATION.md](./MIGRATION.md) (*Before* → *After* → *Workaround on older versions* → *After upgrading*). Link the GitHub issue. Use [TROUBLESHOOTING.md](./TROUBLESHOOTING.md) only when the entry is not version-specific (same behavior on all supported releases).
 5. Open a PR (English title/body, Conventional Commits). Link the issue in **Related issue**; do **not** use `Closes #n` if the issue should stay open until npm publish.
 6. Wait for CI; wait for maintainer merge.
 
@@ -166,13 +167,13 @@ Process open issues **oldest to newest** (`gh issue list --state open`, sort by 
 
 1. Comment on the issue **in English**: the fix is on `master`, planned for the **next** npm release, with a link to the merged PR.
 2. **Keep the issue open** until the fix is published on npm.
-3. Point reporters to [TROUBLESHOOTING.md](./TROUBLESHOOTING.md) for interim workarounds when applicable.
+3. Point reporters to [MIGRATION.md](./MIGRATION.md) (workarounds on their version) when the fix is not on npm yet.
 
 ### On release (when the version containing the fix ships)
 
-1. Comment on the issue **in English** with the **released version** (e.g. `12.1.0`), npm install command, and **concrete steps** from TROUBLESHOOTING (or README) — not only “upgrade”.
+1. Comment on the issue **in English** with the **released version** (e.g. `12.1.0`), `npm install` command, and **concrete steps** from MIGRATION.md — not only “upgrade”.
 2. **Close the issue** with a short note referencing the release tag / CHANGELOG entry.
-3. If TROUBLESHOOTING still says “after the fix ships (upgrade required)”, update that section to name the minimum version and trim obsolete workarounds.
+3. Update MIGRATION.md: set the **minimum version**, move the section under that release heading, and remove obsolete “before upgrade” workarounds.
 
 Skip PRs for duplicates, `wontfix`, or issues that only need a comment (already fixed in a recent release — verify with tests or changelog before closing).
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,6 +16,17 @@ As a user of this project you’re perfect for helping us improve our docs: typo
 
 Some [issues lack information](https://github.com/itgalaxy/webfont/issues?q=is%3Aopen+is%3Aissue+label%3A%22need+more+info%22), aren’t reproducible, or are just [invalid](https://github.com/itgalaxy/webfont/issues?q=is%3Aopen+is%3Aissue+label%3Ainvalid). Help make them easier to resolve.
 
+**Common errors:** see [TROUBLESHOOTING.md](./TROUBLESHOOTING.md) for symptoms, causes, and step-by-step fixes before opening a duplicate issue.
+
+### Maintainer backlog (open issues)
+
+When working through the issue tracker (see also [AGENTS.md](./AGENTS.md) — “GitHub issues workflow”):
+
+1. Triage: assignee, milestone `next`, type label (`bug`, `enhancement`, etc.).
+2. Fix PR: tests where needed, code change, and for **bugs/errors** an entry in [TROUBLESHOOTING.md](./TROUBLESHOOTING.md) (error → why → steps, including workarounds before the fix ships).
+3. After merge: comment on the issue in English that the fix is on `master` and planned for the next release; **leave the issue open** until npm publish.
+4. On release: comment with the **version number** and the exact steps from TROUBLESHOOTING/README, then **close** the issue.
+
 ## Giving feedback on issues
 
 We’re always looking for more opinions on discussions in the issue tracker.
@@ -54,6 +65,7 @@ When it does, update documentation in the same PR:
 | CLI flags, aliases, or accepted flag values | [README.md](./README.md) CLI section, `src/cli/meow/cliOptions.ts` help text, and [FEATURES.md](./FEATURES.md) when capability changes |
 | `webfont()` options, defaults, return shape, or supported inputs/outputs | [README.md](./README.md) Options / Result / Input modes, [FEATURES.md](./FEATURES.md) |
 | New or removed public options or pipelines | README + [FEATURES.md](./FEATURES.md) + TypeScript types under `src/types/` |
+| Bug fixes or recurring user-facing errors (especially from issues) | [TROUBLESHOOTING.md](./TROUBLESHOOTING.md) — error, cause, steps (include workarounds before release and steps after upgrade) |
 | Legal notices, font licensing copy, attribution, or dependency license table | [NOTICE.md](./NOTICE.md); link from README as needed |
 | Internal-only refactors with no usage change | No README or FEATURES change; say so in the PR **Testing** section |
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,16 +16,16 @@ As a user of this project you’re perfect for helping us improve our docs: typo
 
 Some [issues lack information](https://github.com/itgalaxy/webfont/issues?q=is%3Aopen+is%3Aissue+label%3A%22need+more+info%22), aren’t reproducible, or are just [invalid](https://github.com/itgalaxy/webfont/issues?q=is%3Aopen+is%3Aissue+label%3Ainvalid). Help make them easier to resolve.
 
-**Common errors:** see [TROUBLESHOOTING.md](./TROUBLESHOOTING.md) for symptoms, causes, and step-by-step fixes before opening a duplicate issue.
+**Common errors:** see [TROUBLESHOOTING.md](./TROUBLESHOOTING.md) for symptoms and fixes on the current release. **Upgrading?** see [MIGRATION.md](./MIGRATION.md) for what changed between versions.
 
 ### Maintainer backlog (open issues)
 
 When working through the issue tracker (see also [AGENTS.md](./AGENTS.md) — “GitHub issues workflow”):
 
 1. Triage: assignee, milestone `next`, type label (`bug`, `enhancement`, etc.).
-2. Fix PR: tests where needed, code change, and for **bugs/errors** an entry in [TROUBLESHOOTING.md](./TROUBLESHOOTING.md) (error → why → steps, including workarounds before the fix ships).
+2. Fix PR: tests where needed, code change, and for **issue fixes that change behavior across releases** an entry in [MIGRATION.md](./MIGRATION.md) (before → after → workaround → steps after upgrade).
 3. After merge: comment on the issue in English that the fix is on `master` and planned for the next release; **leave the issue open** until npm publish.
-4. On release: comment with the **version number** and the exact steps from TROUBLESHOOTING/README, then **close** the issue.
+4. On release: comment with the **version number** and the exact steps from MIGRATION.md, then **close** the issue.
 
 ## Giving feedback on issues
 
@@ -65,7 +65,7 @@ When it does, update documentation in the same PR:
 | CLI flags, aliases, or accepted flag values | [README.md](./README.md) CLI section, `src/cli/meow/cliOptions.ts` help text, and [FEATURES.md](./FEATURES.md) when capability changes |
 | `webfont()` options, defaults, return shape, or supported inputs/outputs | [README.md](./README.md) Options / Result / Input modes, [FEATURES.md](./FEATURES.md) |
 | New or removed public options or pipelines | README + [FEATURES.md](./FEATURES.md) + TypeScript types under `src/types/` |
-| Bug fixes or recurring user-facing errors (especially from issues) | [TROUBLESHOOTING.md](./TROUBLESHOOTING.md) — error, cause, steps (include workarounds before release and steps after upgrade) |
+| Bug fixes or recurring user-facing errors (especially from issues) | [MIGRATION.md](./MIGRATION.md) when behavior changes across versions; [TROUBLESHOOTING.md](./TROUBLESHOOTING.md) when the fix applies the same on all releases |
 | Legal notices, font licensing copy, attribution, or dependency license table | [NOTICE.md](./NOTICE.md); link from README as needed |
 | Internal-only refactors with no usage change | No README or FEATURES change; say so in the PR **Testing** section |
 


### PR DESCRIPTION
## Summary

### Proposed changes

This PR brings the following changes:

- Add **GitHub issues workflow** to `AGENTS.md` (triage → fix PR → TROUBLESHOOTING for bugs → post-merge comment with issue left open → release comment with version steps → close).
- Extend `CONTRIBUTING.md` with maintainer backlog steps and a TROUBLESHOOTING row in the user-facing docs table.
- Link reporters to `TROUBLESHOOTING.md` from the “Improving issues” section.

Concrete TROUBLESHOOTING content for #2 ships with https://github.com/itgalaxy/webfont/pull/696.

### Related issue

N/A (process documentation)

### Dependencies added/removed (if applicable)

N/A

---

### Testing

- [x] Documentation only; reviewed for consistency with existing AGENTS/CONTRIBUTING style.

#### How to test

Read `AGENTS.md` § “GitHub issues workflow” and `CONTRIBUTING.md` § “Maintainer backlog”.

#### Test configuration

N/A

---

## Checklist

- [ ] I have added corresponding labels to this PR (like bug, enhancement...);
- [x] My commits follow the [Conventional Commits 1.0 Guidelines](https://www.conventionalcommits.org/en/v1.0.0/);
- [x] My code follows the style guidelines of this project;
- [x] I have performed a self-review of my own code;
- [ ] I have mapped technical debts found on my changes;
- [x] I have made changes to the documentation (if applicable);
- [x] My changes generate no new warnings or errors;

Made with [Cursor](https://cursor.com)