### PR TITLE
docs: npm Trusted Publishing blocked on maintainer setup (#703)

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,7 +1,7 @@
 name: npm publish
 
 # Publishes via npm Trusted Publishing (OIDC). Configure the trusted publisher on
-# npmjs.com for workflow filename npm-publish.yml (see CONTRIBUTING.md).
+# npmjs.com for workflow filename npm-publish.yml (see CONTRIBUTING.md, issue #703).
 on:
   release:
     types: [published]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -179,6 +179,8 @@ Do not run local `npm version` or push version tags manually unless coordinating
 
 #### npm publishing
 
+> **Blocked on maintainer:** npm package settings access is required to enable Trusted Publishing. Track progress in [#703](https://github.com/itgalaxy/webfont/issues/703).
+
 Publishing from GitHub Actions uses **[npm Trusted Publishing](https://docs.npmjs.com/trusted-publishers)** (OIDC) — not long-lived publish tokens with bypass 2FA.
 
 **One-time setup on npmjs.com** (package maintainer):


### PR DESCRIPTION
## Summary

### Proposed changes

Draft PR — **do not merge** until [#703](https://github.com/itgalaxy/webfont/issues/703) is resolved by a package maintainer.

- Link CONTRIBUTING and `npm-publish.yml` to #703 (Trusted Publishing setup on npmjs.com).
- Workflow OIDC changes already landed via #702; this PR only documents the blocker.

### Related issue

#703

### Dependencies added/removed (if applicable)

N/A

---

### Testing

- [x] Documentation only.

#### How to test

Review CONTRIBUTING § npm publishing callout and issue #703 steps.

#### Test configuration

N/A

---

## Checklist

- [x] My commits follow the Conventional Commits 1.0 Guidelines;
- [x] I have made changes to the documentation (if applicable);

**Maintainer:** assign #703 to someone with npm `webfont` package admin access, complete Trusted Publishing setup, run `npm publish` workflow for `v12.0.1`, then merge this PR and close #703.

Made with [Cursor](https://cursor.com)