### PR TITLE
fix: guard normalizeRoundOption against invalid inputs (#569)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -131,7 +131,7 @@ When a task changes **how users interact with webfont** (CLI flags, programmatic
 3. **Update [FEATURES.md](./FEATURES.md)** when capabilities, stability, properties, or test criteria change. Mark features `stable`, `in-progress`, or `planned`; tick test criteria when coverage exists.
 4. **Update [NOTICE.md](./NOTICE.md)** when legal notices, font licensing guidance, attribution rules, or runtime dependency licenses change.
 5. **Update [TROUBLESHOOTING.md](./TROUBLESHOOTING.md)** for operational errors (symptoms and fixes on the **current** release, not version-to-version deltas).
-6. **Update [MIGRATION.md](./MIGRATION.md)** when a fix or change alters behavior across releases: document *before* / *after*, workarounds on older versions, and steps after upgrading. Link the GitHub issue; set the **minimum fixed version** when the release ships.
+6. **Update [MIGRATION.md](./MIGRATION.md)** when a fix or change alters behavior across releases. Each entry must follow the [entry structure](./MIGRATION.md#entry-structure): *What changed* → *Before* → *After* → **Workaround on older versions** (required when users on older npm releases have a practical alternative — config/API instead of CLI, external tools, etc.; use `None` + reason only when no workaround exists) → *After upgrading*. Link the GitHub issue; set the **minimum fixed version** when the release ships.
 7. **Do not rely on CHANGELOG alone** for unreleased work; Release Please updates `CHANGELOG.md` at release time.
 
 See also [CONTRIBUTING.md](./CONTRIBUTING.md) — “User-facing changes and documentation”.
@@ -174,7 +174,7 @@ Process open issues **oldest to newest** (`gh issue list --state open`, sort by 
 1. Comment on the issue **in English**: investigation is in progress; link the PR when it exists.
 2. **Tests first:** check coverage for the affected area. Add or extend tests that name the failure **before** changing production code when coverage is missing.
 3. Implement the fix; run `npm test`.
-4. **Bugs and behavior changes across releases:** add or update [MIGRATION.md](./MIGRATION.md) (*Before* → *After* → *Workaround on older versions* → *After upgrading*). Link the GitHub issue. Use [TROUBLESHOOTING.md](./TROUBLESHOOTING.md) only when the entry is not version-specific (same behavior on all supported releases).
+4. **Bugs and behavior changes across releases:** add or update [MIGRATION.md](./MIGRATION.md) using the [entry structure](./MIGRATION.md#entry-structure) (*Before* → *After* → **Workaround on older versions** → *After upgrading*). Include a workaround whenever users on the current npm release can avoid the bug or gap without upgrading (e.g. numeric `round` in config instead of `--round` on CLI). Link the GitHub issue. Use [TROUBLESHOOTING.md](./TROUBLESHOOTING.md) only when the entry is not version-specific (same behavior on all supported releases).
 5. Open a PR (English title/body, Conventional Commits). Link the issue in **Related issue**; do **not** use `Closes #n` if the issue should stay open until npm publish.
 6. Wait for CI; wait for maintainer merge.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,7 +23,7 @@ Some [issues lack information](https://github.com/itgalaxy/webfont/issues?q=is%3
 When working through the issue tracker (see also [AGENTS.md](./AGENTS.md) — “GitHub issues workflow”):
 
 1. Triage: assignee, milestone `next`, type label (`bug`, `enhancement`, etc.).
-2. Fix PR: tests where needed, code change, and for **issue fixes that change behavior across releases** an entry in [MIGRATION.md](./MIGRATION.md) (before → after → workaround → steps after upgrade).
+2. Fix PR: tests where needed, code change, and for **issue fixes that change behavior across releases** an entry in [MIGRATION.md](./MIGRATION.md) following the [entry structure](./MIGRATION.md#entry-structure) (before → after → **workaround on older versions** when applicable → steps after upgrade).
 3. After merge: comment on the issue in English that the fix is on `master` and planned for the next release; **leave the issue open** until npm publish.
 4. On release: comment with the **version number** and the exact steps from MIGRATION.md, then **close** the issue.
 
@@ -65,7 +65,7 @@ When it does, update documentation in the same PR:
 | CLI flags, aliases, or accepted flag values | [README.md](./README.md) CLI section, `src/cli/meow/cliOptions.ts` help text, and [FEATURES.md](./FEATURES.md) when capability changes |
 | `webfont()` options, defaults, return shape, or supported inputs/outputs | [README.md](./README.md) Options / Result / Input modes, [FEATURES.md](./FEATURES.md) |
 | New or removed public options or pipelines | README + [FEATURES.md](./FEATURES.md) + TypeScript types under `src/types/` |
-| Bug fixes or recurring user-facing errors (especially from issues) | [MIGRATION.md](./MIGRATION.md) when behavior changes across versions; [TROUBLESHOOTING.md](./TROUBLESHOOTING.md) when the fix applies the same on all releases |
+| Bug fixes or recurring user-facing errors (especially from issues) | [MIGRATION.md](./MIGRATION.md) ([entry structure](./MIGRATION.md#entry-structure), including **Workaround on older versions** when users can mitigate without upgrading); [TROUBLESHOOTING.md](./TROUBLESHOOTING.md) when the fix applies the same on all releases |
 | Legal notices, font licensing copy, attribution, or dependency license table | [NOTICE.md](./NOTICE.md); link from README as needed |
 | Internal-only refactors with no usage change | No README or FEATURES change; say so in the PR **Testing** section |
 

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,8 +1,31 @@
 # Migration guide
 
-What changed between webfont releases and how to update your setup. Each entry covers **before** / **after**, a **workaround on older versions**, and **steps after upgrading**.
+What changed between webfont releases and how to update your setup.
 
 See also [CHANGELOG.md](./CHANGELOG.md) for the full release history.
+
+## Entry structure
+
+Every migration entry **must** use these headings in order (omit only when a section truly does not apply — see below):
+
+| Section | Required? | Content |
+|---------|-----------|---------|
+| **Minimum version** | Yes | Semver when shipped; *pending* before release |
+| **What changed** | Yes | One short summary |
+| **Before** | Yes | Behavior on older releases |
+| **After** | Yes | Behavior on the fixed release |
+| **Workaround on older versions** | **Yes when applicable** | Concrete steps users on an older npm version can take **without upgrading** (config shape, CLI flags, external tools, pinned version). **Do not skip** for bug fixes — if the bug is CLI-only, document a config/API path that still works. |
+| **After upgrading** | Yes | `npm install webfont@…` and the new recommended command or config |
+
+When no practical workaround exists (rare), keep the heading and write **None** with one sentence explaining why (for example the old release cannot perform the operation at all).
+
+**Example workaround patterns**
+
+- Bug on CLI flag → use cosmiconfig with a **typed** value (number in JSON/JS config instead of a string from argv).
+- Missing feature → external tool or script until upgrade.
+- Config vs CLI conflict → pass input only on the command line on older releases.
+
+Link the GitHub issue in the entry title. On release: set **Minimum version**, move the entry under that release heading, and trim workarounds that only applied to pre-release builds.
 
 ---
 
@@ -12,7 +35,7 @@ See also [CHANGELOG.md](./CHANGELOG.md) for the full release history.
 
 ### What changed
 
-`--round` and `round` in config/API still accept **number or string** (no breaking change). Numeric strings (for example `"4"` from the CLI) are coerced to numbers before `svgicons2svgfont` runs.
+`--round` and `round` in config/API still accept **number or string** (no breaking change). Numeric strings (for example `"4"` from the CLI) are coerced to finite numbers before `svgicons2svgfont` runs. Empty, whitespace-only, non-numeric, and non-finite values are ignored (svgicons2svgfont default rounding applies).
 
 ### Before (bug)
 
@@ -22,9 +45,36 @@ See also [CHANGELOG.md](./CHANGELOG.md) for the full release history.
 Error: assertNumbers arguments[0] is not a number. string == typeof 4
 ```
 
+Misconfigured values such as `""` could also coerce to `0` and silently change rounding.
+
 ### After (fix)
 
-Same CLI and config shapes work; coercion happens at the SVG pipeline boundary only.
+Same CLI and config shapes work; coercion happens at the SVG pipeline boundary only. Invalid `round` values are treated as unset.
+
+### Workaround on older versions
+
+On releases before the fix, **avoid passing `--round` from the CLI** (meow supplies a string). Use one of:
+
+**Programmatic API** — pass a number:
+
+```js
+await webfont({ files: "icons/*.svg", round: 4 });
+```
+
+**Config file** — set `round` as a JSON number (not a string):
+
+```json
+{
+  "files": "icons/**/*.svg",
+  "round": 4
+}
+```
+
+```shell
+webfont --config webfont.config.json -d dist/icons
+```
+
+Or omit `round` if the default meets your needs.
 
 ### After upgrading
 
@@ -66,15 +116,15 @@ await webfont({ files: "icons/*.svg", round: "4" });
   Error: Cannot specify input files on the command line when `files` is set in the config file
   ```
 
-### Workaround on 12.0.0
+### Workaround on older versions
 
-Pass globs on the command line; omit `files` from the config:
+On **12.0.0 and earlier**, pass globs on the command line; omit `files` from the config:
 
 ```shell
 webfont "src/icons/a.svg" "src/icons/b.svg" --config webfont.config.json -d dist/icons
 ```
 
-### After upgrading to 12.0.1
+### After upgrading
 
 ```shell
 npm install webfont@12.0.1

--- a/src/lib/svgicons2svgfont/index.test.ts
+++ b/src/lib/svgicons2svgfont/index.test.ts
@@ -14,6 +14,27 @@ describe("svgicons2svgfont helpers", () => {
     it("should return undefined for non-numeric strings", () => {
       expect(normalizeRoundOption("not-a-number")).toBeUndefined();
     });
+
+    it("should return undefined for empty strings", () => {
+      expect(normalizeRoundOption("")).toBeUndefined();
+    });
+
+    it("should return undefined for whitespace-only strings", () => {
+      expect(normalizeRoundOption("   ")).toBeUndefined();
+    });
+
+    it("should return undefined for non-finite numbers", () => {
+      expect(normalizeRoundOption(Number.POSITIVE_INFINITY)).toBeUndefined();
+      expect(normalizeRoundOption(Number.NaN)).toBeUndefined();
+    });
+
+    it("should return undefined for non-finite numeric strings", () => {
+      expect(normalizeRoundOption("Infinity")).toBeUndefined();
+    });
+
+    it("should return undefined for null", () => {
+      expect(normalizeRoundOption(null)).toBeUndefined();
+    });
   });
 
   describe("getFontStreamOptions", () => {

--- a/src/lib/svgicons2svgfont/index.ts
+++ b/src/lib/svgicons2svgfont/index.ts
@@ -14,23 +14,36 @@ export const getMetadataServiceOptions = (options: WebfontOptions): MetadataServ
   startUnicode: Number(options.startUnicode),
 });
 
-/** Coerce `round` for svgicons2svgfont; accepts number or numeric string (CLI/config). */
-export const normalizeRoundOption = (round: string | number | undefined): number | undefined => {
-  if (round === undefined) {
+/**
+ * Coerce `round` for svgicons2svgfont; accepts number or numeric string (CLI/config).
+ * Returns undefined for undefined/null/empty/non-numeric/non-finite inputs.
+ */
+export const normalizeRoundOption = (round: string | number | null | undefined): number | undefined => {
+  if (round === undefined || round === null) {
     return undefined;
   }
 
   if (typeof round === "number") {
-    return round;
-  }
+    if (Number.isFinite(round)) {
+      return round;
+    }
 
-  const parsed = Number(round);
-
-  if (Number.isNaN(parsed)) {
     return undefined;
   }
 
-  return parsed;
+  const trimmed = round.trim();
+
+  if (trimmed.length === 0) {
+    return undefined;
+  }
+
+  const parsed = Number(trimmed);
+
+  if (Number.isFinite(parsed)) {
+    return parsed;
+  }
+
+  return undefined;
 };
 
 export const getFontStreamOptions = (options: WebfontOptions): Partial<SVGIcons2SVGFontStreamOptions> =>


### PR DESCRIPTION
## Summary

### Proposed changes

- Harden `normalizeRoundOption`: trim strings, reject empty/whitespace, non-numeric, and non-finite values (fixes `""` → `0` and `"Infinity"` passthrough).
- Add focused unit tests documenting guard behavior.
- Add MIGRATION.md entry structure template, **Workaround on older versions** for #569, and align #2 heading (follow-up to Copilot feedback on #701).

### Related issue

https://github.com/itgalaxy/webfont/issues/569

### Dependencies added/removed (if applicable)

N/A

---

### Testing

- [x] I have added or updated tests that prove my fix is effective or that my feature works (if applicable)
  - [x] Unit test

#### How to test

1. `npm test` — `src/lib/svgicons2svgfont/index.test.ts` edge cases.
2. Verify `normalizeRoundOption("")` and `normalizeRoundOption("Infinity")` return `undefined`.

#### Test configuration

N/A

---

## Checklist

- [x] I have added corresponding labels to this PR (like bug, enhancement...);
- [x] My commits follow the [Conventional Commits 1.0 Guidelines](https://www.conventionalcommits.org/en/v1.0.0/);
- [x] My code follows the style guidelines of this project;
- [x] I have performed a self-review of my own code;
- [x] I have mapped technical debts found on my changes;
- [x] I have made changes to the documentation (if applicable);
- [x] My changes generate no new warnings or errors;

Made with [Cursor](https://cursor.com)