### PR TITLE
ci: publish to npm via Trusted Publishing (OIDC)

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,6 +1,7 @@
 name: npm publish
 
-# Runs when a GitHub Release is published, or manually via workflow_dispatch (see CONTRIBUTING.md).
+# Publishes via npm Trusted Publishing (OIDC). Configure the trusted publisher on
+# npmjs.com for workflow filename npm-publish.yml (see CONTRIBUTING.md).
 on:
   release:
     types: [published]
@@ -12,6 +13,10 @@ on:
 
 env:
   RELEASE_TAG: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.event.release.tag_name }}
+
+permissions:
+  contents: read
+  id-token: write
 
 jobs:
   build:
@@ -30,8 +35,6 @@ jobs:
   publish-npm:
     needs: build
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
     steps:
       - uses: actions/checkout@v6
         with:
@@ -40,8 +43,6 @@ jobs:
         with:
           node-version: 24.x
           registry-url: https://registry.npmjs.org/
-          cache: npm
+          package-manager-cache: false
       - run: npm ci
       - run: npm publish --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -179,19 +179,28 @@ Do not run local `npm version` or push version tags manually unless coordinating
 
 #### npm publishing
 
-Configure this repository secret under **Settings → Secrets and variables → Actions**:
+Publishing from GitHub Actions uses **[npm Trusted Publishing](https://docs.npmjs.com/trusted-publishers)** (OIDC) — not long-lived publish tokens with bypass 2FA.
 
-- **`NPM_TOKEN`** — npm access token with publish permission for the `webfont` package (Automation or Granular Access Token).
+**One-time setup on npmjs.com** (package maintainer):
 
-After merging the Release PR, publish from the release tag (recommended):
+1. Open [webfont package settings](https://www.npmjs.com/package/webfont) → **Trusted publishing** → **GitHub Actions**.
+2. Set **Repository** to `itgalaxy/webfont`.
+3. Set **Workflow filename** to `npm-publish.yml` (filename only, including `.yml`).
+4. Save. Allow action **npm publish** if prompted.
+
+**Workflow:** [`.github/workflows/npm-publish.yml`](.github/workflows/npm-publish.yml) requests `id-token: write` and runs `npm publish` without `NPM_TOKEN`. Releases created by `github-actions[bot]` usually do not trigger downstream workflows — use **Actions → npm publish → Run workflow** with the release tag (e.g. `v12.0.1`) after merging a Release PR.
+
+**Manual publish** from a maintainer machine (browser/web auth or local npm login) is still supported:
 
 ```shell
 git fetch origin --tags
-git checkout v12.0.0   # use the tag created by Release Please
+git checkout v12.0.1   # tag from Release Please
 npm ci
 npm test
 npm publish --access public
 ```
+
+Do not create npm tokens with **bypass 2FA** for CI — npm flags that as insecure; use Trusted Publishing instead.
 
 Automated publishing does **not** retroactively upload versions that already exist as git tags only (for example `11.5.x` never published to npm).
 

--- a/docs/adr/0004-release-please-instead-of-standard-version.md
+++ b/docs/adr/0004-release-please-instead-of-standard-version.md
@@ -96,7 +96,7 @@ Do not rename release tags casually: npm publish, `npm-publish.yml`, and changel
 
 ### Follow-up
 
-- ~~If npm registry publish should run automatically, extend `npm-publish.yml` with `npm publish` and `NPM_TOKEN` (today it only runs `npm test` on `release: created`).~~ Done in PR [#639](https://github.com/itgalaxy/webfont/pull/639): publish on `release: published` with `NPM_TOKEN`.
+- ~~If npm registry publish should run automatically, extend `npm-publish.yml` with `npm publish` and `NPM_TOKEN` (today it only runs `npm test` on `release: created`).~~ Done in PR [#639](https://github.com/itgalaxy/webfont/pull/639): publish on `release: published`. CI uses [npm Trusted Publishing](https://docs.npmjs.com/trusted-publishers) (OIDC), not long-lived publish tokens — see `CONTRIBUTING.md`.
 
 ## References
 


### PR DESCRIPTION
## Summary

### Proposed changes

- Switch `npm-publish.yml` to **npm Trusted Publishing** (`permissions.id-token: write`, no `NPM_TOKEN` on publish).
- Disable package manager cache on the publish job (`package-manager-cache: false` per npm guidance).
- Update `CONTRIBUTING.md` and ADR 0004 with trusted publisher setup (avoid bypass-2FA tokens).

### Related issue

N/A

### Dependencies added/removed (if applicable)

N/A

---

### Testing

- [x] Workflow YAML only; `npm test` passes on branch.

#### How to test

**Before merge (maintainer, one-time on npmjs.com):**

1. [webfont → Settings → Trusted publishing](https://www.npmjs.com/package/webfont) → GitHub Actions.
2. Repository: `itgalaxy/webfont`, workflow filename: `npm-publish.yml`.
3. Merge this PR, then **Actions → npm publish → Run workflow** with `tag: v12.0.1`.

#### Test configuration

Node 24.x on `ubuntu-latest` (npm CLI ≥ 11.5.1).

---

## Checklist

- [x] My commits follow the Conventional Commits 1.0 Guidelines;
- [x] I have made changes to the documentation (if applicable);

Made with [Cursor](https://cursor.com)