### PR TITLE
docs: split migration entries per issue; fix round guards (#569)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -131,7 +131,7 @@ When a task changes **how users interact with webfont** (CLI flags, programmatic
 3. **Update [FEATURES.md](./FEATURES.md)** when capabilities, stability, properties, or test criteria change. Mark features `stable`, `in-progress`, or `planned`; tick test criteria when coverage exists.
 4. **Update [NOTICE.md](./NOTICE.md)** when legal notices, font licensing guidance, attribution rules, or runtime dependency licenses change.
 5. **Update [TROUBLESHOOTING.md](./TROUBLESHOOTING.md)** for operational errors (symptoms and fixes on the **current** release, not version-to-version deltas).
-6. **Update [MIGRATION.md](./MIGRATION.md)** when a fix or change alters behavior across releases. Each entry must follow the [entry structure](./MIGRATION.md#entry-structure): *What changed* → *Before* → *After* → **Workaround on older versions** (required when users on older npm releases have a practical alternative — config/API instead of CLI, external tools, etc.; use `None` + reason only when no workaround exists) → *After upgrading*. Link the GitHub issue; set the **minimum fixed version** when the release ships.
+6. **Update migration docs** when a fix or change alters behavior across releases: add **`docs/migration/issue-NNNN-<slug>.md`** (one new file per issue — do **not** append to `MIGRATION.md`; see [entry structure](./MIGRATION.md#entry-structure) and [docs/migration/README.md](./docs/migration/README.md)). Include *What changed* → *Before* → *After* → **Workaround on older versions** (when users on older npm releases have a practical alternative) → *After upgrading*. Link the GitHub issue; set **minimum fixed version** in that file when the release ships.
 7. **Do not rely on CHANGELOG alone** for unreleased work; Release Please updates `CHANGELOG.md` at release time.
 
 See also [CONTRIBUTING.md](./CONTRIBUTING.md) — “User-facing changes and documentation”.
@@ -174,7 +174,7 @@ Process open issues **oldest to newest** (`gh issue list --state open`, sort by 
 1. Comment on the issue **in English**: investigation is in progress; link the PR when it exists.
 2. **Tests first:** check coverage for the affected area. Add or extend tests that name the failure **before** changing production code when coverage is missing.
 3. Implement the fix; run `npm test`.
-4. **Bugs and behavior changes across releases:** add or update [MIGRATION.md](./MIGRATION.md) using the [entry structure](./MIGRATION.md#entry-structure) (*Before* → *After* → **Workaround on older versions** → *After upgrading*). Include a workaround whenever users on the current npm release can avoid the bug or gap without upgrading (e.g. numeric `round` in config instead of `--round` on CLI). Link the GitHub issue. Use [TROUBLESHOOTING.md](./TROUBLESHOOTING.md) only when the entry is not version-specific (same behavior on all supported releases).
+4. **Bugs and behavior changes across releases:** add **`docs/migration/issue-NNNN-<slug>.md`** using the [entry structure](./MIGRATION.md#entry-structure) (*Before* → *After* → **Workaround on older versions** → *After upgrading*). Do not edit `MIGRATION.md` body for new entries — only add a file under `docs/migration/` ([workflow](./docs/migration/README.md)). Link the GitHub issue. Use [TROUBLESHOOTING.md](./TROUBLESHOOTING.md) only when the entry is not version-specific.
 5. Open a PR (English title/body, Conventional Commits). Link the issue in **Related issue**; do **not** use `Closes #n` if the issue should stay open until npm publish.
 6. Wait for CI; wait for maintainer merge.
 
@@ -182,13 +182,13 @@ Process open issues **oldest to newest** (`gh issue list --state open`, sort by 
 
 1. Comment on the issue **in English**: the fix is on `master`, planned for the **next** npm release, with a link to the merged PR.
 2. **Keep the issue open** until the fix is published on npm.
-3. Point reporters to [MIGRATION.md](./MIGRATION.md) (workarounds on their version) when the fix is not on npm yet.
+3. Point reporters to the migration file for their issue under [`docs/migration/`](./docs/migration/) (workarounds on their version) when the fix is not on npm yet.
 
 ### On release (when the version containing the fix ships)
 
-1. Comment on the issue **in English** with the **released version** (e.g. `12.1.0`), `npm install` command, and **concrete steps** from MIGRATION.md — not only “upgrade”.
+1. Comment on the issue **in English** with the **released version** (e.g. `12.1.0`), `npm install` command, and **concrete steps** from that issue’s `docs/migration/issue-*.md` file — not only “upgrade”.
 2. **Close the issue** with a short note referencing the release tag / CHANGELOG entry.
-3. Update MIGRATION.md: set the **minimum version**, move the section under that release heading, and remove obsolete “before upgrade” workarounds.
+3. Update that issue’s migration file: set **Minimum version** and trim obsolete workarounds.
 
 Skip PRs for duplicates, `wontfix`, or issues that only need a comment (already fixed in a recent release — verify with tests or changelog before closing).
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,7 +23,7 @@ Some [issues lack information](https://github.com/itgalaxy/webfont/issues?q=is%3
 When working through the issue tracker (see also [AGENTS.md](./AGENTS.md) — “GitHub issues workflow”):
 
 1. Triage: assignee, milestone `next`, type label (`bug`, `enhancement`, etc.).
-2. Fix PR: tests where needed, code change, and for **issue fixes that change behavior across releases** an entry in [MIGRATION.md](./MIGRATION.md) following the [entry structure](./MIGRATION.md#entry-structure) (before → after → **workaround on older versions** when applicable → steps after upgrade).
+2. Fix PR: tests where needed, code change, and for **issue fixes that change behavior across releases** a new file `docs/migration/issue-NNNN-<slug>.md` ([workflow](./docs/migration/README.md), [entry structure](./MIGRATION.md#entry-structure)).
 3. After merge: comment on the issue in English that the fix is on `master` and planned for the next release; **leave the issue open** until npm publish.
 4. On release: comment with the **version number** and the exact steps from MIGRATION.md, then **close** the issue.
 
@@ -65,7 +65,7 @@ When it does, update documentation in the same PR:
 | CLI flags, aliases, or accepted flag values | [README.md](./README.md) CLI section, `src/cli/meow/cliOptions.ts` help text, and [FEATURES.md](./FEATURES.md) when capability changes |
 | `webfont()` options, defaults, return shape, or supported inputs/outputs | [README.md](./README.md) Options / Result / Input modes, [FEATURES.md](./FEATURES.md) |
 | New or removed public options or pipelines | README + [FEATURES.md](./FEATURES.md) + TypeScript types under `src/types/` |
-| Bug fixes or recurring user-facing errors (especially from issues) | [MIGRATION.md](./MIGRATION.md) ([entry structure](./MIGRATION.md#entry-structure), including **Workaround on older versions** when users can mitigate without upgrading); [TROUBLESHOOTING.md](./TROUBLESHOOTING.md) when the fix applies the same on all releases |
+| Bug fixes or recurring user-facing errors (especially from issues) | New `docs/migration/issue-NNNN-<slug>.md` ([workflow](./docs/migration/README.md)); [TROUBLESHOOTING.md](./TROUBLESHOOTING.md) when the fix applies the same on all releases |
 | Legal notices, font licensing copy, attribution, or dependency license table | [NOTICE.md](./NOTICE.md); link from README as needed |
 | Internal-only refactors with no usage change | No README or FEATURES change; say so in the PR **Testing** section |
 

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -4,9 +4,15 @@ What changed between webfont releases and how to update your setup.
 
 See also [CHANGELOG.md](./CHANGELOG.md) for the full release history.
 
+## Where entries live
+
+**Each change has its own file** under [`docs/migration/`](./docs/migration/) — not a growing section in this document. That keeps parallel PRs from conflicting on the same markdown file.
+
+Read [docs/migration/README.md](./docs/migration/README.md) for naming (`issue-0569-cli-round.md`) and PR workflow.
+
 ## Entry structure
 
-Every migration entry **must** use these headings in order (omit only when a section truly does not apply — see below):
+Every file in `docs/migration/` **must** use these headings in order (omit only when a section truly does not apply):
 
 | Section | Required? | Content |
 |---------|-----------|---------|
@@ -25,156 +31,4 @@ When no practical workaround exists (rare), keep the heading and write **None** 
 - Missing feature → external tool or script until upgrade.
 - Config vs CLI conflict → pass input only on the command line on older releases.
 
-Link the GitHub issue in the entry title. On release: set **Minimum version**, move the entry under that release heading, and trim workarounds that only applied to pre-release builds.
-
----
-
-## Next release — TTF to WOFF/WOFF2 encoding ([#13](https://github.com/itgalaxy/webfont/issues/13))
-
-**Minimum version:** *pending*
-
-### What changed
-
-webfont auto-detects **`.ttf` input** (no new flag). One or more TrueType files can be encoded to `eot`, `woff`, and/or `woff2`. Default output when SVG-pipeline `formats` are still configured: `woff` + `woff2`.
-
-### Before
-
-TTF files were rejected (`did not match any supported files`). Users relied on external tools or manual `ttf2woff` / `wawoff2` scripts.
-
-### After
-
-```shell
-webfont path/to/font.ttf -d dist/fonts -f woff,woff2
-```
-
-Programmatic:
-
-```js
-const result = await webfont({
-  files: "fonts/MyFont.ttf",
-  formats: ["woff", "woff2"],
-});
-// result.woff, result.woff2
-```
-
-Batch runs expose `result.transcodedFonts` (`{ source, ttf?, eot?, woff?, woff2? }[]`).
-
-### Workaround on older versions
-
-Use external encoders until upgrade:
-
-```shell
-# Example with npx (adjust paths)
-npx ttf2woff path/to/font.ttf > path/to/font.woff
-```
-
-Or decompress an existing `.woff2` if you only need the SFNT inside (see WOFF/WOFF2 decompression in README).
-
-### After upgrading
-
-```shell
-npm install webfont@<version>
-webfont "fonts/*.ttf" -d dist/webfonts -f woff,woff2 --dest-create
-```
-
----
-
-## Next release — CLI `--round` numeric strings ([#569](https://github.com/itgalaxy/webfont/issues/569))
-
-**Minimum version:** *pending*
-
-### What changed
-
-`--round` and `round` in config/API still accept **number or string** (no breaking change). Numeric strings (for example `"4"` from the CLI) are coerced to numbers before `svgicons2svgfont` runs.
-
-### Before (bug)
-
-`webfont icons/*.svg --round 4` could throw:
-
-```text
-Error: assertNumbers arguments[0] is not a number. string == typeof 4
-```
-
-### After (fix)
-
-Same CLI and config shapes work; coercion happens at the SVG pipeline boundary only.
-
-### Workaround on older versions
-
-On releases before the fix, **avoid passing `--round` from the CLI** (meow supplies a string). Use one of:
-
-**Programmatic API** — pass a number:
-
-```js
-await webfont({ files: "icons/*.svg", round: 4 });
-```
-
-**Config file** — set `round` as a JSON number (not a string):
-
-```json
-{
-  "files": "icons/**/*.svg",
-  "round": 4
-}
-```
-
-```shell
-webfont --config webfont.config.json -d dist/icons
-```
-
-Or omit `round` if the default meets your needs.
-
-### After upgrading
-
-```shell
-npm install webfont@<version>
-webfont "icons/*.svg" --round 4 -d dist/icons
-```
-
-Programmatic usage unchanged:
-
-```js
-await webfont({ files: "icons/*.svg", round: 4 });
-await webfont({ files: "icons/*.svg", round: "4" });
-```
-
----
-
-## 12.0.1 — CLI `files` from config ([#2](https://github.com/itgalaxy/webfont/issues/2))
-
-**Minimum version:** `12.0.1`
-
-### Before (12.0.0 and earlier)
-
-- The CLI required at least one SVG path as a **positional argument**, even when `files` was set in a config file loaded via `--config`.
-- Config-only runs ignored or failed to use config `files`:
-
-  ```shell
-  webfont --config webfont.config.json -d dist/icons
-  ```
-
-- Passing **both** CLI paths and config `files` was ambiguous; older releases could prefer CLI input only.
-
-### After (12.0.1+)
-
-- **Config-only input:** `webfont --config webfont.config.json -d dist/icons` uses `files` from the config when no positional SVG paths are passed.
-- **Mutual exclusion:** CLI positional paths and config `files` cannot be combined — webfont exits with:
-
-  ```text
-  Error: Cannot specify input files on the command line when `files` is set in the config file
-  ```
-
-### Workaround on older versions
-
-On **12.0.0 and earlier**, pass globs on the command line; omit `files` from the config:
-
-```shell
-webfont "src/icons/a.svg" "src/icons/b.svg" --config webfont.config.json -d dist/icons
-```
-
-### After upgrading
-
-```shell
-npm install webfont@12.0.1
-webfont --config webfont.config.json -d dist/icons
-```
+**On release:** edit only that issue’s file — set **Minimum version** and trim workarounds that only applied to pre-release builds.

--- a/docs/adr/0010-one-migration-file-per-issue.md
+++ b/docs/adr/0010-one-migration-file-per-issue.md
@@ -1,0 +1,28 @@
+# ADR 0010: One migration file per issue
+
+- **Status:** Accepted
+- **Date:** 2026-07-02
+- **Related:** [MIGRATION.md](../../MIGRATION.md), [docs/migration/README.md](../migration/README.md)
+
+## Context
+
+[MIGRATION.md](../../MIGRATION.md) accumulated **all** upgrade guides in one file. Parallel PRs (e.g. #706 TTF encoding + #707 round guards) edited the same document near the top → frequent Git merge conflicts.
+
+## Decision
+
+- **Template** stays in `MIGRATION.md` (entry structure, links).
+- **Each behavior change** gets its own file: `docs/migration/issue-NNNN-<slug>.md` (issue number zero-padded to four digits).
+- PRs **add a new file**; they do not append sections to `MIGRATION.md`.
+- On release, maintainers edit **only** that issue’s file (set minimum version, trim workarounds).
+
+## Consequences
+
+### Positive
+
+- Parallel migration docs merge without conflicts (unique paths).
+- Issues and PRs link directly to one file.
+
+### Negative
+
+- No single scrollable changelog-style page; use `ls docs/migration/issue-*.md` or GitHub search.
+- Discoverability relies on issue links and README conventions.

--- a/docs/migration/README.md
+++ b/docs/migration/README.md
@@ -1,0 +1,30 @@
+# Migration entries
+
+One file per behavior change. **Do not append long entries to [MIGRATION.md](../../MIGRATION.md)** — add a new file here (or edit only the file for your issue).
+
+## Naming
+
+```
+docs/migration/issue-<issue-number-zero-padded>-<short-slug>.md
+```
+
+Examples: `issue-0002-config-files.md`, `issue-0569-cli-round.md`.
+
+Zero-pad the issue number to **four digits** so filenames sort in issue order.
+
+## PR workflow (merge-conflict safe)
+
+| Do | Don't |
+|----|--------|
+| Add **one new** `issue-NNNN-*.md` per PR | Append sections to `MIGRATION.md` |
+| Edit **only** your issue’s file when updating wording | Edit another issue’s migration file |
+| On release, set **Minimum version** in that file | Rename files unless the issue number was wrong |
+
+Parallel PRs touch **different paths** → Git merges cleanly.
+
+## Find an entry
+
+- GitHub: search `issue-0569` in `docs/migration/`
+- Local: `ls docs/migration/issue-*.md`
+
+Link the file from the GitHub issue and PR (**Related issue** / comments).

--- a/docs/migration/issue-0002-config-files.md
+++ b/docs/migration/issue-0002-config-files.md
@@ -1,0 +1,42 @@
+# CLI `files` from config ([#2](https://github.com/itgalaxy/webfont/issues/2))
+
+**Minimum version:** `12.0.1`
+
+## What changed
+
+The CLI can load input globs from a config file without positional SVG paths. CLI paths and config `files` are mutually exclusive.
+
+## Before (12.0.0 and earlier)
+
+- The CLI required at least one SVG path as a **positional argument**, even when `files` was set in a config file loaded via `--config`.
+- Config-only runs ignored or failed to use config `files`:
+
+  ```shell
+  webfont --config webfont.config.json -d dist/icons
+  ```
+
+- Passing **both** CLI paths and config `files` was ambiguous; older releases could prefer CLI input only.
+
+## After (12.0.1+)
+
+- **Config-only input:** `webfont --config webfont.config.json -d dist/icons` uses `files` from the config when no positional SVG paths are passed.
+- **Mutual exclusion:** CLI positional paths and config `files` cannot be combined — webfont exits with:
+
+  ```text
+  Error: Cannot specify input files on the command line when `files` is set in the config file
+  ```
+
+## Workaround on older versions
+
+On **12.0.0 and earlier**, pass globs on the command line; omit `files` from the config:
+
+```shell
+webfont "src/icons/a.svg" "src/icons/b.svg" --config webfont.config.json -d dist/icons
+```
+
+## After upgrading
+
+```shell
+npm install webfont@12.0.1
+webfont --config webfont.config.json -d dist/icons
+```

--- a/docs/migration/issue-0013-ttf-encoding.md
+++ b/docs/migration/issue-0013-ttf-encoding.md
@@ -1,0 +1,47 @@
+# TTF to WOFF/WOFF2 encoding ([#13](https://github.com/itgalaxy/webfont/issues/13))
+
+**Minimum version:** *pending*
+
+## What changed
+
+webfont auto-detects **`.ttf` input** (no new flag). One or more TrueType files can be encoded to `eot`, `woff`, and/or `woff2`. Default output when SVG-pipeline `formats` are still configured: `woff` + `woff2`.
+
+## Before
+
+TTF files were rejected (`did not match any supported files`). Users relied on external tools or manual `ttf2woff` / `wawoff2` scripts.
+
+## After
+
+```shell
+webfont path/to/font.ttf -d dist/fonts -f woff,woff2
+```
+
+Programmatic:
+
+```js
+const result = await webfont({
+  files: "fonts/MyFont.ttf",
+  formats: ["woff", "woff2"],
+});
+// result.woff, result.woff2
+```
+
+Batch runs expose `result.transcodedFonts` (`{ source, ttf?, eot?, woff?, woff2? }[]`).
+
+## Workaround on older versions
+
+Use external encoders until upgrade:
+
+```shell
+# Example with npx (adjust paths)
+npx ttf2woff path/to/font.ttf > path/to/font.woff
+```
+
+Or decompress an existing `.woff2` if you only need the SFNT inside (see WOFF/WOFF2 decompression in README).
+
+## After upgrading
+
+```shell
+npm install webfont@<version>
+webfont "fonts/*.ttf" -d dist/webfonts -f woff,woff2 --dest-create
+```

--- a/docs/migration/issue-0569-cli-round.md
+++ b/docs/migration/issue-0569-cli-round.md
@@ -1,0 +1,60 @@
+# CLI `--round` numeric strings ([#569](https://github.com/itgalaxy/webfont/issues/569))
+
+**Minimum version:** *pending*
+
+## What changed
+
+`--round` and `round` in config/API still accept **number or string** (no breaking change). Numeric strings (for example `"4"` from the CLI) are coerced to **finite** numbers before `svgicons2svgfont` runs. Empty, whitespace-only, non-numeric, and non-finite values are ignored (library default rounding applies).
+
+## Before (bug)
+
+`webfont icons/*.svg --round 4` could throw:
+
+```text
+Error: assertNumbers arguments[0] is not a number. string == typeof 4
+```
+
+Misconfigured values such as `""` could also coerce to `0` and silently change rounding.
+
+## After (fix)
+
+Same CLI and config shapes work; coercion happens at the SVG pipeline boundary only. Invalid `round` values are treated as unset.
+
+## Workaround on older versions
+
+On releases before the fix, **avoid passing `--round` from the CLI** (meow supplies a string). Use one of:
+
+**Programmatic API** — pass a number:
+
+```js
+await webfont({ files: "icons/*.svg", round: 4 });
+```
+
+**Config file** — set `round` as a JSON number (not a string):
+
+```json
+{
+  "files": "icons/**/*.svg",
+  "round": 4
+}
+```
+
+```shell
+webfont --config webfont.config.json -d dist/icons
+```
+
+Or omit `round` if the default meets your needs.
+
+## After upgrading
+
+```shell
+npm install webfont@<version>
+webfont "icons/*.svg" --round 4 -d dist/icons
+```
+
+Programmatic usage unchanged:
+
+```js
+await webfont({ files: "icons/*.svg", round: 4 });
+await webfont({ files: "icons/*.svg", round: "4" });
+```

--- a/src/lib/svgicons2svgfont/index.test.ts
+++ b/src/lib/svgicons2svgfont/index.test.ts
@@ -14,6 +14,27 @@ describe("svgicons2svgfont helpers", () => {
     it("should return undefined for non-numeric strings", () => {
       expect(normalizeRoundOption("not-a-number")).toBeUndefined();
     });
+
+    it("should return undefined for empty strings", () => {
+      expect(normalizeRoundOption("")).toBeUndefined();
+    });
+
+    it("should return undefined for whitespace-only strings", () => {
+      expect(normalizeRoundOption("   ")).toBeUndefined();
+    });
+
+    it("should return undefined for non-finite numbers", () => {
+      expect(normalizeRoundOption(Number.POSITIVE_INFINITY)).toBeUndefined();
+      expect(normalizeRoundOption(Number.NaN)).toBeUndefined();
+    });
+
+    it("should return undefined for non-finite numeric strings", () => {
+      expect(normalizeRoundOption("Infinity")).toBeUndefined();
+    });
+
+    it("should return undefined for null", () => {
+      expect(normalizeRoundOption(null)).toBeUndefined();
+    });
   });
 
   describe("getFontStreamOptions", () => {

--- a/src/lib/svgicons2svgfont/index.ts
+++ b/src/lib/svgicons2svgfont/index.ts
@@ -14,23 +14,36 @@ export const getMetadataServiceOptions = (options: WebfontOptions): MetadataServ
   startUnicode: Number(options.startUnicode),
 });
 
-/** Coerce `round` for svgicons2svgfont; accepts number or numeric string (CLI/config). */
-export const normalizeRoundOption = (round: string | number | undefined): number | undefined => {
-  if (round === undefined) {
+/**
+ * Coerce `round` for svgicons2svgfont; accepts number or numeric string (CLI/config).
+ * Returns undefined for undefined/null/empty/non-numeric/non-finite inputs.
+ */
+export const normalizeRoundOption = (round: string | number | null | undefined): number | undefined => {
+  if (round === undefined || round === null) {
     return undefined;
   }
 
   if (typeof round === "number") {
-    return round;
-  }
+    if (Number.isFinite(round)) {
+      return round;
+    }
 
-  const parsed = Number(round);
-
-  if (Number.isNaN(parsed)) {
     return undefined;
   }
 
-  return parsed;
+  const trimmed = round.trim();
+
+  if (trimmed.length === 0) {
+    return undefined;
+  }
+
+  const parsed = Number(trimmed);
+
+  if (Number.isFinite(parsed)) {
+    return parsed;
+  }
+
+  return undefined;
 };
 
 export const getFontStreamOptions = (options: WebfontOptions): Partial<SVGIcons2SVGFontStreamOptions> =>


### PR DESCRIPTION
## Summary

### Proposed changes

- **Conflict-proof migrations (ADR 0010):** move each upgrade guide to `docs/migration/issue-NNNN-<slug>.md`; `MIGRATION.md` keeps only the entry template and links.
- Migrate existing entries: #2, #13, #569.
- **Supersedes [#707](https://github.com/itgalaxy/webfont/pull/707)** — includes `normalizeRoundOption` finite/empty guards + tests; updates `docs/migration/issue-0569-cli-round.md` only (no `MIGRATION.md` body conflict with #706).

### Related issue

https://github.com/itgalaxy/webfont/issues/569

### Dependencies added/removed (if applicable)

N/A

---

### Testing

- [x] I have added or updated tests that prove my fix is effective or that my feature works (if applicable)
  - [x] Unit test

#### How to test

1. `npm test` — 315 tests; `normalizeRoundOption` edge cases in `index.test.ts`.
2. Review `docs/migration/` layout and [ADR 0010](docs/adr/0010-one-migration-file-per-issue.md).

#### Test configuration

N/A

---

## Checklist

- [ ] I have added corresponding labels to this PR (like bug, enhancement...);
- [x] My commits follow the [Conventional Commits 1.0 Guidelines](https://www.conventionalcommits.org/en/v1.0.0/);
- [x] My code follows the style guidelines of this project;
- [x] I have performed a self-review of my own code;
- [x] I have mapped technical debts found on my changes;
- [x] I have made changes to the documentation (if applicable);
- [x] My changes generate no new warnings or errors;

Made with [Cursor](https://cursor.com)