### PR TITLE
feat: encode TTF input to WOFF and WOFF2 (#13)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -131,7 +131,7 @@ When a task changes **how users interact with webfont** (CLI flags, programmatic
 3. **Update [FEATURES.md](./FEATURES.md)** when capabilities, stability, properties, or test criteria change. Mark features `stable`, `in-progress`, or `planned`; tick test criteria when coverage exists.
 4. **Update [NOTICE.md](./NOTICE.md)** when legal notices, font licensing guidance, attribution rules, or runtime dependency licenses change.
 5. **Update [TROUBLESHOOTING.md](./TROUBLESHOOTING.md)** for operational errors (symptoms and fixes on the **current** release, not version-to-version deltas).
-6. **Update [MIGRATION.md](./MIGRATION.md)** when a fix or change alters behavior across releases: document *before* / *after*, workarounds on older versions, and steps after upgrading. Link the GitHub issue; set the **minimum fixed version** when the release ships.
+6. **Update [MIGRATION.md](./MIGRATION.md)** when a fix or change alters behavior across releases. Each entry must follow the [entry structure](./MIGRATION.md#entry-structure): *What changed* → *Before* → *After* → **Workaround on older versions** (required when users on older npm releases have a practical alternative — config/API instead of CLI, external tools, etc.; use `None` + reason only when no workaround exists) → *After upgrading*. Link the GitHub issue; set the **minimum fixed version** when the release ships.
 7. **Do not rely on CHANGELOG alone** for unreleased work; Release Please updates `CHANGELOG.md` at release time.
 
 See also [CONTRIBUTING.md](./CONTRIBUTING.md) — “User-facing changes and documentation”.
@@ -174,7 +174,7 @@ Process open issues **oldest to newest** (`gh issue list --state open`, sort by 
 1. Comment on the issue **in English**: investigation is in progress; link the PR when it exists.
 2. **Tests first:** check coverage for the affected area. Add or extend tests that name the failure **before** changing production code when coverage is missing.
 3. Implement the fix; run `npm test`.
-4. **Bugs and behavior changes across releases:** add or update [MIGRATION.md](./MIGRATION.md) (*Before* → *After* → *Workaround on older versions* → *After upgrading*). Link the GitHub issue. Use [TROUBLESHOOTING.md](./TROUBLESHOOTING.md) only when the entry is not version-specific (same behavior on all supported releases).
+4. **Bugs and behavior changes across releases:** add or update [MIGRATION.md](./MIGRATION.md) using the [entry structure](./MIGRATION.md#entry-structure) (*Before* → *After* → **Workaround on older versions** → *After upgrading*). Include a workaround whenever users on the current npm release can avoid the bug or gap without upgrading (e.g. numeric `round` in config instead of `--round` on CLI). Link the GitHub issue. Use [TROUBLESHOOTING.md](./TROUBLESHOOTING.md) only when the entry is not version-specific (same behavior on all supported releases).
 5. Open a PR (English title/body, Conventional Commits). Link the issue in **Related issue**; do **not** use `Closes #n` if the issue should stay open until npm publish.
 6. Wait for CI; wait for maintainer merge.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,7 +23,7 @@ Some [issues lack information](https://github.com/itgalaxy/webfont/issues?q=is%3
 When working through the issue tracker (see also [AGENTS.md](./AGENTS.md) — “GitHub issues workflow”):
 
 1. Triage: assignee, milestone `next`, type label (`bug`, `enhancement`, etc.).
-2. Fix PR: tests where needed, code change, and for **issue fixes that change behavior across releases** an entry in [MIGRATION.md](./MIGRATION.md) (before → after → workaround → steps after upgrade).
+2. Fix PR: tests where needed, code change, and for **issue fixes that change behavior across releases** an entry in [MIGRATION.md](./MIGRATION.md) following the [entry structure](./MIGRATION.md#entry-structure) (before → after → **workaround on older versions** when applicable → steps after upgrade).
 3. After merge: comment on the issue in English that the fix is on `master` and planned for the next release; **leave the issue open** until npm publish.
 4. On release: comment with the **version number** and the exact steps from MIGRATION.md, then **close** the issue.
 
@@ -65,7 +65,7 @@ When it does, update documentation in the same PR:
 | CLI flags, aliases, or accepted flag values | [README.md](./README.md) CLI section, `src/cli/meow/cliOptions.ts` help text, and [FEATURES.md](./FEATURES.md) when capability changes |
 | `webfont()` options, defaults, return shape, or supported inputs/outputs | [README.md](./README.md) Options / Result / Input modes, [FEATURES.md](./FEATURES.md) |
 | New or removed public options or pipelines | README + [FEATURES.md](./FEATURES.md) + TypeScript types under `src/types/` |
-| Bug fixes or recurring user-facing errors (especially from issues) | [MIGRATION.md](./MIGRATION.md) when behavior changes across versions; [TROUBLESHOOTING.md](./TROUBLESHOOTING.md) when the fix applies the same on all releases |
+| Bug fixes or recurring user-facing errors (especially from issues) | [MIGRATION.md](./MIGRATION.md) ([entry structure](./MIGRATION.md#entry-structure), including **Workaround on older versions** when users can mitigate without upgrading); [TROUBLESHOOTING.md](./TROUBLESHOOTING.md) when the fix applies the same on all releases |
 | Legal notices, font licensing copy, attribution, or dependency license table | [NOTICE.md](./NOTICE.md); link from README as needed |
 | Internal-only refactors with no usage change | No README or FEATURES change; say so in the PR **Testing** section |
 

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -32,6 +32,27 @@ Canonical list of product capabilities. **Update this file in the same PR** when
   - [x] SVG input with `formats: ['otf']` rejects
   - [x] Built-in CSS template works with default SVG formats
 
+### TTF to webfont encoding
+
+- **Stability**: in-progress
+- **Description**: Encode one or more `.ttf` TrueType files to `eot`, `woff`, and/or `woff2` (and optional TTF pass-through). Auto-detected from input extension — no separate flag (see [#13](https://github.com/itgalaxy/webfont/issues/13)).
+- **Properties**:
+  - Input: one or more local `.ttf` paths or globs per run.
+  - Output: `ttf` (copy), `eot`, `woff`, and/or `woff2` per input via existing encoders (`ttf2eot`, `ttf2woff`, `wawoff2`).
+  - Batch results on `result.transcodedFonts` (`{ source, ttf?, eot?, woff?, woff2? }[]`). Single input mirrors buffers on `result` top level.
+  - Default `formats` when SVG-pipeline defaults are still configured: `['woff', 'woff2']`.
+  - Does **not** accept `.otf` input (TrueType only). Does **not** merge multiple weights into one file.
+  - `template` and `glyphTransformFn` are not supported in this mode.
+  - **Licensing:** encoding does not grant rights to the font; users must comply with the font’s license. See [NOTICE.md](./NOTICE.md) §3.3.
+  - **Architecture:** see [ADR 0009](docs/adr/0009-ttf-webfont-encoding-pipeline.md).
+- **Test Criteria**:
+  - [x] `.ttf` input with `formats: ['woff', 'woff2']` yields valid WOFF and WOFF2
+  - [x] Default formats produce `woff` + `woff2` when SVG defaults are configured
+  - [x] Multiple TTF files encode in one run (`transcodedFonts`)
+  - [x] Mixed `.svg` + `.ttf` or `.ttf` + `.woff2` inputs reject
+  - [x] Template option in TTF mode rejects
+  - [x] CLI writes encoded outputs for a single TTF input
+
 ### WOFF / WOFF2 container decompression
 
 - **Stability**: in-progress
@@ -47,7 +68,7 @@ Canonical list of product capabilities. **Update this file in the same PR** when
   - Does **not** re-encode to `eot`, `woff`, or `woff2` in this mode.
   - Default `formats` when SVG-pipeline defaults are still configured: `['ttf']`.
   - `template` and `glyphTransformFn` are not supported in this mode.
-  - **Licensing:** decompression does not grant rights to the font; users must comply with the font’s license for input and extracted output. Copyright/metadata in the SFNT is preserved. See [NOTICE.md](./NOTICE.md) §3.2.
+  - **Licensing:** decompression does not grant rights to the font; users must comply with the font’s license for input and extracted output. Copyright/metadata in the SFNT is preserved. See [NOTICE.md](./NOTICE.md) §3.4.
   - **Architecture:** see [ADR 0007](docs/adr/0007-woff-woff2-decompression-pipeline.md).
 - **Test Criteria**:
   - [x] `.woff2` input with `formats: ['ttf']` yields a valid TTF when the container holds TrueType
@@ -63,13 +84,13 @@ Canonical list of product capabilities. **Update this file in the same PR** when
 - **Stability**: in-progress
 - **Description**: Classify matched paths into SVG mode, webfont mode, mixed, or unsupported before running a pipeline.
 - **Properties**:
-  - Supported extensions: `.svg`, `.woff`, `.woff2` only.
+  - Supported extensions: `.svg`, `.ttf`, `.woff`, `.woff2` only.
   - Extension-less paths (e.g. `LICENSE`, `.webfontrc`) are **not** treated as compatible wildcards; globs that match them alongside fonts fail as unsupported.
   - Unsupported extensions (e.g. `.txt`, `.json`) cause the run to fail with “did not match any supported files”.
 - **Test Criteria**:
   - [x] Extension-less file + `.woff2` classifies as unsupported (error)
   - [x] `.txt`-only input classifies as unsupported (error)
-  - [x] Pure `.svg` / pure `.woff`/`.woff2` classify correctly
+  - [x] Pure `.svg` / pure `.ttf` / pure `.woff`/`.woff2` classify correctly
 
 ### Configuration file discovery
 
@@ -131,10 +152,12 @@ Canonical list of product capabilities. **Update this file in the same PR** when
 ### Arbitrary format transcoding
 
 - **Stability**: planned
-- **Description**: Convert between outline/container formats beyond the current two pipelines (e.g. TTF ↔ OTF transcoding, “any format to any format”).
+- **Description**: Convert between outline/container formats beyond the current three pipelines (e.g. TTF ↔ OTF transcoding, OTF input encoding).
 - **Properties**:
-  - **Out of scope today.** WOFF/WOFF2 mode only decompresses; SVG mode only builds TrueType-based outputs.
+  - **Partially supported:** TTF → `eot` / `woff` / `woff2` (see TTF to webfont encoding). WOFF/WOFF2 → TTF/OTF decompression.
+  - **Out of scope today:** OTF input encoding, TTF ↔ OTF outline conversion.
   - External tools (FontForge, fontTools, etc.) are required for TTF → OTF today.
 - **Test Criteria**:
+  - [x] TTF input encoded to WOFF/WOFF2
   - [ ] TTF input transcoded to OTF
   - [ ] Documented public API for generic transcoding

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -6,6 +6,49 @@ See also [CHANGELOG.md](./CHANGELOG.md) for the full release history.
 
 ---
 
+## Next release — TTF to WOFF/WOFF2 encoding ([#13](https://github.com/itgalaxy/webfont/issues/13))
+
+**Minimum version:** *pending*
+
+### What changed
+
+webfont auto-detects **`.ttf` input** (no new flag). One or more TrueType files can be encoded to `eot`, `woff`, and/or `woff2`. Default output when SVG-pipeline `formats` are still configured: `woff` + `woff2`.
+
+### Before
+
+TTF files were rejected (`did not match any supported files`). Users relied on external tools or manual `ttf2woff` / `wawoff2` scripts.
+
+### After
+
+```shell
+webfont path/to/font.ttf -d dist/fonts -f woff,woff2
+```
+
+Programmatic:
+
+```js
+const result = await webfont({
+  files: "fonts/MyFont.ttf",
+  formats: ["woff", "woff2"],
+});
+// result.woff, result.woff2
+```
+
+Batch runs expose `result.transcodedFonts` (`{ source, ttf?, eot?, woff?, woff2? }[]`).
+
+### Workaround on older versions
+
+Use `ttf2woff`, `wawoff2`, or FontForge outside webfont, or decompress from an existing WOFF/WOFF2 container if you only need the SFNT inside.
+
+### After upgrading
+
+```shell
+npm install webfont@<version>
+webfont "fonts/*.ttf" -d dist/webfonts -f woff,woff2 --dest-create
+```
+
+---
+
 ## Next release — CLI `--round` numeric strings ([#569](https://github.com/itgalaxy/webfont/issues/569))
 
 **Minimum version:** *pending*

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,8 +1,31 @@
 # Migration guide
 
-What changed between webfont releases and how to update your setup. Each entry covers **before** / **after**, a **workaround on older versions**, and **steps after upgrading**.
+What changed between webfont releases and how to update your setup.
 
 See also [CHANGELOG.md](./CHANGELOG.md) for the full release history.
+
+## Entry structure
+
+Every migration entry **must** use these headings in order (omit only when a section truly does not apply — see below):
+
+| Section | Required? | Content |
+|---------|-----------|---------|
+| **Minimum version** | Yes | Semver when shipped; *pending* before release |
+| **What changed** | Yes | One short summary |
+| **Before** | Yes | Behavior on older releases |
+| **After** | Yes | Behavior on the fixed release |
+| **Workaround on older versions** | **Yes when applicable** | Concrete steps users on an older npm version can take **without upgrading** (config shape, CLI flags, external tools, pinned version). **Do not skip** for bug fixes — if the bug is CLI-only, document a config/API path that still works. |
+| **After upgrading** | Yes | `npm install webfont@…` and the new recommended command or config |
+
+When no practical workaround exists (rare), keep the heading and write **None** with one sentence explaining why (for example the old release cannot perform the operation at all).
+
+**Example workaround patterns**
+
+- Bug on CLI flag → use cosmiconfig with a **typed** value (number in JSON/JS config instead of a string from argv).
+- Missing feature → external tool or script until upgrade.
+- Config vs CLI conflict → pass input only on the command line on older releases.
+
+Link the GitHub issue in the entry title. On release: set **Minimum version**, move the entry under that release heading, and trim workarounds that only applied to pre-release builds.
 
 ---
 
@@ -38,7 +61,14 @@ Batch runs expose `result.transcodedFonts` (`{ source, ttf?, eot?, woff?, woff2?
 
 ### Workaround on older versions
 
-Use `ttf2woff`, `wawoff2`, or FontForge outside webfont, or decompress from an existing WOFF/WOFF2 container if you only need the SFNT inside.
+Use external encoders until upgrade:
+
+```shell
+# Example with npx (adjust paths)
+npx ttf2woff path/to/font.ttf > path/to/font.woff
+```
+
+Or decompress an existing `.woff2` if you only need the SFNT inside (see WOFF/WOFF2 decompression in README).
 
 ### After upgrading
 
@@ -68,6 +98,31 @@ Error: assertNumbers arguments[0] is not a number. string == typeof 4
 ### After (fix)
 
 Same CLI and config shapes work; coercion happens at the SVG pipeline boundary only.
+
+### Workaround on older versions
+
+On releases before the fix, **avoid passing `--round` from the CLI** (meow supplies a string). Use one of:
+
+**Programmatic API** — pass a number:
+
+```js
+await webfont({ files: "icons/*.svg", round: 4 });
+```
+
+**Config file** — set `round` as a JSON number (not a string):
+
+```json
+{
+  "files": "icons/**/*.svg",
+  "round": 4
+}
+```
+
+```shell
+webfont --config webfont.config.json -d dist/icons
+```
+
+Or omit `round` if the default meets your needs.
 
 ### After upgrading
 
@@ -109,15 +164,15 @@ await webfont({ files: "icons/*.svg", round: "4" });
   Error: Cannot specify input files on the command line when `files` is set in the config file
   ```
 
-### Workaround on 12.0.0
+### Workaround on older versions
 
-Pass globs on the command line; omit `files` from the config:
+On **12.0.0 and earlier**, pass globs on the command line; omit `files` from the config:
 
 ```shell
 webfont "src/icons/a.svg" "src/icons/b.svg" --config webfont.config.json -d dist/icons
 ```
 
-### After upgrading to 12.0.1
+### After upgrading
 
 ```shell
 npm install webfont@12.0.1

--- a/NOTICE.md
+++ b/NOTICE.md
@@ -43,7 +43,18 @@ If you build a font from **`.svg` icons**, you must have the right to use those 
 
 Generated font files may be subject to the same restrictions as the source icons and to any third-party notices you embed via options such as `metadata` / `copyright`.
 
-### 3.2 WOFF / WOFF2 decompression
+### 3.3 TTF to webfont encoding
+
+If you **encode** one or more `.ttf` files to `eot`, `woff`, or `woff2`, you are re-wrapping font data you already hold. That operation:
+
+- does **not** make a restricted or commercial font free to use or share;
+- does **not** bypass foundry EULAs or redistribution terms;
+- preserves copyright/metadata embedded in the source TTF;
+- does **not** merge multiple weights into one file — each input yields separate outputs.
+
+**Only process fonts you are authorized to convert and redistribute** under their license.
+
+### 3.4 WOFF / WOFF2 decompression
 
 If you **decompress** one or more `.woff` or `.woff2` files (from disk or from an `http(s)` URL) to `.ttf` or `.otf`, you are extracting the **SFNT payload** inside each container. That operation:
 
@@ -54,7 +65,7 @@ If you **decompress** one or more `.woff` or `.woff2` files (from disk or from a
 
 **Only process fonts you are authorized to use and download** under their license. For remote URLs, you must also have permission to fetch and store those bytes.
 
-### 3.3 Redistribution of output
+### 3.5 Redistribution of output
 
 Publishing, shipping, or sublicensing fonts produced or extracted with webfont (in apps, websites, PDFs, design assets, npm packages, etc.) is **your responsibility**. The MIT license on webfont does **not** apply to those font files.
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![NPM version](https://img.shields.io/npm/v/webfont.svg)](https://www.npmjs.org/package/webfont)
 [![Node.js CI](https://github.com/itgalaxy/webfont/actions/workflows/pr.yml/badge.svg)](https://github.com/itgalaxy/webfont/actions/workflows/pr.yml)
 
-Generator of fonts from SVG icons, with a separate mode to **decompress** WOFF/WOFF2 containers to the TTF or OTF inside.
+Generator of fonts from SVG icons, with separate modes to **encode** TTF to web formats and **decompress** WOFF/WOFF2 containers to the TTF or OTF inside.
 
 See **[FEATURES.md](./FEATURES.md)** for the canonical capability list (what is stable, in progress, or planned).
 
@@ -16,6 +16,7 @@ See **[FEATURES.md](./FEATURES.md)** for the canonical capability list (what is 
 ## Features
 
 - **SVG icon pipeline** (default): `.svg` icons → `svg`, `ttf`, `eot`, `woff`, `woff2` (not `otf`);
+- **TTF encoding**: one or more `.ttf` files → `ttf` (pass-through), `eot`, `woff`, and/or `woff2` (auto-detected — no extra flag);
 - **Webfont decompression**: one `.woff` or `.woff2` file → `ttf` and/or `otf` matching the **embedded SFNT flavor** (decompress only — not TTF ↔ OTF transcoding);
 - Config files: `JavaScript`, `JSON`, or `YAML` via [cosmiconfig](https://github.com/cosmiconfig/cosmiconfig);
 - Built-in and custom CSS templates (`css`, `scss`, [`styl`](https://github.com/itgalaxy/webfont/pull/164/));
@@ -24,21 +25,23 @@ See **[FEATURES.md](./FEATURES.md)** for the canonical capability list (what is 
 
 ## Input modes
 
-webfont runs one of two pipelines depending on matched input files. They cannot be mixed in a single run.
+webfont runs one of three pipelines depending on matched input files. They cannot be mixed in a single run.
 
 | Mode | Input | Outputs | Notes |
 |------|--------|---------|--------|
 | **SVG icons** | One or more `.svg` files | `svg`, `ttf`, `eot`, `woff`, `woff2` | Default. Builds TrueType via `svg2ttf`. **`otf` is rejected** — use `ttf`. |
+| **TTF encoding** | One or more `.ttf` files | `ttf`, `eot`, `woff`, and/or `woff2` per input | Auto-detected. Default when SVG-pipeline `formats` are still configured: `woff` + `woff2`. No templates. |
 | **Webfont decompress** | One or more `.woff` / `.woff2` paths, globs, or `http(s)` URLs | `ttf` and/or `otf` per input | One output file per source (basename from filename; collisions get `-woff`/`-woff2`). Not a single merged font. |
 
 **Not supported today**
 
 - Renaming or re-wrapping without matching the real outline format (e.g. requesting `otf` when the WOFF2 holds TrueType).
 - Converting TTF to OTF (or OTF to TTF) — use [FontForge](https://fontforge.org/) or similar.
-- Templates, `glyphTransformFn`, or merged multi-weight SFNT output in webfont decompress mode.
+- `.otf` as input for webfont encoding (TrueType `.ttf` only today).
+- Templates, `glyphTransformFn`, or merged multi-weight SFNT output in TTF encoding or webfont decompress mode.
 - Globs that match extension-less or unsupported files together with fonts (the run fails instead of silently ignoring extras).
 
-Every matched path must end in `.svg`, `.woff`, or `.woff2`. See [FEATURES.md](./FEATURES.md) for test-backed criteria.
+Every matched path must end in `.svg`, `.ttf`, `.woff`, or `.woff2`. See [FEATURES.md](./FEATURES.md) for test-backed criteria.
 
 ### Font licensing
 
@@ -116,6 +119,30 @@ webfont({
   });
 ```
 
+### TTF encoding examples
+
+```js
+import webfont from "webfont";
+
+// Single local TTF → WOFF + WOFF2 (default when formats unset)
+const encoded = await webfont({
+  files: "path/to/font.ttf",
+});
+
+// Explicit formats
+const subset = await webfont({
+  files: "path/to/font.ttf",
+  formats: ["woff2"],
+});
+
+// Batch: multiple TTF files in one run
+const batch = await webfont({
+  files: ["fonts/Inter-Regular.ttf", "fonts/Inter-Bold.ttf"],
+  formats: ["woff", "woff2"],
+});
+// batch.transcodedFonts → [{ source, woff, woff2 }, …]
+```
+
 ### Webfont decompress examples
 
 ```js
@@ -148,9 +175,10 @@ const remote = await webfont({
 - Type: `string` | `array`
 - Description: A file glob, or array of file globs. Ultimately passed to [fast-glob](https://github.com/mrmlnc/fast-glob) to figure out what files you want to get.
 - **SVG mode**: one or more `.svg` icon paths or globs (default pipeline).
+- **TTF encoding mode**: one or more `.ttf` paths or globs.
 - **Webfont decompress mode**: one or more `.woff` / `.woff2` paths, globs, or `https://…` URLs (see [`formats`](#formats) and [Input modes](#input-modes)).
-- Do not mix `.svg` with `.woff` / `.woff2` in the same run.
-- Every matched file must have a supported extension (`.svg`, `.woff`, `.woff2`); extension-less files such as `LICENSE` are not ignored when matched by a broad glob.
+- Do not mix `.svg`, `.ttf`, and `.woff` / `.woff2` in the same run.
+- Every matched file must have a supported extension (`.svg`, `.ttf`, `.woff`, `.woff2`); extension-less files such as `LICENSE` are not ignored when matched by a broad glob.
 - `node_modules` and `bower_components` are always ignored.
 
 #### `configFile`
@@ -173,10 +201,11 @@ const remote = await webfont({
 #### `formats`
 
 - Type: `array`
-- Default: `['svg', 'ttf', 'eot', 'woff', 'woff2']` (SVG input). For WOFF/WOFF2 input, defaults to `['ttf']` when SVG-pipeline formats are still configured.
+- Default: `['svg', 'ttf', 'eot', 'woff', 'woff2']` (SVG input). For TTF input, defaults to `['woff', 'woff2']` when SVG-pipeline formats are still configured. For WOFF/WOFF2 input, defaults to `['ttf']` when SVG-pipeline formats are still configured.
 - Possible values: `svg`, `ttf`, `otf`, `eot`, `woff`, `woff2`
 - Description: Font file types to generate.
   - **SVG input**: `svg`, `ttf`, `eot`, `woff`, `woff2` only. **`otf` is not supported** (pipeline uses TrueType outlines).
+  - **TTF input**: `ttf`, `eot`, `woff`, and/or `woff2` only. **`svg` and `otf` are not produced** in this mode.
   - **WOFF/WOFF2 input**: `ttf` and/or `otf` only — must match the decompressed SFNT flavor inside the file (not arbitrary transcoding). `eot`, `woff`, `woff2`, and `svg` are not produced in this mode.
 - CLI: pass `-f` / `--formats` as a JSON array (for example `'["woff2"]'`) or as a comma-separated list (for example `woff2` or `svg, ttf, woff2`). Invalid format names throw an error.
 

--- a/docs/adr/0009-ttf-webfont-encoding-pipeline.md
+++ b/docs/adr/0009-ttf-webfont-encoding-pipeline.md
@@ -1,0 +1,63 @@
+# ADR 0009: TTF to webfont encoding pipeline
+
+- **Status:** Accepted
+- **Date:** 2026-07-02
+- **Related:** [FEATURES.md](../../FEATURES.md) (TTF to webfont encoding), [NOTICE.md](../../NOTICE.md) §3.3, Issue [#13](https://github.com/itgalaxy/webfont/issues/13)
+
+## Context
+
+Users need to convert existing **TrueType (`.ttf`)** fonts to web formats (`woff`, `woff2`, legacy `eot`) without rebuilding from SVG icons. webfont already ships `ttf2woff`, `wawoff2`, and `ttf2eot` for the SVG pipeline; issue [#13](https://github.com/itgalaxy/webfont/issues/13) requested exposing that path for TTF input.
+
+An abandoned PR ([#185](https://github.com/itgalaxy/webfont/pull/185)) used a `ttfMode` boolean. Maintainers and reporters preferred **auto-detection** from file extension (same pattern as WOFF/WOFF2 decompression in [ADR 0007](./0007-woff-woff2-decompression-pipeline.md)).
+
+## Decision drivers
+
+- **No new public flag:** Extend `classifyInputFiles()` with a `ttf` mode when all matched paths end in `.ttf`.
+- **Reuse encoders:** Share `encodeTtfToEot` / `encodeTtfToWoff` / `encodeTtfToWoff2` (`src/lib/ttfEncode.ts`) with the SVG pipeline.
+- **Batch API:** `result.transcodedFonts` mirrors `decompressedFonts` for multi-file runs; single input keeps top-level `result.woff` / `result.woff2` for backward compatibility with CLI naming.
+- **Clear limits:** TrueType input only (`is-ttf` + SFNT flavor guard). No templates or `glyphTransformFn`. No merge of multiple weights.
+
+## Decision
+
+**Add a dedicated TTF encoding pipeline** alongside SVG and WOFF/WOFF2 decompression.
+
+### Input classification
+
+`classifyInputFiles()` routes:
+
+- **SVG mode** — `.svg` only.
+- **TTF mode** — `.ttf` only.
+- **Webfont mode** — `.woff` / `.woff2` (and URLs).
+- **Mixed** — any combination of the above → reject.
+
+### Encoding flow
+
+1. Read TTF bytes from disk (`fs/promises`).
+2. Validate with `is-ttf` and `getSfntFlavor()` (reject OTF/CFF masquerading as `.ttf`).
+3. For each requested format in `resolveTtfConversionFormats()`:
+   - `ttf` — pass-through buffer;
+   - `eot` / `woff` / `woff2` — existing encoders.
+4. Default output when SVG-pipeline `formats` are unchanged: `['woff', 'woff2']`.
+
+### CLI batch naming
+
+Reuse `resolveDecompressedFontBasenames()` (strip extension; suffix on basename collisions). `writeTranscodedFontFiles()` writes per-format files under `--dest`.
+
+## Consequences
+
+### Positive
+
+- Fulfills long-standing [#13](https://github.com/itgalaxy/webfont/issues/13) without a breaking API flag.
+- Round-trip compatible with WOFF/WOFF2 decompression (encode → decompress → valid TTF).
+
+### Negative / trade-offs
+
+- **No OTF input** — PostScript/CFF fonts must be converted externally first.
+- **No remote TTF URLs** in v1 (local paths/globs only).
+- **No CSS templates** in TTF mode (fonts already exist; `@font-face` is user-owned).
+
+## References
+
+- Issue [#13](https://github.com/itgalaxy/webfont/issues/13)
+- PR [#185](https://github.com/itgalaxy/webfont/pull/185) (historical `ttfMode` approach)
+- [ADR 0007](./0007-woff-woff2-decompression-pipeline.md)

--- a/src/cli/index.test.ts
+++ b/src/cli/index.test.ts
@@ -558,4 +558,21 @@ describe("cli", () => {
     expect(output.stderr).toBe("");
     expect(output.files).toEqual(expect.arrayContaining(["iconfont-woff.ttf", "iconfont-woff2.ttf"]));
   });
+
+  it("should encode ttf input to woff and woff2 via the CLI", async () => {
+    const conversionDest = "temp/cli-ttf-encode";
+    const output = await execCLI(
+      `src/fixtures/fonts/iconfont.ttf -d ${conversionDest} -f woff,woff2 -u iconfont --dest-create`,
+      conversionDest,
+    );
+
+    expect(output.code).toBe(0);
+    expect(output.stderr).toBe("");
+    expect(output.files).toEqual(expect.arrayContaining(["iconfont.woff", "iconfont.woff2"]));
+
+    const woff = await fsPromise.readFile(`${conversionDest}/iconfont.woff`);
+    const woff2 = await fsPromise.readFile(`${conversionDest}/iconfont.woff2`);
+    expect(woff.length).toBeGreaterThan(0);
+    expect(woff2.length).toBeGreaterThan(0);
+  });
 });

--- a/src/cli/program.ts
+++ b/src/cli/program.ts
@@ -8,6 +8,7 @@ import type { InitialOptions } from "../types/InitialOptions";
 import type { OptionsBase } from "../types/OptionsBase";
 import type { Result } from "../types/Result";
 import type { ResultConfig } from "../types/ResultConfig";
+import type { TranscodedFont } from "../types/TranscodedFont";
 import { parseFormatsFlag } from "./parseFormatsFlag";
 import { resolveCliFiles } from "./resolveCliFiles";
 
@@ -257,8 +258,8 @@ export const ensureDestExists = async (dest: string, destCreate?: boolean): Prom
 };
 
 export const getDecompressedFontOutputBasename = (
-  fonts: readonly DecompressedFont[],
-  font: DecompressedFont,
+  fonts: readonly { source: string }[],
+  font: { source: string },
   config: ResultConfig,
 ): string => {
   if (fonts.length === 1 && config.fontName) {
@@ -294,6 +295,43 @@ export const writeDecompressedFontFiles = async (
   );
 };
 
+export const getTranscodedFontOutputBasename = (
+  fonts: readonly TranscodedFont[],
+  font: TranscodedFont,
+  config: ResultConfig,
+): string => getDecompressedFontOutputBasename(fonts, font, config);
+
+export const writeTranscodedFontFiles = async (
+  fonts: readonly TranscodedFont[],
+  config: ResultConfig,
+  dest: string,
+): Promise<void> => {
+  await Promise.all(
+    fonts.flatMap((font) => {
+      const basename = getTranscodedFontOutputBasename(fonts, font, config);
+      const writes: Promise<void>[] = [];
+
+      if (font.ttf) {
+        writes.push(fs.promises.writeFile(path.resolve(path.join(dest, `${basename}.ttf`)), font.ttf));
+      }
+
+      if (font.eot) {
+        writes.push(fs.promises.writeFile(path.resolve(path.join(dest, `${basename}.eot`)), font.eot));
+      }
+
+      if (font.woff) {
+        writes.push(fs.promises.writeFile(path.resolve(path.join(dest, `${basename}.woff`)), font.woff));
+      }
+
+      if (font.woff2) {
+        writes.push(fs.promises.writeFile(path.resolve(path.join(dest, `${basename}.woff2`)), font.woff2));
+      }
+
+      return writes;
+    }),
+  );
+};
+
 export const writeResultFiles = async (result: Result): Promise<Result> => {
   const config = ensureResultConfig(result);
   const dest = config.dest ?? process.cwd();
@@ -304,6 +342,11 @@ export const writeResultFiles = async (result: Result): Promise<Result> => {
   }
 
   await ensureDestExists(dest, config.destCreate);
+
+  if (result.transcodedFonts && result.transcodedFonts.length > 1) {
+    await writeTranscodedFontFiles(result.transcodedFonts, config, dest);
+    return result;
+  }
 
   if (result.decompressedFonts && result.decompressedFonts.length > 1) {
     await writeDecompressedFontFiles(result.decompressedFonts, config, dest);

--- a/src/lib/ttfEncode.ts
+++ b/src/lib/ttfEncode.ts
@@ -1,0 +1,11 @@
+import ttf2woff from "ttf2woff";
+import wawoff2 from "wawoff2";
+import convertTtfToEot from "./ttf2eot";
+
+export const encodeTtfToEot = (buffer: Buffer): Buffer => convertTtfToEot(buffer);
+
+export const encodeTtfToWoff = (buffer: Buffer, options: { metadata?: string } = {}): Buffer =>
+  Buffer.from(ttf2woff(buffer, options).buffer);
+
+export const encodeTtfToWoff2 = async (buffer: Buffer): Promise<Buffer> =>
+  Buffer.from(await wawoff2.compress(buffer));

--- a/src/standalone/convertTtfInput.test.ts
+++ b/src/standalone/convertTtfInput.test.ts
@@ -1,0 +1,102 @@
+import * as fsPromise from "fs/promises";
+import isTtf from "is-ttf";
+import isWoff2 from "is-woff2";
+import { vi } from "vitest";
+import { encodeTtfToWoff2 } from "../lib/ttfEncode";
+import type { WebfontOptions } from "../types/WebfontOptions";
+import { convertTtfInput } from "./convertTtfInput";
+
+const fixtureTtf = "src/fixtures/fonts/iconfont.ttf";
+
+describe("convertTtfInput", () => {
+  it("should reject template option", async () => {
+    await expect(
+      convertTtfInput([fixtureTtf], {
+        files: fixtureTtf,
+        formats: ["woff2"],
+        template: "css",
+      } as WebfontOptions),
+    ).rejects.toThrow("Templates are not supported when converting TTF input");
+  });
+
+  it("should reject glyphTransformFn option", async () => {
+    await expect(
+      convertTtfInput([fixtureTtf], {
+        files: fixtureTtf,
+        formats: ["woff2"],
+        glyphTransformFn: async () => ({ name: "x", unicode: [] }),
+      }),
+    ).rejects.toThrow("glyphTransformFn is not supported when converting TTF input");
+  });
+
+  it("should reject empty font file list", async () => {
+    await expect(
+      convertTtfInput([], {
+        files: fixtureTtf,
+        formats: ["woff2"],
+      }),
+    ).rejects.toThrow("No TTF files matched");
+  });
+
+  it("should reject invalid ttf bytes", async () => {
+    const invalidPath = "temp/invalid.ttf";
+
+    await fsPromise.mkdir("temp", { recursive: true });
+    await fsPromise.writeFile(invalidPath, "not a font");
+
+    try {
+      await expect(
+        convertTtfInput([invalidPath], {
+          files: invalidPath,
+          formats: ["woff2"],
+        }),
+      ).rejects.toThrow(`Input is not a valid TrueType font: ${invalidPath}`);
+    } finally {
+      await fsPromise.rm(invalidPath, { force: true });
+    }
+  });
+
+  it("should log verbose progress when encoding", async () => {
+    const logSpy = vi.spyOn(console, "log").mockImplementation(vi.fn());
+
+    try {
+      await convertTtfInput([fixtureTtf], {
+        files: fixtureTtf,
+        formats: ["woff2"],
+        verbose: true,
+      });
+
+      expect(logSpy).toHaveBeenCalledWith(`Encoding ${fixtureTtf}...`);
+    } finally {
+      logSpy.mockRestore();
+    }
+  });
+
+  it("should mirror single-input outputs on result top level", async () => {
+    const result = await convertTtfInput([fixtureTtf], {
+      files: fixtureTtf,
+      formats: ["ttf", "woff2"],
+    });
+
+    expect(isTtf(result.ttf)).toBe(true);
+    expect(isWoff2(result.woff2)).toBe(true);
+    expect(result.transcodedFonts).toHaveLength(1);
+  });
+
+  it("should not mirror top-level outputs for batch runs", async () => {
+    const result = await convertTtfInput([fixtureTtf, fixtureTtf], {
+      files: [fixtureTtf, fixtureTtf],
+      formats: ["woff2"],
+    });
+
+    expect(result.woff2).toBeUndefined();
+    expect(result.transcodedFonts).toHaveLength(2);
+  });
+
+  it("should document shared ttf encoder output", async () => {
+    const ttf = await fsPromise.readFile(fixtureTtf);
+    const encoded = await encodeTtfToWoff2(ttf);
+
+    expect(isWoff2(encoded)).toBe(true);
+  });
+});

--- a/src/standalone/convertTtfInput.test.ts
+++ b/src/standalone/convertTtfInput.test.ts
@@ -56,6 +56,17 @@ describe("convertTtfInput", () => {
     }
   });
 
+  it("should reject remote ttf URLs with a clear error", async () => {
+    const remoteUrl = "https://cdn.example.com/fonts/iconfont.ttf";
+
+    await expect(
+      convertTtfInput([remoteUrl], {
+        files: remoteUrl,
+        formats: ["woff2"],
+      }),
+    ).rejects.toThrow(`Remote TTF URLs are not supported. Download the file first: ${remoteUrl}`);
+  });
+
   it("should log verbose progress when encoding", async () => {
     const logSpy = vi.spyOn(console, "log").mockImplementation(vi.fn());
 

--- a/src/standalone/convertTtfInput.ts
+++ b/src/standalone/convertTtfInput.ts
@@ -1,4 +1,5 @@
 import * as fsPromise from "fs/promises";
+import { isHttpUrl } from "../lib/inputSource";
 import { getSfntFlavor } from "../lib/sfnt/flavor";
 import { encodeTtfToEot, encodeTtfToWoff, encodeTtfToWoff2 } from "../lib/ttfEncode";
 import type { Result } from "../types/Result";
@@ -72,6 +73,10 @@ const transcodeTtfSource = async (
   options: WebfontOptions,
   verbose?: boolean,
 ): Promise<TranscodedFont> => {
+  if (isHttpUrl(source)) {
+    throw new Error(`Remote TTF URLs are not supported. Download the file first: ${source}`);
+  }
+
   if (verbose) {
     // biome-ignore lint/suspicious/noConsole: verbose conversion progress
     console.log(`Encoding ${source}...`);

--- a/src/standalone/convertTtfInput.ts
+++ b/src/standalone/convertTtfInput.ts
@@ -1,0 +1,115 @@
+import * as fsPromise from "fs/promises";
+import { getSfntFlavor } from "../lib/sfnt/flavor";
+import { encodeTtfToEot, encodeTtfToWoff, encodeTtfToWoff2 } from "../lib/ttfEncode";
+import type { Result } from "../types/Result";
+import type { TranscodedFont } from "../types/TranscodedFont";
+import type { WebfontOptions } from "../types/WebfontOptions";
+import { resolveTtfConversionFormats, type TtfEncodeFormat } from "./inputMode";
+
+const assertNonEmptyFontFiles = (fontFiles: readonly string[]): void => {
+  if (fontFiles.length === 0) {
+    throw new Error("No TTF files matched");
+  }
+};
+
+const assertConversionOptions = (options: WebfontOptions): void => {
+  if (options.template) {
+    throw new Error("Templates are not supported when converting TTF input");
+  }
+
+  if (options.glyphTransformFn) {
+    throw new Error("glyphTransformFn is not supported when converting TTF input");
+  }
+};
+
+const assertValidTtfInput = (buffer: Buffer, source: string): void => {
+  let flavor: ReturnType<typeof getSfntFlavor>;
+
+  try {
+    flavor = getSfntFlavor(buffer);
+  } catch {
+    throw new Error(`Input is not a valid TrueType font: ${source}`);
+  }
+
+  if (flavor !== "ttf") {
+    throw new Error(`OpenType (OTF) input is not supported for webfont encoding. Use a .ttf file for ${source}.`);
+  }
+};
+
+const assignTtfOutput = async (
+  transcoded: TranscodedFont,
+  buffer: Buffer,
+  format: TtfEncodeFormat,
+  options: WebfontOptions,
+): Promise<void> => {
+  if (format === "ttf") {
+    transcoded.ttf = buffer;
+    return;
+  }
+
+  if (format === "eot") {
+    transcoded.eot = encodeTtfToEot(buffer);
+    return;
+  }
+
+  if (format === "woff") {
+    let metadata: string | undefined;
+
+    if (typeof options.metadata === "string") {
+      metadata = options.metadata;
+    }
+
+    transcoded.woff = encodeTtfToWoff(buffer, { metadata });
+    return;
+  }
+
+  transcoded.woff2 = await encodeTtfToWoff2(buffer);
+};
+
+const transcodeTtfSource = async (
+  source: string,
+  formats: TtfEncodeFormat[],
+  options: WebfontOptions,
+  verbose?: boolean,
+): Promise<TranscodedFont> => {
+  if (verbose) {
+    // biome-ignore lint/suspicious/noConsole: verbose conversion progress
+    console.log(`Encoding ${source}...`);
+  }
+
+  const buffer = await fsPromise.readFile(source);
+
+  assertValidTtfInput(buffer, source);
+
+  const transcoded: TranscodedFont = { source };
+
+  await Promise.all(formats.map((format) => assignTtfOutput(transcoded, buffer, format, options)));
+
+  return transcoded;
+};
+
+export const convertTtfInput = async (fontFiles: readonly string[], options: WebfontOptions): Promise<Result> => {
+  assertConversionOptions(options);
+  assertNonEmptyFontFiles(fontFiles);
+
+  const formats = resolveTtfConversionFormats(options.formats);
+  const transcodedFonts = await Promise.all(
+    fontFiles.map((source) => transcodeTtfSource(source, formats, options, options.verbose)),
+  );
+
+  const result: Result = {
+    config: { ...options },
+    transcodedFonts,
+  };
+
+  if (transcodedFonts.length === 1) {
+    const [single] = transcodedFonts;
+
+    result.ttf = single.ttf;
+    result.eot = single.eot;
+    result.woff = single.woff;
+    result.woff2 = single.woff2;
+  }
+
+  return result;
+};

--- a/src/standalone/index.ts
+++ b/src/standalone/index.ts
@@ -4,15 +4,14 @@ import deepmerge from "deepmerge";
 import nunjucks from "nunjucks";
 import path from "path";
 import { Readable } from "stream";
-import ttf2woff from "ttf2woff";
-import wawoff2 from "wawoff2";
 import { getBuiltInTemplates, getTemplateFilePath } from "../../templates";
 import { resolveInputSources } from "../lib/inputSource";
 import { getFontStreamOptions, SVGIcons2SVGFontStream } from "../lib/svgicons2svgfont";
-import convertTtfToEot from "../lib/ttf2eot";
+import { encodeTtfToEot, encodeTtfToWoff, encodeTtfToWoff2 } from "../lib/ttfEncode";
 import type { Format, GlyphData, GlyphMetadata, InitialOptions, WebfontOptions } from "../types";
 import type { Result } from "../types/Result";
 import type { ResultConfig } from "../types/ResultConfig";
+import { convertTtfInput } from "./convertTtfInput";
 import { convertWebfontInput } from "./convertWebfontInput";
 import { getGlyphsData } from "./glyphsData";
 import { assertSvgPipelineFormats, classifyInputFiles, filterInputFilesByMode } from "./inputMode";
@@ -78,11 +77,11 @@ const toSvg = (glyphsData: GlyphData[], options: WebfontOptions) => {
   });
 };
 
-const toEot = (buffer: Buffer) => convertTtfToEot(buffer);
+const toEot = (buffer: Buffer) => encodeTtfToEot(buffer);
 
-const toWoff = (buffer: Buffer, options: { metadata?: string }) => Buffer.from(ttf2woff(buffer, options).buffer);
+const toWoff = (buffer: Buffer, options: { metadata?: string }) => encodeTtfToWoff(buffer, options);
 
-const toWoff2 = (buffer: Buffer) => wawoff2.compress(buffer);
+const toWoff2 = (buffer: Buffer) => encodeTtfToWoff2(buffer);
 
 type Webfont = (_initialOptions?: InitialOptions) => Promise<Result>;
 
@@ -115,7 +114,7 @@ export const webfont: Webfont = async (initialOptions) => {
   const inputMode = classifyInputFiles(foundFiles);
 
   if (inputMode === "mixed") {
-    throw new Error("Cannot mix SVG icons with WOFF/WOFF2 font files in the same run");
+    throw new Error("Cannot mix SVG icons, TTF fonts, and WOFF/WOFF2 files in the same run");
   }
 
   if (inputMode === "empty") {
@@ -125,6 +124,17 @@ export const webfont: Webfont = async (initialOptions) => {
   if (inputMode === "webfont") {
     const fontFiles = filterInputFilesByMode(foundFiles, inputMode);
     const result = await convertWebfontInput(fontFiles, options);
+
+    if (discoveredConfigPath) {
+      result.config = { ...options, filePath: discoveredConfigPath };
+    }
+
+    return result;
+  }
+
+  if (inputMode === "ttf") {
+    const fontFiles = filterInputFilesByMode(foundFiles, inputMode);
+    const result = await convertTtfInput(fontFiles, options);
 
     if (discoveredConfigPath) {
       result.config = { ...options, filePath: discoveredConfigPath };

--- a/src/standalone/inputMode.test.ts
+++ b/src/standalone/inputMode.test.ts
@@ -2,6 +2,7 @@ import {
   assertSvgPipelineFormats,
   classifyInputFiles,
   filterInputFilesByMode,
+  resolveTtfConversionFormats,
   resolveWebfontConversionFormats,
 } from "./inputMode";
 
@@ -25,6 +26,22 @@ describe("classifyInputFiles", () => {
   it("should classify mixed woff and woff2 as webfont mode", () => {
     expect(classifyInputFiles(["src/fixtures/fonts/iconfont.woff", "src/fixtures/fonts/iconfont.woff2"])).toBe(
       "webfont",
+    );
+  });
+
+  it("should classify ttf-only globs as ttf mode", () => {
+    expect(classifyInputFiles(["src/fixtures/fonts/iconfont.ttf"])).toBe("ttf");
+  });
+
+  it("should reject mixed svg and ttf inputs", () => {
+    expect(classifyInputFiles(["src/fixtures/svg-icons/avatar.svg", "src/fixtures/fonts/iconfont.ttf"])).toBe(
+      "mixed",
+    );
+  });
+
+  it("should reject mixed ttf and webfont inputs", () => {
+    expect(classifyInputFiles(["src/fixtures/fonts/iconfont.ttf", "src/fixtures/fonts/iconfont.woff2"])).toBe(
+      "mixed",
     );
   });
 
@@ -80,6 +97,12 @@ describe("filterInputFilesByMode", () => {
     ).toEqual(["src/fixtures/fonts/iconfont.woff2"]);
   });
 
+  it("should filter ttf files in ttf mode", () => {
+    expect(
+      filterInputFilesByMode(["src/fixtures/fonts/iconfont.ttf", "src/fixtures/fonts/iconfont.woff2"], "ttf"),
+    ).toEqual(["src/fixtures/fonts/iconfont.ttf"]);
+  });
+
   it("should return an empty list for unsupported modes", () => {
     expect(filterInputFilesByMode(["src/fixtures/fonts/iconfont.woff2"], "empty")).toEqual([]);
   });
@@ -101,6 +124,26 @@ describe("resolveWebfontConversionFormats", () => {
   it("should reject conversion runs without ttf or otf output formats", () => {
     expect(() => resolveWebfontConversionFormats(["woff2"])).toThrow(
       'formats must include "ttf" and/or "otf" when converting WOFF/WOFF2 input',
+    );
+  });
+});
+
+describe("resolveTtfConversionFormats", () => {
+  it("should default to woff and woff2 when svg pipeline formats are still configured", () => {
+    expect(resolveTtfConversionFormats(["svg", "ttf", "eot", "woff", "woff2"])).toEqual(["woff", "woff2"]);
+  });
+
+  it("should keep explicit webfont output requests", () => {
+    expect(resolveTtfConversionFormats(["ttf", "woff2"])).toEqual(["ttf", "woff2"]);
+  });
+
+  it("should deduplicate explicit encode formats", () => {
+    expect(resolveTtfConversionFormats(["woff2", "woff2", "woff"])).toEqual(["woff2", "woff"]);
+  });
+
+  it("should reject ttf runs without webfont output formats", () => {
+    expect(() => resolveTtfConversionFormats(["svg"])).toThrow(
+      'formats must include at least one of "ttf", "eot", "woff", or "woff2" when converting TTF input',
     );
   });
 });

--- a/src/standalone/inputMode.ts
+++ b/src/standalone/inputMode.ts
@@ -1,16 +1,18 @@
 import { getInputExtension } from "../lib/inputSource";
 import type { Format } from "../types/Format";
 
-export type InputMode = "empty" | "mixed" | "svg" | "webfont";
+export type InputMode = "empty" | "mixed" | "svg" | "ttf" | "webfont";
 
 const WEBFONT_EXTENSIONS = new Set([".woff", ".woff2"]);
 const SVG_EXTENSION = ".svg";
+const TTF_EXTENSION = ".ttf";
 const SVG_PIPELINE_DEFAULT: Format[] = ["svg", "ttf", "eot", "woff", "woff2"];
 
 const isSvgExtension = (extension: string): boolean => extension === SVG_EXTENSION;
+const isTtfExtension = (extension: string): boolean => extension === TTF_EXTENSION;
 const isWebfontExtension = (extension: string): boolean => WEBFONT_EXTENSIONS.has(extension);
 const isSupportedInputExtension = (extension: string): boolean =>
-  isSvgExtension(extension) || isWebfontExtension(extension);
+  isSvgExtension(extension) || isWebfontExtension(extension) || isTtfExtension(extension);
 
 export const classifyInputFiles = (filePaths: readonly string[]): InputMode => {
   if (filePaths.length === 0) {
@@ -25,13 +27,19 @@ export const classifyInputFiles = (filePaths: readonly string[]): InputMode => {
 
   const hasSvg = extensions.some(isSvgExtension);
   const hasWebfont = extensions.some(isWebfontExtension);
+  const hasTtf = extensions.some(isTtfExtension);
+  const modeKinds = [hasSvg, hasWebfont, hasTtf].filter(Boolean).length;
 
-  if (hasSvg && hasWebfont) {
+  if (modeKinds > 1) {
     return "mixed";
   }
 
   if (hasWebfont) {
     return "webfont";
+  }
+
+  if (hasTtf) {
+    return "ttf";
   }
 
   if (hasSvg) {
@@ -58,10 +66,37 @@ export const filterInputFilesByMode = (filePaths: readonly string[], mode: Input
     return filePaths.filter((filePath) => WEBFONT_EXTENSIONS.has(getInputExtension(filePath)));
   }
 
+  if (mode === "ttf") {
+    return filePaths.filter((filePath) => getInputExtension(filePath) === TTF_EXTENSION);
+  }
+
   return [];
 };
 
 export type ConversionFormat = "otf" | "ttf";
+
+export type TtfEncodeFormat = "eot" | "ttf" | "woff" | "woff2";
+
+const TTF_ENCODE_FORMATS = new Set<Format>(["ttf", "eot", "woff", "woff2"]);
+
+export const resolveTtfConversionFormats = (formats: readonly Format[]): TtfEncodeFormat[] => {
+  const encodeFormats = formats.filter((format): format is TtfEncodeFormat => TTF_ENCODE_FORMATS.has(format));
+  const isFullSvgDefault =
+    formats.length === SVG_PIPELINE_DEFAULT.length &&
+    SVG_PIPELINE_DEFAULT.every((format) => formats.includes(format));
+
+  if (isFullSvgDefault) {
+    return ["woff", "woff2"];
+  }
+
+  if (encodeFormats.length === 0) {
+    throw new Error(
+      'formats must include at least one of "ttf", "eot", "woff", or "woff2" when converting TTF input',
+    );
+  }
+
+  return [...new Set(encodeFormats)];
+};
 
 export const resolveWebfontConversionFormats = (formats: readonly Format[]): ConversionFormat[] => {
   const ttfOrOtf = formats.filter((format): format is "otf" | "ttf" => format === "ttf" || format === "otf");

--- a/src/standalone/ttfConversion.integration.test.ts
+++ b/src/standalone/ttfConversion.integration.test.ts
@@ -1,0 +1,119 @@
+import * as fsPromise from "fs/promises";
+import isEot from "is-eot";
+import isTtf from "is-ttf";
+import isWoff from "is-woff";
+import isWoff2 from "is-woff2";
+import standalone from "../standalone";
+
+const fixtureTtf = "src/fixtures/fonts/iconfont.ttf";
+const fixtureWoff2 = "src/fixtures/fonts/iconfont.woff2";
+
+describe("TTF to webfont conversion", () => {
+  it("should encode ttf input to woff and woff2 output", async () => {
+    const result = await standalone({
+      files: fixtureTtf,
+      formats: ["woff", "woff2"],
+    });
+
+    expect(result.woff).toBeDefined();
+    expect(result.woff2).toBeDefined();
+    expect(isWoff(result.woff)).toBe(true);
+    expect(isWoff2(result.woff2)).toBe(true);
+    expect(result.svg).toBeUndefined();
+    expect(result.glyphsData).toBeUndefined();
+  });
+
+  it("should default to woff and woff2 when svg pipeline formats are still configured", async () => {
+    const result = await standalone({
+      files: fixtureTtf,
+    });
+
+    expect(result.woff).toBeDefined();
+    expect(result.woff2).toBeDefined();
+    expect(isWoff(result.woff)).toBe(true);
+    expect(isWoff2(result.woff2)).toBe(true);
+    expect(result.ttf).toBeUndefined();
+  });
+
+  it("should pass through ttf and encode eot when requested", async () => {
+    const result = await standalone({
+      files: fixtureTtf,
+      formats: ["ttf", "eot", "woff"],
+    });
+
+    expect(isTtf(result.ttf)).toBe(true);
+    expect(isEot(result.eot)).toBe(true);
+    expect(isWoff(result.woff)).toBe(true);
+    expect(result.woff2).toBeUndefined();
+  });
+
+  it("should reject mixed svg and ttf inputs", async () => {
+    await expect(
+      standalone({
+        files: ["src/fixtures/svg-icons/avatar.svg", fixtureTtf],
+        formats: ["woff2"],
+      }),
+    ).rejects.toThrow("Cannot mix SVG icons, TTF fonts, and WOFF/WOFF2 files");
+  });
+
+  it("should reject mixed ttf and webfont inputs", async () => {
+    await expect(
+      standalone({
+        files: [fixtureTtf, fixtureWoff2],
+        formats: ["woff2"],
+      }),
+    ).rejects.toThrow("Cannot mix SVG icons, TTF fonts, and WOFF/WOFF2 files");
+  });
+
+  it("should reject template option in ttf mode", async () => {
+    await expect(
+      standalone({
+        files: fixtureTtf,
+        formats: ["woff2"],
+        template: "css",
+      }),
+    ).rejects.toThrow("Templates are not supported when converting TTF input");
+  });
+
+  it("should reject formats without webfont outputs for ttf input", async () => {
+    await expect(
+      standalone({
+        files: fixtureTtf,
+        formats: ["svg"],
+      }),
+    ).rejects.toThrow(
+      'formats must include at least one of "ttf", "eot", "woff", or "woff2" when converting TTF input',
+    );
+  });
+
+  it("should produce woff2 that decompresses back to valid ttf", async () => {
+    const encoded = await standalone({ files: fixtureTtf, formats: ["woff2"] });
+    const tempWoff2 = "temp/ttf-roundtrip.woff2";
+
+    await fsPromise.mkdir("temp", { recursive: true });
+    await fsPromise.writeFile(tempWoff2, encoded.woff2 as Buffer);
+
+    try {
+      const decompressed = await standalone({
+        files: tempWoff2,
+        formats: ["ttf"],
+      });
+
+      expect(isWoff2(encoded.woff2)).toBe(true);
+      expect(isTtf(decompressed.ttf)).toBe(true);
+    } finally {
+      await fsPromise.rm(tempWoff2, { force: true });
+    }
+  });
+
+  it("should transcode multiple ttf files in one run", async () => {
+    const result = await standalone({
+      files: [fixtureTtf, fixtureTtf],
+      formats: ["woff2"],
+    });
+
+    expect(result.transcodedFonts).toHaveLength(2);
+    expect(result.woff2).toBeUndefined();
+    expect(result.transcodedFonts?.every((font) => isWoff2(font.woff2))).toBe(true);
+  });
+});

--- a/src/standalone/ttfConversion.integration.test.ts
+++ b/src/standalone/ttfConversion.integration.test.ts
@@ -65,6 +65,17 @@ describe("TTF to webfont conversion", () => {
     ).rejects.toThrow("Cannot mix SVG icons, TTF fonts, and WOFF/WOFF2 files");
   });
 
+  it("should reject remote ttf URLs with a clear error", async () => {
+    const remoteUrl = "https://cdn.example.com/fonts/iconfont.ttf";
+
+    await expect(
+      standalone({
+        files: remoteUrl,
+        formats: ["woff2"],
+      }),
+    ).rejects.toThrow(`Remote TTF URLs are not supported. Download the file first: ${remoteUrl}`);
+  });
+
   it("should reject template option in ttf mode", async () => {
     await expect(
       standalone({

--- a/src/standalone/webfontConversion.integration.test.ts
+++ b/src/standalone/webfontConversion.integration.test.ts
@@ -62,7 +62,7 @@ describe("webfont WOFF/WOFF2 conversion", () => {
         files: ["src/fixtures/svg-icons/avatar.svg", fixtureWoff2],
         formats: ["ttf"],
       }),
-    ).rejects.toThrow("Cannot mix SVG icons with WOFF/WOFF2 font files");
+    ).rejects.toThrow("Cannot mix SVG icons, TTF fonts, and WOFF/WOFF2 files");
   });
 
   it("should reject unsupported input extensions", async () => {

--- a/src/types/Result.ts
+++ b/src/types/Result.ts
@@ -1,12 +1,15 @@
 import type { DecompressedFont } from "./DecompressedFont";
 import type { GlyphData } from "./GlyphData";
 import type { ResultConfig } from "./ResultConfig";
+import type { TranscodedFont } from "./TranscodedFont";
 
 export type { DecompressedFont } from "./DecompressedFont";
+export type { TranscodedFont } from "./TranscodedFont";
 
 export type Result = {
   config?: ResultConfig;
   decompressedFonts?: DecompressedFont[];
+  transcodedFonts?: TranscodedFont[];
   eot?: Buffer;
   glyphsData?: Array<GlyphData>;
   hash?: string;

--- a/src/types/TranscodedFont.ts
+++ b/src/types/TranscodedFont.ts
@@ -1,0 +1,7 @@
+export type TranscodedFont = {
+  source: string;
+  eot?: Buffer;
+  ttf?: Buffer;
+  woff?: Buffer;
+  woff2?: Buffer;
+};


### PR DESCRIPTION
## Summary

### Proposed changes

- Add a third auto-detected pipeline for `.ttf` input → `eot`, `woff`, and/or `woff2` (default `woff` + `woff2` when SVG-pipeline `formats` are unchanged).
- Introduce `convertTtfInput`, shared `ttfEncode` helpers, and `result.transcodedFonts` for batch runs.
- Extend CLI batch writes (`writeTranscodedFontFiles`) and input classification (reject mixed `.svg` / `.ttf` / `.woff`/`.woff2`).
- Document in README, FEATURES.md, MIGRATION.md, NOTICE.md, and [ADR 0009](docs/adr/0009-ttf-webfont-encoding-pipeline.md).

### Related issue

https://github.com/itgalaxy/webfont/issues/13

### Dependencies added/removed (if applicable)

N/A

---

### Testing

- [x] I have added or updated tests that prove my fix is effective or that my feature works (if applicable)
  - [x] Unit test

#### How to test

1. `npm test` — 308 tests including `convertTtfInput.test.ts`, `ttfConversion.integration.test.ts`, and CLI TTF encode test.
2. `webfont src/fixtures/fonts/iconfont.ttf -d temp/out -f woff,woff2 --dest-create`
3. Confirm mixed inputs fail: `webfont src/fixtures/svg-icons/avatar.svg src/fixtures/fonts/iconfont.ttf`

#### Test configuration

N/A

---

## Checklist

- [x] I have added corresponding labels to this PR (like bug, enhancement...);
- [x] My commits follow the [Conventional Commits 1.0 Guidelines](https://www.conventionalcommits.org/en/v1.0.0/);
- [x] My code follows the style guidelines of this project;
- [x] I have performed a self-review of my own code;
- [x] I have mapped technical debts found on my changes;
- [x] I have made changes to the documentation (if applicable);
- [x] My changes generate no new warnings or errors;

Made with [Cursor](https://cursor.com)