### PR TITLE
feat: support multiple templates per run (#158)

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -145,6 +145,16 @@ Canonical list of product capabilities. **Update this file in the same PR** when
   - [x] Unit tests in `validateWebfontOptions.test.ts`
   - [x] Standalone and CLI integration tests for unknown format names (#133)
 
+### Multiple templates
+
+- **Stability**: stable
+- **Description**: Generate more than one style/preview template per run.
+- **Properties**:
+  - `template` accepts a string or array of built-in names (`css`, `html`, `scss`, `styl`, `json`) or custom template paths.
+  - `result.templates` lists each rendered output; `result.template` remains the first entry for backward compatibility.
+- **Test Criteria**:
+  - [x] Standalone and CLI tests for `template: ['html', 'scss']` (#158)
+
 ### Glyph metadata hooks
 
 - **Stability**: stable

--- a/README.md
+++ b/README.md
@@ -212,9 +212,11 @@ const remote = await webfont({
 
 #### `template`
 
-- Type: `string`
+- Type: `string` or `string[]`
 - Default: `null`
-- Possible values: `css`, `scss`, [`styl`](https://github.com/itgalaxy/webfont/pull/164/) (feel free to contribute more).
+- Possible values: `css`, `scss`, `styl`, `html`, `json` (feel free to contribute more), or a path to a custom `.njk` template.
+- Pass an **array** to generate multiple outputs in one run (for example `['html', 'scss']` for preview + styles, #158).
+- CLI: pass `-t` / `--template` as a single name, a JSON array (`'["html","scss"]'`), or a comma-separated list (`html,scss`).
 - Note: If you want to use a custom template use this option pass in a path `string` like this:
 
   ```js

--- a/src/cli/index.test.ts
+++ b/src/cli/index.test.ts
@@ -290,6 +290,21 @@ describe("cli", () => {
     expect(data).toMatchSnapshot();
   });
 
+  it("should generate multiple built-in templates (#158)", async () => {
+    const output = await execCLI(`${source} -d ${destination} -t '["html","scss"]' --templateCacheString test`);
+
+    expect(output.files).toEqual(
+      expect.arrayContaining(["webfont.html", "webfont.scss", "webfont.woff2", "webfont.woff", "webfont.ttf"]),
+    );
+    expect(output.code).toBe(0);
+    expect(output.stderr).toBe("");
+
+    const html = await fsPromise.readFile(`${destination}/webfont.html`, { encoding: "utf-8" });
+    const scss = await fsPromise.readFile(`${destination}/webfont.scss`, { encoding: "utf-8" });
+    expect(html).toContain("<!doctype html>");
+    expect(scss).toContain("$webfont-");
+  });
+
   it("should respect `template` options", async () => {
     const output = await execCLI(
       `${source} -d ${destination} --template css --templateClassName foo --templateCacheString test --templateFontPath test/path --templateFontName testname`,

--- a/src/cli/meow/cliOptions.ts
+++ b/src/cli/meow/cliOptions.ts
@@ -65,7 +65,8 @@ export const webfontCliHelpText = `
 
         -t, --template
 
-            Type of template ('css', 'scss', 'styl') or path to custom template.
+            Built-in template name(s) ('css', 'scss', 'styl', 'html', 'json') or path to a custom template.
+            Pass a JSON array (e.g. '["html","scss"]') or comma-separated list for multiple outputs.
 
         -s, --destTemplate
 

--- a/src/cli/parseTemplateFlag.test.ts
+++ b/src/cli/parseTemplateFlag.test.ts
@@ -1,0 +1,19 @@
+import { parseTemplateFlag } from "./parseTemplateFlag";
+
+describe("parseTemplateFlag", () => {
+  it("should parse a single built-in template", () => {
+    expect(parseTemplateFlag("css")).toBe("css");
+  });
+
+  it("should parse JSON array templates (#158)", () => {
+    expect(parseTemplateFlag('["html","scss"]')).toEqual(["html", "scss"]);
+  });
+
+  it("should parse comma-separated templates", () => {
+    expect(parseTemplateFlag("html, scss")).toEqual(["html", "scss"]);
+  });
+
+  it("should reject non-array JSON values", () => {
+    expect(() => parseTemplateFlag('{"template":"css"}')).toThrow("template must be a JSON array");
+  });
+});

--- a/src/cli/parseTemplateFlag.ts
+++ b/src/cli/parseTemplateFlag.ts
@@ -1,0 +1,40 @@
+import { normalizeTemplateOption, type TemplateOption } from "../lib/parseTemplateOption";
+
+export const parseTemplateFlag = (value: string | undefined): TemplateOption | undefined => {
+  if (value === undefined) {
+    return undefined;
+  }
+
+  const trimmed = value.trim();
+
+  if (trimmed.length === 0) {
+    throw new Error("template must not be empty");
+  }
+
+  if (trimmed.startsWith("[") || trimmed.startsWith("{")) {
+    let parsed: unknown;
+
+    try {
+      parsed = JSON.parse(trimmed);
+    } catch {
+      throw new Error('template must be a JSON array (e.g. ["html","scss"]) or a template name');
+    }
+
+    if (!Array.isArray(parsed)) {
+      throw new Error('template must be a JSON array (e.g. ["html","scss"]) or a template name');
+    }
+
+    return normalizeTemplateOption(parsed);
+  }
+
+  if (trimmed.includes(",")) {
+    return normalizeTemplateOption(
+      trimmed
+        .split(",")
+        .map((part) => part.trim())
+        .filter((part) => part.length > 0),
+    );
+  }
+
+  return trimmed;
+};

--- a/src/cli/program.test.ts
+++ b/src/cli/program.test.ts
@@ -174,6 +174,24 @@ describe("cli program", () => {
       expect(destTemplate).toBe(path.join("temp/out", "webfont.css"));
     });
 
+    it("should resolve the first template when template is an array (#158)", () => {
+      const config = {
+        dest: "temp/out",
+        fontName: "webfont",
+        template: ["html", "scss"],
+      };
+
+      const destTemplate = resolveDestTemplate(
+        {
+          template: "html-content",
+          usedBuildInTemplate: true,
+        },
+        config as never,
+      );
+
+      expect(destTemplate).toBe(path.join("temp/out", "webfont.html"));
+    });
+
     it("should resolve destTemplate when provided explicitly", () => {
       const config = {
         dest: "temp/out",
@@ -384,6 +402,32 @@ describe("cli program", () => {
 
       await fsPromise.access(path.join(destination, "webfont.css"));
       expect(await fsPromise.readFile(path.join(destination, "webfont.css"), "utf8")).toBe("body { color: red; }");
+    });
+
+    it("should write multiple template files (#158)", async () => {
+      const result: Result = {
+        config: {
+          dest: destination,
+          files: "icons/*.svg",
+          fontName: "webfont",
+          formats: ["svg"],
+          formatsOptions: {},
+          maxConcurrency: 1,
+          template: ["html", "scss"],
+        },
+        svg: Buffer.from("svg"),
+        template: "<html></html>",
+        templates: [
+          { template: "html", content: "<html></html>", builtIn: "html" },
+          { template: "scss", content: "$x: 1;", builtIn: "scss" },
+        ],
+        usedBuildInTemplate: true,
+      };
+
+      await writeResultFiles(result);
+
+      expect(await fsPromise.readFile(path.join(destination, "webfont.html"), "utf8")).toBe("<html></html>");
+      expect(await fsPromise.readFile(path.join(destination, "webfont.scss"), "utf8")).toBe("$x: 1;");
     });
 
     it("should create destination when destCreate is enabled", async () => {

--- a/src/cli/program.ts
+++ b/src/cli/program.ts
@@ -6,10 +6,11 @@ import { webfont } from "../standalone";
 import type { DecompressedFont } from "../types/DecompressedFont";
 import type { InitialOptions } from "../types/InitialOptions";
 import type { OptionsBase } from "../types/OptionsBase";
+import type { RenderedTemplate } from "../types/RenderedTemplate";
 import type { Result } from "../types/Result";
-import type { ResultConfig } from "../types/ResultConfig";
 import type { TranscodedFont } from "../types/TranscodedFont";
 import { parseFormatsFlag } from "./parseFormatsFlag";
+import { parseTemplateFlag } from "./parseTemplateFlag";
 import { resolveCliFiles } from "./resolveCliFiles";
 
 export type CliLike = {
@@ -79,7 +80,7 @@ export const buildOptionsBase = (cli: CliLike): OptionsBase => {
   }
 
   if (cli.flags.template) {
-    optionsBase.template = cli.flags.template;
+    optionsBase.template = parseTemplateFlag(cli.flags.template);
   }
 
   if (cli.flags.templateClassName) {
@@ -196,29 +197,69 @@ export const mergeCliDestIntoConfig = (
   return result;
 };
 
+export const resolveTemplateOutputPath = (
+  template: string,
+  config: ResultConfig,
+  usedBuiltIn: boolean,
+): string => {
+  const dest = config.dest ?? process.cwd();
+  let destTemplate = dest;
+
+  if (typeof config.destTemplate === "string") {
+    destTemplate = config.destTemplate;
+  }
+
+  if (usedBuiltIn) {
+    return path.join(destTemplate, `${config.fontName}.${template}`);
+  }
+
+  return path.join(destTemplate, path.basename(template).replace(".njk", ""));
+};
+
+const getPrimaryTemplateOption = (template: ResultConfig["template"]): string | undefined => {
+  if (Array.isArray(template)) {
+    return template[0];
+  }
+
+  return template;
+};
+
 export const resolveDestTemplate = (result: Result, config: ResultConfig): string | undefined => {
   if (!result.template) {
     return undefined;
   }
 
+  const primaryTemplate = getPrimaryTemplateOption(config.template);
+
+  if (result.usedBuildInTemplate && primaryTemplate) {
+    return resolveTemplateOutputPath(primaryTemplate, config, true);
+  }
+
+  if (primaryTemplate) {
+    return resolveTemplateOutputPath(primaryTemplate, config, false);
+  }
+
   const dest = config.dest ?? process.cwd();
-  let destTemplate: string;
 
   if (typeof config.destTemplate === "string") {
-    destTemplate = config.destTemplate;
-  } else {
-    destTemplate = dest;
+    return config.destTemplate;
   }
 
-  if (result.usedBuildInTemplate && typeof config.template === "string") {
-    return path.join(destTemplate, `${config.fontName}.${config.template}`);
-  }
+  return dest;
+};
 
-  if (typeof config.template === "string") {
-    return path.join(destTemplate, path.basename(config.template).replace(".njk", ""));
-  }
+export const writeRenderedTemplates = async (
+  templates: readonly RenderedTemplate[],
+  config: ResultConfig,
+): Promise<void> => {
+  await Promise.all(
+    templates.map(async (entry) => {
+      const file = path.resolve(resolveTemplateOutputPath(entry.template, config, Boolean(entry.builtIn)));
 
-  return destTemplate;
+      await fs.promises.mkdir(path.dirname(file), { recursive: true });
+      await fs.promises.writeFile(file, entry.content);
+    }),
+  );
 };
 
 export const getResultOutputPath = (
@@ -343,6 +384,10 @@ export const writeResultFiles = async (result: Result): Promise<Result> => {
 
   await ensureDestExists(dest, config.destCreate);
 
+  if (result.templates && result.templates.length > 0) {
+    await writeRenderedTemplates(result.templates, config);
+  }
+
   if (result.transcodedFonts && result.transcodedFonts.length > 1) {
     await writeTranscodedFontFiles(result.transcodedFonts, config, dest);
     return result;
@@ -355,7 +400,13 @@ export const writeResultFiles = async (result: Result): Promise<Result> => {
 
   await Promise.all(
     resultFileKeys
-      .filter((type) => result[type] !== undefined)
+      .filter((type) => {
+        if (type === "template" && result.templates && result.templates.length > 0) {
+          return false;
+        }
+
+        return result[type] !== undefined;
+      })
       .map(async (type) => {
         const content = result[type];
 

--- a/src/lib/parseTemplateOption.test.ts
+++ b/src/lib/parseTemplateOption.test.ts
@@ -1,0 +1,21 @@
+import { normalizeTemplateOption } from "./parseTemplateOption";
+
+describe("normalizeTemplateOption", () => {
+  it("should accept a single template name", () => {
+    expect(normalizeTemplateOption("css")).toEqual(["css"]);
+  });
+
+  it("should accept multiple template names (#158)", () => {
+    expect(normalizeTemplateOption(["html", "scss"])).toEqual(["html", "scss"]);
+  });
+
+  it("should reject empty template arrays", () => {
+    expect(() => normalizeTemplateOption([])).toThrow("template must not be empty");
+  });
+
+  it("should reject non-string template entries", () => {
+    expect(() => normalizeTemplateOption(["css", 1 as never])).toThrow(
+      "template must be a string or an array of non-empty strings",
+    );
+  });
+});

--- a/src/lib/parseTemplateOption.ts
+++ b/src/lib/parseTemplateOption.ts
@@ -1,0 +1,31 @@
+export type TemplateOption = string | string[];
+
+export const normalizeTemplateOption = (template: unknown): string[] => {
+  if (template === undefined || template === null) {
+    return [];
+  }
+
+  if (typeof template === "string") {
+    const trimmed = template.trim();
+
+    if (trimmed.length === 0) {
+      throw new Error("template must not be empty");
+    }
+
+    return [trimmed];
+  }
+
+  if (Array.isArray(template)) {
+    if (template.length === 0) {
+      throw new Error("template must not be empty");
+    }
+
+    if (!template.every((entry) => typeof entry === "string" && entry.trim().length > 0)) {
+      throw new Error("template must be a string or an array of non-empty strings");
+    }
+
+    return template.map((entry) => entry.trim());
+  }
+
+  throw new Error("template must be a string or an array of strings");
+};

--- a/src/standalone/index.test.ts
+++ b/src/standalone/index.test.ts
@@ -421,6 +421,22 @@ describe("standalone", () => {
     expect(result.template).toMatchSnapshot();
   });
 
+  it("should generate multiple built-in templates (#158)", async () => {
+    const result = await standalone({
+      files: `${fixturesGlob}/svg-icons/**/*`,
+      formats: ["woff2"],
+      template: ["html", "scss"],
+      templateCacheString: "test",
+    });
+
+    expect(result.templates).toHaveLength(2);
+    expect(result.templates?.[0]?.builtIn).toBe("html");
+    expect(result.templates?.[1]?.builtIn).toBe("scss");
+    expect(result.template).toBe(result.templates?.[0]?.content);
+    expect(result.templates?.[0]?.content).toContain("<!doctype html>");
+    expect(result.templates?.[1]?.content).toContain("$webfont-");
+  });
+
   it("should generate built-in html template", async () => {
     const result = await standalone({
       files: `${fixturesGlob}/svg-icons/**/*`,

--- a/src/standalone/index.ts
+++ b/src/standalone/index.ts
@@ -1,14 +1,12 @@
 import { cosmiconfig } from "cosmiconfig";
 import crypto from "crypto";
 import deepmerge from "deepmerge";
-import nunjucks from "nunjucks";
 import path from "path";
 import { Readable } from "stream";
-import { getBuiltInTemplates, getTemplateFilePath } from "../../templates";
 import { resolveInputSources } from "../lib/inputSource";
 import { getFontStreamOptions, SVGIcons2SVGFontStream } from "../lib/svgicons2svgfont";
 import { encodeTtfToEot, encodeTtfToWoff, encodeTtfToWoff2 } from "../lib/ttfEncode";
-import type { Format, GlyphData, GlyphMetadata, InitialOptions, WebfontOptions } from "../types";
+import type { GlyphData, GlyphMetadata, InitialOptions, WebfontOptions } from "../types";
 import type { Result } from "../types/Result";
 import type { ResultConfig } from "../types/ResultConfig";
 import { convertTtfInput } from "./convertTtfInput";
@@ -16,7 +14,7 @@ import { convertWebfontInput } from "./convertWebfontInput";
 import { getGlyphsData } from "./glyphsData";
 import { assertSvgPipelineFormats, classifyInputFiles, filterInputFilesByMode } from "./inputMode";
 import { getOptions } from "./options";
-import { getTemplateFontBase64 } from "./templateFonts";
+import { renderTemplates } from "./renderTemplates";
 import toTtf from "./toTtf";
 import { validateWebfontOptions } from "./validateWebfontOptions";
 
@@ -215,49 +213,13 @@ export const webfont: Webfont = async (initialOptions) => {
   }
 
   if (options.template) {
-    const builtInTemplates = getBuiltInTemplates();
+    const { templates, usedBuildInTemplate } = renderTemplates(options, result, formats);
 
-    let templateFilePath: string;
-
-    if (Object.keys(builtInTemplates).includes(options.template)) {
-      result.usedBuildInTemplate = true;
-
-      const builtInPath = path.resolve(__dirname, "../..");
-      nunjucks.configure(builtInPath);
-      templateFilePath = getTemplateFilePath(options.template);
-    } else {
-      const resolvedTemplateFilePath = path.resolve(options.template);
-
-      nunjucks.configure(path.dirname(resolvedTemplateFilePath));
-      templateFilePath = path.resolve(resolvedTemplateFilePath);
+    if (templates.length > 0) {
+      result.templates = templates;
+      result.template = templates[0]?.content;
+      result.usedBuildInTemplate = usedBuildInTemplate;
     }
-
-    let hashOption = {};
-
-    if (options.addHashInFontUrl) {
-      hashOption = { hash: result.hash };
-    }
-
-    const nunjucksOptions = deepmerge.all([
-      {
-        glyphs: result.glyphsData?.map((glyph: GlyphData) => glyph.metadata) ?? [],
-      },
-      options,
-      {
-        cacheString: options.templateCacheString || Date.now(),
-        className: options.templateClassName || options.fontName,
-        fontName: options.templateFontName || options.fontName,
-        fontPath: options.templateFontPath.replace(/\/?$/u, "/"),
-      },
-      hashOption,
-      {
-        fonts: Object.fromEntries(
-          new Map(formats.map((format: Format) => [format, () => getTemplateFontBase64(format, result)])),
-        ),
-      },
-    ]);
-
-    result.template = nunjucks.render(templateFilePath, nunjucksOptions);
   }
 
   if (!formats.includes("svg")) {

--- a/src/standalone/renderTemplates.ts
+++ b/src/standalone/renderTemplates.ts
@@ -1,0 +1,84 @@
+import deepmerge from "deepmerge";
+import nunjucks from "nunjucks";
+import path from "path";
+import { getBuiltInTemplates, getTemplateFilePath } from "../../templates";
+import { normalizeTemplateOption } from "../lib/parseTemplateOption";
+import type { Format } from "../types/Format";
+import type { GlyphData } from "../types/GlyphData";
+import type { RenderedTemplate } from "../types/RenderedTemplate";
+import type { Result } from "../types/Result";
+import type { WebfontOptions } from "../types/WebfontOptions";
+import { getTemplateFontBase64 } from "./templateFonts";
+
+type RenderTemplatesResult = {
+  templates: RenderedTemplate[];
+  usedBuildInTemplate: boolean;
+};
+
+export const renderTemplates = (
+  options: WebfontOptions,
+  result: Pick<Result, "glyphsData" | "hash"> & Partial<Result>,
+  formats: readonly Format[],
+): RenderTemplatesResult => {
+  const templateNames = normalizeTemplateOption(options.template);
+
+  if (templateNames.length === 0) {
+    return { templates: [], usedBuildInTemplate: false };
+  }
+
+  const builtInTemplates = getBuiltInTemplates();
+  const renderedTemplates: RenderedTemplate[] = [];
+  let usedBuildInTemplate = false;
+
+  let hashOption = {};
+
+  if (options.addHashInFontUrl) {
+    hashOption = { hash: result.hash };
+  }
+
+  const nunjucksBaseOptions = deepmerge.all([
+    {
+      glyphs: result.glyphsData?.map((glyph: GlyphData) => glyph.metadata) ?? [],
+    },
+    options,
+    {
+      cacheString: options.templateCacheString || Date.now(),
+      className: options.templateClassName || options.fontName,
+      fontName: options.templateFontName || options.fontName,
+      fontPath: options.templateFontPath.replace(/\/?$/u, "/"),
+    },
+    hashOption,
+    {
+      fonts: Object.fromEntries(
+        new Map(formats.map((format: Format) => [format, () => getTemplateFontBase64(format, result)])),
+      ),
+    },
+  ]);
+
+  for (const templateName of templateNames) {
+    let templateFilePath: string;
+    let builtIn: string | undefined;
+
+    if (Object.keys(builtInTemplates).includes(templateName)) {
+      usedBuildInTemplate = true;
+      builtIn = templateName;
+
+      const builtInPath = path.resolve(__dirname, "../..");
+      nunjucks.configure(builtInPath);
+      templateFilePath = getTemplateFilePath(templateName);
+    } else {
+      const resolvedTemplateFilePath = path.resolve(templateName);
+
+      nunjucks.configure(path.dirname(resolvedTemplateFilePath));
+      templateFilePath = path.resolve(resolvedTemplateFilePath);
+    }
+
+    renderedTemplates.push({
+      template: templateName,
+      content: nunjucks.render(templateFilePath, nunjucksBaseOptions),
+      builtIn,
+    });
+  }
+
+  return { templates: renderedTemplates, usedBuildInTemplate };
+};

--- a/src/standalone/validateWebfontOptions.test.ts
+++ b/src/standalone/validateWebfontOptions.test.ts
@@ -72,4 +72,13 @@ describe("validateWebfontOptions", () => {
       }),
     ).toThrow("fontName must be a string");
   });
+
+  it("should accept template as an array (#158)", () => {
+    expect(
+      validateWebfontOptions({
+        ...baseOptions(),
+        template: ["html", "scss"],
+      }).template,
+    ).toEqual(["html", "scss"]);
+  });
 });

--- a/src/standalone/validateWebfontOptions.ts
+++ b/src/standalone/validateWebfontOptions.ts
@@ -1,4 +1,5 @@
 import { assertFormatsOption } from "../lib/parseFormats";
+import { normalizeTemplateOption } from "../lib/parseTemplateOption";
 import type { WebfontOptions } from "../types/WebfontOptions";
 
 const assertStringOption = (name: string, value: unknown): void => {
@@ -39,7 +40,9 @@ export const validateWebfontOptions = (options: WebfontOptions): WebfontOptions 
   assertFilesOption(options.files);
   options.formats = assertFormatsOption(options.formats);
   assertStringOption("fontName", options.fontName);
-  assertStringOption("template", options.template);
+  if (options.template !== undefined) {
+    normalizeTemplateOption(options.template);
+  }
   assertStringOption("templateFontPath", options.templateFontPath);
 
   return options;

--- a/src/types/OptionsBase.ts
+++ b/src/types/OptionsBase.ts
@@ -1,3 +1,4 @@
+import type { TemplateOption } from "../lib/parseTemplateOption";
 import type { Formats } from "./Format";
 
 export type OptionsBase = {
@@ -6,7 +7,7 @@ export type OptionsBase = {
   destCreate?: boolean;
   fontName?: string | unknown;
   formats?: Formats;
-  template?: "css" | string;
+  template?: TemplateOption;
   templateClassName?: string | unknown;
   templateFontPath?: string;
   templateFontName?: string | unknown;

--- a/src/types/RenderedTemplate.ts
+++ b/src/types/RenderedTemplate.ts
@@ -1,0 +1,7 @@
+export type RenderedTemplate = {
+  /** Original template option (built-in name or custom path). */
+  template: string;
+  content: string;
+  /** Built-in template id when applicable (css, html, scss, …). */
+  builtIn?: string;
+};

--- a/src/types/Result.ts
+++ b/src/types/Result.ts
@@ -1,5 +1,6 @@
 import type { DecompressedFont } from "./DecompressedFont";
 import type { GlyphData } from "./GlyphData";
+import type { RenderedTemplate } from "./RenderedTemplate";
 import type { ResultConfig } from "./ResultConfig";
 import type { TranscodedFont } from "./TranscodedFont";
 
@@ -16,6 +17,7 @@ export type Result = {
   otf?: Buffer;
   svg?: string | Buffer;
   template?: string;
+  templates?: RenderedTemplate[];
   ttf?: Buffer;
   usedBuildInTemplate?: boolean;
   woff?: Buffer;

--- a/src/types/WebfontOptions.ts
+++ b/src/types/WebfontOptions.ts
@@ -1,3 +1,4 @@
+import type { TemplateOption } from "../lib/parseTemplateOption";
 import type { Formats, FormatsOptions } from "./Format";
 import type { GlyphContentTransformFn } from "./GlyphContentTransformFn";
 import type { GlyphTransformFn } from "./GlyphTransformFn";
@@ -26,7 +27,7 @@ export interface WebfontOptions extends InitialOptions {
   round: string | number;
   sort: boolean;
   startUnicode: number;
-  template?: string;
+  template?: TemplateOption;
   templateCacheString?: unknown;
   templateClassName?: unknown;
   templateFontName?: unknown;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,4 +1,4 @@
-export type { Format } from "../types/Format";
+export type { Format, FormatsOptions } from "../types/Format";
 export type { GlyphContentTransformFn } from "./GlyphContentTransformFn";
 export type { GlyphData } from "./GlyphData";
 export type { GlyphMetadata } from "./GlyphMetadata";


### PR DESCRIPTION
## Summary

### Proposed changes

This PR brings the following changes:

- Accept `template` as a `string` or `string[]` (API, cosmiconfig, CLI).
- Add `result.templates` with each rendered output; keep `result.template` as the first entry for backward compatibility.
- Parse CLI `-t` / `--template` as JSON array or comma-separated list (`html,scss`).
- Write multiple template files in the CLI (`webfont.html`, `webfont.scss`, …).

### Related issue

Closes #158

### Dependencies added/removed (if applicable)

N/A

---

### Testing

- [x] I have added or updated tests that prove my fix is effective or that my feature works (if applicable)
  - [x] Unit test

#### How to test

1. Run `npm test`.
2. `webfont({ files: 'icons/*.svg', template: ['html', 'scss'] })` — check `result.templates` length and contents.
3. CLI: `webfont 'icons/*.svg' -d out -t '["html","scss"]'` — verify `out/webfont.html` and `out/webfont.scss`.

#### Test configuration

N/A

---

## Checklist

- [x] I have added corresponding labels to this PR (like bug, enhancement...);
- [x] My commits follow the [Conventional Commits 1.0 Guidelines](https://www.conventionalcommits.org/en/v1.0.0/);
- [x] My code follows the style guidelines of this project;
- [x] I have performed a self-review of my own code;
- [x] I have mapped technical debts found on my changes;
- [x] I have made changes to the documentation (if applicable);
- [x] My changes generate no new warnings or errors;

Made with [Cursor](https://cursor.com)