### PR TITLE
docs: document addHashInFontUrl for cache busting (#125)

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -110,10 +110,13 @@ Canonical list of product capabilities. **Update this file in the same PR** when
 - **Properties**:
   - Built-in: `css`, `scss`, `styl`.
   - Custom template: path to a Nunjucks file.
-  - SVG pipeline only (not webfont decompression mode).
+  - SVG pipeline only (not webfont decompression or TTF encoding mode).
+  - `templateCacheString`: manual query string on font URLs (default `Date.now()`).
+  - `addHashInFontUrl`: append MD5 `&v=<hash>` from SVG font content; **filenames stay** `fontName.*` ([#125](https://github.com/itgalaxy/webfont/issues/125)).
 - **Test Criteria**:
   - [x] Built-in `css` template snapshot / integration coverage
   - [x] Subset `formats` with template omits unused format URLs
+  - [x] `addHashInFontUrl` on `css` and `scss` templates appends content hash to URLs
 
 ### Command-line interface (CLI)
 

--- a/README.md
+++ b/README.md
@@ -256,6 +256,42 @@ const remote = await webfont({
 - Default: Gets is from `fontName` if not set, but you can specify any value.
 - Description: Template font family name you want.
 
+#### `templateCacheString`
+
+- Type: `string`
+- Default: `Date.now()` at generation time
+- Description: Query string appended to font `url(...)` values in built-in templates (before optional `&v=` hash). Use a fixed value (for example `v=1`) when you only need manual cache busting; pair with [`addHashInFontUrl`](#addhashinfonturl) for automatic content-based busting.
+
+#### `addHashInFontUrl`
+
+- Type: `boolean`
+- Default: `false`
+- Description: When `true` and a built-in `template` is used, append `&v=<md5>` to each font URL in the generated CSS/SCSS/Styl. The hash is derived from the SVG font output — it changes only when icon data changes. **Output filenames stay** `fontName.woff2`, `fontName.scss`, etc. (stable `@import` paths).
+- CLI: `--addHashInFontUrl`
+- Addresses browser cache issues without renaming font files on every build ([#125](https://github.com/itgalaxy/webfont/issues/125)).
+
+**Example — stable `webfont.scss`, cache-busted font URLs:**
+
+```shell
+webfont "icons/*.svg" -d dist/icons -t scss --addHashInFontUrl
+```
+
+```js
+import webfont from "webfont";
+
+await webfont({
+  files: "src/icons/**/*.svg",
+  fontName: "webfont",
+  template: "scss",
+  templateFontPath: "./fonts/",
+  addHashInFontUrl: true,
+});
+// Writes dist/icons/webfont.scss and dist/icons/webfont.woff2 (fixed names).
+// SCSS contains url("./fonts/webfont.woff2?...&v=<md5>") — hash updates when icons change.
+```
+
+Do **not** use `Math.random()` in `fontName` — that renames both font files and the stylesheet on every run.
+
 #### `ligatures`
 
 - Type: `boolean`

--- a/src/cli/index.test.ts
+++ b/src/cli/index.test.ts
@@ -385,6 +385,26 @@ describe("cli", () => {
     expect(css).toMatchSnapshot();
   });
 
+  it("should include font hash in scss template when addHashInFontUrl is enabled (#125)", async () => {
+    const output = await execCLI(
+      `${source} -d ${destination} --template scss --templateCacheString test --addHashInFontUrl`,
+    );
+
+    expect(output.files).toEqual([
+      "webfont.eot",
+      "webfont.scss",
+      "webfont.svg",
+      "webfont.ttf",
+      "webfont.woff",
+      "webfont.woff2",
+    ]);
+    expect(output.code).toBe(0);
+    expect(output.stderr).toBe("");
+    const scss = await fsPromise.readFile(`${destination}/webfont.scss`, { encoding: "utf-8" });
+    expect(scss).toMatch(/&v=[a-f0-9]{32}/u);
+    expect(scss).toContain('url("./webfont.woff2?');
+  });
+
   it("should set font name", async () => {
     const output = await execCLI(`${source} -d ${destination} --fontName foobar`);
 

--- a/src/cli/meow/cliOptions.ts
+++ b/src/cli/meow/cliOptions.ts
@@ -155,7 +155,9 @@ export const webfontCliHelpText = `
 
         --addHashInFontUrl
 
-            Generated font url will be : [webfont].[ext]?v=[hash]
+            Append an MD5 content hash to font URLs in built-in templates
+            (?v=[hash]) while keeping output filenames stable (fontName.woff2, etc.).
+            Use with a fixed fontName — do not randomize fontName for cache busting.
 `;
 
 export const webfontMeowFlags = {


### PR DESCRIPTION
## Summary

### Proposed changes

- Document **`addHashInFontUrl`** and **`templateCacheString`** in README (stable `webfont.scss` / `webfont.woff2` filenames + `&v=<md5>` in URLs — addresses #125 without random `fontName`).
- Update FEATURES.md template section and CLI help text.
- Add CLI integration test: `scss` + `--addHashInFontUrl`.

### Related issue

https://github.com/itgalaxy/webfont/issues/125

### Dependencies added/removed (if applicable)

N/A

---

### Testing

- [x] I have added or updated tests that prove my fix is effective or that my feature works (if applicable)
  - [x] Unit test

#### How to test

1. `npm test` — new SCSS `addHashInFontUrl` CLI test.
2. `webfont "src/fixtures/svg-icons/*.svg" -d temp/out -t scss --addHashInFontUrl` — inspect `webfont.scss` for `&v=<32-char hex>`.

#### Test configuration

N/A

---

## Checklist

- [x] I have added corresponding labels to this PR (like bug, enhancement...);
- [x] My commits follow the [Conventional Commits 1.0 Guidelines](https://www.conventionalcommits.org/en/v1.0.0/);
- [x] My code follows the style guidelines of this project;
- [x] I have performed a self-review of my own code;
- [x] I have mapped technical debts found on my changes;
- [x] I have made changes to the documentation (if applicable);
- [x] My changes generate no new warnings or errors;

Made with [Cursor](https://cursor.com)