### PR TITLE
feat: add glyphContentTransformFn for stroke SVG icons (#144)

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -43,6 +43,7 @@ Canonical list of product capabilities. **Update this file in the same PR** when
   - Default `formats` when SVG-pipeline defaults are still configured: `['woff', 'woff2']`.
   - Does **not** accept `.otf` input (TrueType only). Does **not** merge multiple weights into one file.
   - `template` and `glyphTransformFn` are not supported in this mode.
+  - `glyphContentTransformFn` is not supported in this mode.
   - **Licensing:** encoding does not grant rights to the font; users must comply with the font’s license. See [NOTICE.md](./NOTICE.md) §3.3.
   - **Architecture:** see [ADR 0009](docs/adr/0009-ttf-webfont-encoding-pipeline.md).
 - **Test Criteria**:
@@ -68,6 +69,7 @@ Canonical list of product capabilities. **Update this file in the same PR** when
   - Does **not** re-encode to `eot`, `woff`, or `woff2` in this mode.
   - Default `formats` when SVG-pipeline defaults are still configured: `['ttf']`.
   - `template` and `glyphTransformFn` are not supported in this mode.
+  - `glyphContentTransformFn` is not supported in this mode.
   - **Licensing:** decompression does not grant rights to the font; users must comply with the font’s license for input and extracted output. Copyright/metadata in the SFNT is preserved. See [NOTICE.md](./NOTICE.md) §3.4.
   - **Architecture:** see [ADR 0007](docs/adr/0007-woff-woff2-decompression-pipeline.md).
 - **Test Criteria**:
@@ -150,8 +152,10 @@ Canonical list of product capabilities. **Update this file in the same PR** when
 - **Properties**:
   - `metadataProvider`: replace default SVG metadata lookup.
   - `glyphTransformFn`: transform metadata after load (SVG mode only).
+  - `glyphContentTransformFn`: transform SVG glyph contents before font generation (SVG mode only; e.g. stroke-to-fill via `svg-outline-stroke`, #144).
 - **Test Criteria**:
   - [x] `glyphTransformFn` applied before font generation
+  - [x] `glyphContentTransformFn` applied before font generation (#144)
   - [x] `metadataProvider` error paths unit-tested (`glyphsData`)
 
 ### svgicons2svgfont options

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ webfont runs one of three pipelines depending on matched input files. They canno
 - Renaming or re-wrapping without matching the real outline format (e.g. requesting `otf` when the WOFF2 holds TrueType).
 - Converting TTF to OTF (or OTF to TTF) — use [FontForge](https://fontforge.org/) or similar.
 - `.otf` as input for webfont encoding (TrueType `.ttf` only today).
-- Templates, `glyphTransformFn`, or merged multi-weight SFNT output in TTF encoding or webfont decompress mode.
+- Templates, `glyphTransformFn`, `glyphContentTransformFn`, or merged multi-weight SFNT output in TTF encoding or webfont decompress mode.
 - Globs that match extension-less or unsupported files together with fonts (the run fails instead of silently ignoring extras).
 
 Every matched path must end in `.svg`, `.ttf`, `.woff`, or `.woff2`. See [FEATURES.md](./FEATURES.md) for test-backed criteria.
@@ -328,6 +328,25 @@ Do **not** use `Math.random()` in `fontName` — that renames both font files an
       throw error;
     });
   ```
+
+#### `glyphContentTransformFn`
+
+- Type: `function`
+- Default: `null`
+- Description: Transform each SVG glyph **before** font generation (SVG pipeline only). Use this to preprocess stroke-based icons into filled paths, for example with [`svg-outline-stroke`](https://github.com/elrumordelaluz/outline-stroke). `glyphTransformFn` only changes metadata; this hook receives the full `GlyphData` (`contents`, `srcPath`, optional `metadata`) and must return the new SVG string.
+- Example (stroke icons, #144):
+
+  ```js
+  import outlineStroke from "svg-outline-stroke";
+  import webfont from "webfont";
+
+  await webfont({
+    files: "src/svg-icons/**/*.svg",
+    glyphContentTransformFn: async (glyph) => outlineStroke(glyph.contents),
+  });
+  ```
+
+  For better trace quality with `svg-outline-stroke`, use a larger `width` / `height` / `viewBox` on the source SVG (see the library README).
 
 #### `metadataProvider`
 

--- a/src/fixtures/svg-stroke-icons/plus-filled.svg
+++ b/src/fixtures/svg-stroke-icons/plus-filled.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <rect x="30" y="14" width="4" height="36" fill="#000"/>
+  <rect x="14" y="30" width="36" height="4" fill="#000"/>
+</svg>

--- a/src/fixtures/svg-stroke-icons/stroked-plus.svg
+++ b/src/fixtures/svg-stroke-icons/stroked-plus.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <line x1="32" y1="16" x2="32" y2="48" fill="none" stroke="#000" stroke-width="4"/>
+  <line x1="48" y1="32" x2="16" y2="32" fill="none" stroke="#000" stroke-width="4"/>
+</svg>

--- a/src/standalone/convertTtfInput.test.ts
+++ b/src/standalone/convertTtfInput.test.ts
@@ -29,6 +29,16 @@ describe("convertTtfInput", () => {
     ).rejects.toThrow("glyphTransformFn is not supported when converting TTF input");
   });
 
+  it("should reject glyphContentTransformFn option", async () => {
+    await expect(
+      convertTtfInput([fixtureTtf], {
+        files: fixtureTtf,
+        formats: ["woff2"],
+        glyphContentTransformFn: async () => "<svg></svg>",
+      }),
+    ).rejects.toThrow("glyphContentTransformFn is not supported when converting TTF input");
+  });
+
   it("should reject empty font file list", async () => {
     await expect(
       convertTtfInput([], {

--- a/src/standalone/convertTtfInput.ts
+++ b/src/standalone/convertTtfInput.ts
@@ -21,6 +21,10 @@ const assertConversionOptions = (options: WebfontOptions): void => {
   if (options.glyphTransformFn) {
     throw new Error("glyphTransformFn is not supported when converting TTF input");
   }
+
+  if (options.glyphContentTransformFn) {
+    throw new Error("glyphContentTransformFn is not supported when converting TTF input");
+  }
 };
 
 const assertValidTtfInput = (buffer: Buffer, source: string): void => {

--- a/src/standalone/convertWebfontInput.test.ts
+++ b/src/standalone/convertWebfontInput.test.ts
@@ -128,6 +128,17 @@ describe("convertWebfontInput", () => {
     ).rejects.toThrow("glyphTransformFn is not supported when converting WOFF/WOFF2 input");
   });
 
+  it("should reject glyphContentTransformFn for webfont conversion", async () => {
+    await expect(
+      convertWebfontInput(
+        [fixtureWoff2],
+        getConversionOptions({
+          glyphContentTransformFn: async () => "<svg></svg>",
+        }),
+      ),
+    ).rejects.toThrow("glyphContentTransformFn is not supported when converting WOFF/WOFF2 input");
+  });
+
   it("should log verbose progress when verbose is enabled", async () => {
     const sfnt = await fsPromise.readFile(fixtureTtf);
     mockedConvert.mockResolvedValue(sfnt);

--- a/src/standalone/convertWebfontInput.ts
+++ b/src/standalone/convertWebfontInput.ts
@@ -22,6 +22,10 @@ const assertConversionOptions = (options: WebfontOptions): void => {
   if (options.glyphTransformFn) {
     throw new Error("glyphTransformFn is not supported when converting WOFF/WOFF2 input");
   }
+
+  if (options.glyphContentTransformFn) {
+    throw new Error("glyphContentTransformFn is not supported when converting WOFF/WOFF2 input");
+  }
 };
 
 type AssignSfntOutputOptions = {

--- a/src/standalone/index.test.ts
+++ b/src/standalone/index.test.ts
@@ -1,4 +1,5 @@
 import crypto from "crypto";
+import * as fsPromise from "fs/promises";
 import isEot from "is-eot";
 import isSvg from "is-svg";
 import isTtf from "is-ttf";
@@ -310,6 +311,31 @@ describe("standalone", () => {
         files: `${fixturesGlob}/svg-icons/**/*`,
       }),
     ).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it("should transform SVG glyph contents before font generation (#144)", async () => {
+    const strokedPath = `${fixturesGlob}/svg-stroke-icons/stroked-plus.svg`;
+    const filledContents = await fsPromise.readFile(`${fixturesGlob}/svg-stroke-icons/plus-filled.svg`, "utf8");
+
+    const withoutTransform = await standalone({
+      files: strokedPath,
+      formats: ["ttf"],
+      fontName: "plus",
+    });
+
+    const withTransform = await standalone({
+      files: strokedPath,
+      formats: ["ttf"],
+      fontName: "plus",
+      glyphContentTransformFn: () => filledContents,
+    });
+
+    const hash = (buffer: Buffer) => crypto.createHash("md5").update(buffer).digest("hex");
+
+    expect(withTransform.glyphsData[0]?.contents).toBe(filledContents);
+    expect(hash(withTransform.ttf)).not.toBe(hash(withoutTransform.ttf));
+    expect(withTransform.ttf.length).toBeGreaterThan(withoutTransform.ttf.length);
+    expect(isTtf(withTransform.ttf)).toBe(true);
   });
 
   it("should create css selectors with transform titles through function", async () => {

--- a/src/standalone/index.ts
+++ b/src/standalone/index.ts
@@ -152,6 +152,19 @@ export const webfont: Webfont = async (initialOptions) => {
 
   let glyphsData = (await getGlyphsData(filteredFiles, options)) as GlyphData[];
 
+  if (options.glyphContentTransformFn) {
+    const glyphContentTransformFn = options.glyphContentTransformFn;
+    const transformedGlyphs = glyphsData.map(async (glyphData: GlyphData) => {
+      const contents = await glyphContentTransformFn(glyphData);
+
+      return {
+        ...glyphData,
+        contents,
+      };
+    });
+    glyphsData = await Promise.all(transformedGlyphs);
+  }
+
   if (options.glyphTransformFn) {
     const glyphTransformFn = options.glyphTransformFn;
     const transformedGlyphs = glyphsData.map(async (glyphData: GlyphData) => {

--- a/src/types/GlyphContentTransformFn.ts
+++ b/src/types/GlyphContentTransformFn.ts
@@ -1,0 +1,3 @@
+import type { GlyphData } from "./GlyphData";
+
+export type GlyphContentTransformFn = (_glyph: GlyphData) => string | Promise<string>;

--- a/src/types/InitialOptions.ts
+++ b/src/types/InitialOptions.ts
@@ -1,9 +1,11 @@
+import type { GlyphContentTransformFn } from "./GlyphContentTransformFn";
 import type { GlyphTransformFn } from "./GlyphTransformFn";
 import type { MetadataProvider } from "./MetadataProvider";
 import type { OptionsBase } from "./OptionsBase";
 
 export type InitialOptions = OptionsBase & {
   files: string | Array<string>;
+  glyphContentTransformFn?: GlyphContentTransformFn;
   glyphTransformFn?: GlyphTransformFn;
   metadataProvider?: MetadataProvider;
 };

--- a/src/types/WebfontOptions.ts
+++ b/src/types/WebfontOptions.ts
@@ -1,4 +1,5 @@
 import type { Formats, FormatsOptions } from "./Format";
+import type { GlyphContentTransformFn } from "./GlyphContentTransformFn";
 import type { GlyphTransformFn } from "./GlyphTransformFn";
 import type { InitialOptions } from "./InitialOptions";
 import type { MetadataProvider } from "./MetadataProvider";
@@ -15,6 +16,7 @@ export interface WebfontOptions extends InitialOptions {
   formats: Formats;
   formatsOptions: FormatsOptions;
   glyphTransformFn?: GlyphTransformFn;
+  glyphContentTransformFn?: GlyphContentTransformFn;
   ligatures: boolean;
   maxConcurrency: number;
   metadata: unknown;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,4 +1,5 @@
 export type { Format } from "../types/Format";
+export type { GlyphContentTransformFn } from "./GlyphContentTransformFn";
 export type { GlyphData } from "./GlyphData";
 export type { GlyphMetadata } from "./GlyphMetadata";
 export type { GlyphTransformFn } from "./GlyphTransformFn";


### PR DESCRIPTION
## Summary

### Proposed changes

This PR brings the following changes:

- Add `glyphContentTransformFn` to transform each SVG glyph before font generation (SVG pipeline only).
- Document usage with [`svg-outline-stroke`](https://github.com/elrumordelaluz/outline-stroke) for stroke-based icons (#144).
- Add stroke/filled fixtures and integration tests; reject the hook in TTF and WOFF/WOFF2 modes.

### Related issue

Closes #144

### Dependencies added/removed (if applicable)

N/A

---

### Testing

- [x] I have added or updated tests that prove my fix is effective or that my feature works (if applicable)
  - [x] Unit test

#### How to test

1. Run `npm test`.
2. Use `glyphContentTransformFn` with a stroked SVG and verify `glyphsData[].contents` and TTF output change (see `src/standalone/index.test.ts`).

#### Test configuration

N/A

---

## Checklist

- [ ] I have added corresponding labels to this PR (like bug, enhancement...);
- [x] My commits follow the [Conventional Commits 1.0 Guidelines](https://www.conventionalcommits.org/en/v1.0.0/);
- [x] My code follows the style guidelines of this project;
- [x] I have performed a self-review of my own code;
- [ ] I have mapped technical debts found on my changes;
- [x] I have made changes to the documentation (if applicable);
- [x] My changes generate no new warnings or errors;

Made with [Cursor](https://cursor.com)