### PR TITLE
feat(templates): add unicode-range to built-in @font-face (#322)

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -115,10 +115,12 @@ Canonical list of product capabilities. **Update this file in the same PR** when
   - SVG pipeline only (not webfont decompression or TTF encoding mode).
   - `templateCacheString`: manual query string on font URLs (default `Date.now()`).
   - `addHashInFontUrl`: append MD5 `&v=<hash>` from SVG font content; **filenames stay** `fontName.*` ([#125](https://github.com/itgalaxy/webfont/issues/125)).
+  - `unicodeRange`: emit `unicode-range` in built-in `@font-face` from glyph code points (default on); `--no-unicode-range` or `unicodeRange: false` to omit ([#322](https://github.com/itgalaxy/webfont/issues/322)).
 - **Test Criteria**:
   - [x] Built-in `css` template snapshot / integration coverage
   - [x] Subset `formats` with template omits unused format URLs
   - [x] `addHashInFontUrl` on `css` and `scss` templates appends content hash to URLs
+  - [x] `unicodeRange` adds computed `U+<min>-<max>` to built-in templates; `false` omits it
 
 ### Command-line interface (CLI)
 

--- a/README.md
+++ b/README.md
@@ -299,6 +299,14 @@ await webfont({
 
 Do **not** use `Math.random()` in `fontName` — that renames both font files and the stylesheet on every run.
 
+#### `unicodeRange`
+
+- Type: `boolean | string`
+- Default: `true` (auto-computed from glyph code points)
+- Description: When a built-in `template` is used, emit a `unicode-range` declaration in `@font-face` so the browser can load only the icon font that owns the code points on the page. With the default `startUnicode` (`0xEA01`), the range is derived from the minimum and maximum allocated code points (for example `U+EA01-EA03`). Set to `false` to omit the rule, or pass a CSS value string (for example `U+EA01-EAFF`) to override the computed range.
+- CLI: `--no-unicode-range` to disable
+- Helps when multiple icon fonts share a page ([#322](https://github.com/itgalaxy/webfont/issues/322)).
+
 #### `ligatures`
 
 - Type: `boolean`

--- a/src/cli/__snapshots__/index.test.ts.snap
+++ b/src/cli/__snapshots__/index.test.ts.snap
@@ -6,6 +6,9 @@ exports[`cli > short options > should set destTemplate with -s 1`] = `
   font-family: "webfont";
   font-style: normal;
   font-weight: 400;
+  
+  unicode-range: U+EA01-EA03;
+  
   src: url("./webfont.eot?test");
   src: url("./webfont.eot?#iefix") format("embedded-opentype"), url("./webfont.woff2?test") format("woff2"), url("./webfont.woff?test") format("woff"), url("./webfont.ttf?test") format("truetype"), url("./webfont.svg?test#webfont") format("svg");
 }
@@ -125,6 +128,9 @@ exports[`cli > should generate all fonts with build-in template 1`] = `
   font-family: "webfont";
   font-style: normal;
   font-weight: 400;
+  
+  unicode-range: U+EA01-EA03;
+  
   src: url("./webfont.eot?test");
   src: url("./webfont.eot?#iefix") format("embedded-opentype"), url("./webfont.woff2?test") format("woff2"), url("./webfont.woff?test") format("woff"), url("./webfont.ttf?test") format("truetype"), url("./webfont.svg?test#webfont") format("svg");
 }
@@ -292,6 +298,9 @@ exports[`cli > should generate built-in html template 1`] = `
         font-family: "webfont";
         font-style: normal;
         font-weight: 400;
+        
+        unicode-range: U+EA01-EA03;
+        
         src: url("./webfont.eot?test");
         src: url("./webfont.eot?#iefix") format("embedded-opentype"), url("./webfont.woff2?test") format("woff2"), url("./webfont.woff?test") format("woff"), url("./webfont.ttf?test") format("truetype"), url("./webfont.svg?test#webfont") format("svg");
       }
@@ -455,6 +464,9 @@ exports[`cli > should include font hash in template when addHashInFontUrl is ena
   font-family: "webfont";
   font-style: normal;
   font-weight: 400;
+  
+  unicode-range: U+EA01-EA03;
+  
   src: url("./webfont.eot?test&v=1154313a3843c5f5ec70890715e8a527");
   src: url("./webfont.eot?v=1154313a3843c5f5ec70890715e8a527#iefix") format("embedded-opentype"), url("./webfont.woff2?test&v=1154313a3843c5f5ec70890715e8a527") format("woff2"), url("./webfont.woff?test&v=1154313a3843c5f5ec70890715e8a527") format("woff"), url("./webfont.ttf?test&v=1154313a3843c5f5ec70890715e8a527") format("truetype"), url("./webfont.svg?test&v=1154313a3843c5f5ec70890715e8a527#webfont") format("svg");
 }
@@ -610,6 +622,9 @@ exports[`cli > should respect \`template\` options 1`] = `
   font-family: "testname";
   font-style: normal;
   font-weight: 400;
+  
+  unicode-range: U+EA01-EA03;
+  
   src: url("test/path/testname.eot?test");
   src: url("test/path/testname.eot?#iefix") format("embedded-opentype"), url("test/path/testname.woff2?test") format("woff2"), url("test/path/testname.woff?test") format("woff"), url("test/path/testname.ttf?test") format("truetype"), url("test/path/testname.svg?test#testname") format("svg");
 }

--- a/src/cli/index.test.ts
+++ b/src/cli/index.test.ts
@@ -428,6 +428,29 @@ describe("cli", () => {
     expect(scss).toContain('url("./webfont.woff2?');
   });
 
+  it("should include unicode-range in css template by default (#322)", async () => {
+    const output = await execCLI(
+      `${source} -d ${destination} --template css --templateCacheString test --formats woff2`,
+    );
+
+    expect(output.files).toEqual(["webfont.css", "webfont.woff2"]);
+    expect(output.code).toBe(0);
+    expect(output.stderr).toBe("");
+    const css = await fsPromise.readFile(`${destination}/webfont.css`, { encoding: "utf-8" });
+    expect(css).toContain("unicode-range: U+EA01-EA03;");
+  });
+
+  it("should omit unicode-range when --no-unicode-range is passed", async () => {
+    const output = await execCLI(
+      `${source} -d ${destination} --template css --templateCacheString test --formats woff2 --no-unicode-range`,
+    );
+
+    expect(output.code).toBe(0);
+    expect(output.stderr).toBe("");
+    const css = await fsPromise.readFile(`${destination}/webfont.css`, { encoding: "utf-8" });
+    expect(css).not.toContain("unicode-range:");
+  });
+
   it("should set font name", async () => {
     const output = await execCLI(`${source} -d ${destination} --fontName foobar`);
 

--- a/src/cli/meow/cliOptions.ts
+++ b/src/cli/meow/cliOptions.ts
@@ -6,6 +6,7 @@ export const WEBFONT_CLI_HELP_MARKERS = [
   "--dest-create",
   "--no-sort",
   "--no-ligatures",
+  "--no-unicode-range",
   "--addHashInFontUrl",
   "svg-diagnose",
 ] as const;
@@ -96,6 +97,10 @@ export const webfontCliHelpText = `
         --no-ligatures
 
             Prevents adding ligature unicode
+
+        --no-unicode-range
+
+            Omit unicode-range from built-in @font-face rules
 
         --verbose
 
@@ -267,6 +272,10 @@ export const webfontMeowFlags = {
   templateCacheString: {
     default: "",
     type: "string",
+  },
+  unicodeRange: {
+    default: true,
+    type: "boolean",
   },
   verbose: {
     default: false,

--- a/src/cli/meow/index.test.ts
+++ b/src/cli/meow/index.test.ts
@@ -32,6 +32,7 @@ const PROGRAM_CLI_FLAG_KEYS = [
   "templateClassName",
   "templateFontName",
   "templateFontPath",
+  "unicodeRange",
   "verbose",
   "svgDiagnose",
   "version",
@@ -90,22 +91,24 @@ describe("cli/meow", () => {
       expect(createMeowCli(["-v"]).flags.version).toBe(true);
     });
 
-    it("should apply boolean defaults for sort, ligatures, verbose, destCreate, and addHashInFontUrl", () => {
+    it("should apply boolean defaults for sort, ligatures, unicodeRange, verbose, destCreate, and addHashInFontUrl", () => {
       const cli = createMeowCli(["input.svg"]);
 
       expect(cli.flags.sort).toBe(true);
       expect(cli.flags.ligatures).toBe(true);
+      expect(cli.flags.unicodeRange).toBe(true);
       expect(cli.flags.verbose).toBe(false);
       expect(cli.flags.destCreate).toBe(false);
       expect(cli.flags.addHashInFontUrl).toBe(false);
       expect(cli.flags.templateCacheString).toBe("");
     });
 
-    it("should parse --no-sort and --no-ligatures negated booleans", () => {
-      const cli = createMeowCli(["input.svg", "--no-sort", "--no-ligatures"]);
+    it("should parse --no-sort, --no-ligatures, and --no-unicode-range negated booleans", () => {
+      const cli = createMeowCli(["input.svg", "--no-sort", "--no-ligatures", "--no-unicode-range"]);
 
       expect(cli.flags.sort).toBe(false);
       expect(cli.flags.ligatures).toBe(false);
+      expect(cli.flags.unicodeRange).toBe(false);
     });
 
     it("should parse short aliases for common flags", () => {
@@ -254,6 +257,7 @@ describe("cli/meow", () => {
           "meta",
           "--no-sort",
           "--no-ligatures",
+          "--no-unicode-range",
           "--addHashInFontUrl",
           "--config",
           "webfont.config.js",
@@ -286,6 +290,7 @@ describe("cli/meow", () => {
       expect(options.metadata).toBe("meta");
       expect(options.sort).toBe(false);
       expect(options.ligatures).toBe(false);
+      expect(options.unicodeRange).toBe(false);
       expect(options.addHashInFontUrl).toBe(true);
       expect(options.configFile).toContain("webfont.config.js");
     });

--- a/src/cli/program.ts
+++ b/src/cli/program.ts
@@ -39,6 +39,7 @@ export type CliLike = {
     round?: string;
     sort?: boolean;
     startUnicode?: string;
+    unicodeRange?: boolean;
     template?: string;
     templateCacheString?: string;
     templateClassName?: string;
@@ -167,6 +168,10 @@ export const buildOptionsBase = (cli: CliLike): OptionsBase => {
 
   if (cli.flags.ligatures === false) {
     optionsBase.ligatures = cli.flags.ligatures;
+  }
+
+  if (cli.flags.unicodeRange === false) {
+    optionsBase.unicodeRange = cli.flags.unicodeRange;
   }
 
   if (cli.flags.addHashInFontUrl) {

--- a/src/lib/templateUnicodeRange.test.ts
+++ b/src/lib/templateUnicodeRange.test.ts
@@ -1,0 +1,38 @@
+import {
+  collectCodePointsFromGlyphs,
+  computeUnicodeRangeFromGlyphs,
+  resolveTemplateUnicodeRange,
+} from "./templateUnicodeRange";
+
+describe("templateUnicodeRange", () => {
+  const glyphsWithLigatures = [
+    { unicode: [String.fromCodePoint(0xea01), "avatar"] },
+    { unicode: [String.fromCodePoint(0xea02), "envelope"] },
+    { unicode: [String.fromCodePoint(0xea03), "phone_call"] },
+  ];
+
+  it("should collect icon code points and ignore ligature names", () => {
+    expect(collectCodePointsFromGlyphs(glyphsWithLigatures)).toEqual([0xea01, 0xea02, 0xea03]);
+  });
+
+  it("should format a min-max unicode-range from glyphs", () => {
+    expect(computeUnicodeRangeFromGlyphs(glyphsWithLigatures)).toBe("U+EA01-EA03");
+  });
+
+  it("should format a single-codepoint unicode-range", () => {
+    expect(computeUnicodeRangeFromGlyphs([{ unicode: [String.fromCodePoint(0xea01)] }])).toBe("U+EA01");
+  });
+
+  it("should resolve auto unicode-range by default", () => {
+    expect(resolveTemplateUnicodeRange(undefined, glyphsWithLigatures)).toBe("U+EA01-EA03");
+    expect(resolveTemplateUnicodeRange(true, glyphsWithLigatures)).toBe("U+EA01-EA03");
+  });
+
+  it("should omit unicode-range when disabled", () => {
+    expect(resolveTemplateUnicodeRange(false, glyphsWithLigatures)).toBeUndefined();
+  });
+
+  it("should use a manual unicode-range override", () => {
+    expect(resolveTemplateUnicodeRange("U+EA01-EAFF", glyphsWithLigatures)).toBe("U+EA01-EAFF");
+  });
+});

--- a/src/lib/templateUnicodeRange.ts
+++ b/src/lib/templateUnicodeRange.ts
@@ -1,0 +1,80 @@
+import type { GlyphMetadata } from "../types/GlyphMetadata";
+
+const formatCodePoint = (codePoint: number): string => {
+  let width = 4;
+
+  if (codePoint > 0xffff) {
+    width = 6;
+  }
+
+  return codePoint.toString(16).toUpperCase().padStart(width, "0");
+};
+
+const codePointFromUnicodeEntry = (value: string): number | undefined => {
+  if (value.length === 0 || value.length > 2) {
+    return undefined;
+  }
+
+  const codePoint = value.codePointAt(0);
+
+  if (codePoint === undefined) {
+    return undefined;
+  }
+
+  // Ligature names are multi-code-unit ASCII identifiers (for example "avatar").
+  if (value.length > 1 && codePoint < 0x80) {
+    return undefined;
+  }
+
+  return codePoint;
+};
+
+export const collectCodePointsFromGlyphs = (glyphs: readonly Pick<GlyphMetadata, "unicode">[]): number[] => {
+  const codePoints: number[] = [];
+
+  for (const glyph of glyphs) {
+    for (const entry of glyph.unicode ?? []) {
+      const codePoint = codePointFromUnicodeEntry(entry);
+
+      if (codePoint !== undefined) {
+        codePoints.push(codePoint);
+      }
+    }
+  }
+
+  return codePoints;
+};
+
+export const computeUnicodeRangeFromGlyphs = (
+  glyphs: readonly Pick<GlyphMetadata, "unicode">[],
+): string | undefined => {
+  const codePoints = collectCodePointsFromGlyphs(glyphs);
+
+  if (codePoints.length === 0) {
+    return undefined;
+  }
+
+  const min = Math.min(...codePoints);
+  const max = Math.max(...codePoints);
+
+  if (min === max) {
+    return `U+${formatCodePoint(min)}`;
+  }
+
+  return `U+${formatCodePoint(min)}-${formatCodePoint(max)}`;
+};
+
+export const resolveTemplateUnicodeRange = (
+  unicodeRange: boolean | string | undefined,
+  glyphs: readonly Pick<GlyphMetadata, "unicode">[],
+): string | undefined => {
+  if (unicodeRange === false) {
+    return undefined;
+  }
+
+  if (typeof unicodeRange === "string") {
+    return unicodeRange;
+  }
+
+  return computeUnicodeRangeFromGlyphs(glyphs);
+};

--- a/src/standalone/__snapshots__/index.test.ts.snap
+++ b/src/standalone/__snapshots__/index.test.ts.snap
@@ -6,6 +6,9 @@ exports[`standalone > should change unicode symbols in the result using async fu
   font-family: "webfont";
   font-style: normal;
   font-weight: 400;
+  
+  unicode-range: U+0001;
+  
   src: url("./webfont.eot?test");
   src: url("./webfont.eot?#iefix") format("embedded-opentype"); 
 }
@@ -125,6 +128,9 @@ exports[`standalone > should change unicode symbols in the result using sync fun
   font-family: "webfont";
   font-style: normal;
   font-weight: 400;
+  
+  unicode-range: U+0001;
+  
   src: url("./webfont.eot?test");
   src: url("./webfont.eot?#iefix") format("embedded-opentype"); 
 }
@@ -244,6 +250,9 @@ exports[`standalone > should create css selectors with transform titles through 
   font-family: "webfont";
   font-style: normal;
   font-weight: 400;
+  
+  unicode-range: U+EA01-EA03;
+  
   src: url("./webfont.eot?test");
   src: url("./webfont.eot?#iefix") format("embedded-opentype"); 
 }
@@ -363,6 +372,9 @@ exports[`standalone > should generate all fonts with build-in template 1`] = `
   font-family: "webfont";
   font-style: normal;
   font-weight: 400;
+  
+  unicode-range: U+EA01-EA03;
+  
   src: url("./webfont.eot?test");
   src: url("./webfont.eot?#iefix") format("embedded-opentype"), url("./webfont.woff2?test") format("woff2"), url("./webfont.woff?test") format("woff"), url("./webfont.ttf?test") format("truetype"), url("./webfont.svg?test#webfont") format("svg");
 }
@@ -662,6 +674,9 @@ exports[`standalone > should generate built-in html template 1`] = `
         font-family: "webfont";
         font-style: normal;
         font-weight: 400;
+        
+        unicode-range: U+EA01-EA03;
+        
         src: url("./webfont.eot?test");
         src: url("./webfont.eot?#iefix") format("embedded-opentype"), url("./webfont.woff2?test") format("woff2"), url("./webfont.woff?test") format("woff"), url("./webfont.ttf?test") format("truetype"), url("./webfont.svg?test#webfont") format("svg");
       }
@@ -875,6 +890,9 @@ $webfont-phone-call = "\\ea03";
 
 @font-face {
     font-family: webfont;
+    
+    unicode-range: U+EA01-EA03;
+    
     src: url("./webfont.eot");
     src: url("./webfont.eot?#iefix") format("embedded-opentype"), url("./webfont.woff2") format("woff2"), url("./webfont.woff") format("woff"), url("./webfont.ttf") format("truetype"), url("./webfont.svg#webfont") format("svg");
     font-display: block;
@@ -939,6 +957,9 @@ exports[`standalone > should generate only \`woff\` and \`woff2\` fonts with bui
   font-family: "webfont";
   font-style: normal;
   font-weight: 400;
+  
+  unicode-range: U+EA01-EA03;
+  
   
   src: url("./webfont.woff2?test") format("woff2"), url("./webfont.woff?test") format("woff"); 
 }
@@ -1058,6 +1079,9 @@ exports[`standalone > should include font hash in template URLs when addHashInFo
   font-family: "webfont";
   font-style: normal;
   font-weight: 400;
+  
+  unicode-range: U+EA01-EA03;
+  
   
   src: url("./webfont.woff2?test&v=1154313a3843c5f5ec70890715e8a527") format("woff2"); 
 }
@@ -1185,6 +1209,9 @@ exports[`standalone > should load config and respect \`template\` option with bu
   font-family: "webfont";
   font-style: normal;
   font-weight: 400;
+  
+  unicode-range: U+EA01-EA03;
+  
   src: url("./webfont.eot?test");
   src: url("./webfont.eot?#iefix") format("embedded-opentype"), url("./webfont.woff2?test") format("woff2"), url("./webfont.woff?test") format("woff"), url("./webfont.ttf?test") format("truetype"), url("./webfont.svg?test#webfont") format("svg");
 }
@@ -1374,6 +1401,9 @@ exports[`standalone > should respect \`template\` options 1`] = `
   font-family: "bar";
   font-style: normal;
   font-weight: 400;
+  
+  unicode-range: U+EA01-EA03;
+  
   src: url("./foo-bar/bar.eot?test");
   src: url("./foo-bar/bar.eot?#iefix") format("embedded-opentype"), url("./foo-bar/bar.woff2?test") format("woff2"), url("./foo-bar/bar.woff?test") format("woff"), url("./foo-bar/bar.ttf?test") format("truetype"), url("./foo-bar/bar.svg?test#bar") format("svg");
 }

--- a/src/standalone/index.test.ts
+++ b/src/standalone/index.test.ts
@@ -519,6 +519,41 @@ describe("standalone", () => {
     expect(result.template).toMatchSnapshot();
   });
 
+  it("should include unicode-range in built-in templates by default (#322)", async () => {
+    const result = await standalone({
+      files: `${fixturesGlob}/svg-icons/**/*`,
+      template: "css",
+      templateCacheString: "test",
+      formats: ["woff2"],
+    });
+
+    expect(result.template).toContain("unicode-range: U+EA01-EA03;");
+  });
+
+  it("should omit unicode-range when unicodeRange is false", async () => {
+    const result = await standalone({
+      files: `${fixturesGlob}/svg-icons/**/*`,
+      template: "css",
+      templateCacheString: "test",
+      formats: ["woff2"],
+      unicodeRange: false,
+    });
+
+    expect(result.template).not.toContain("unicode-range:");
+  });
+
+  it("should use a manual unicode-range override", async () => {
+    const result = await standalone({
+      files: `${fixturesGlob}/svg-icons/**/*`,
+      template: "css",
+      templateCacheString: "test",
+      formats: ["woff2"],
+      unicodeRange: "U+EA01-EAFF",
+    });
+
+    expect(result.template).toContain("unicode-range: U+EA01-EAFF;");
+  });
+
   it("should export `glyphsData` in `result`", async () => {
     const result = await standalone({
       files: `${fixturesGlob}/svg-icons/**/*`,

--- a/src/standalone/renderTemplates.ts
+++ b/src/standalone/renderTemplates.ts
@@ -3,8 +3,10 @@ import nunjucks from "nunjucks";
 import path from "path";
 import { getBuiltInTemplates, getTemplateFilePath } from "../../templates";
 import { normalizeTemplateOption } from "../lib/parseTemplateOption";
+import { resolveTemplateUnicodeRange } from "../lib/templateUnicodeRange";
 import type { Format } from "../types/Format";
 import type { GlyphData } from "../types/GlyphData";
+import type { GlyphMetadata } from "../types/GlyphMetadata";
 import type { RenderedTemplate } from "../types/RenderedTemplate";
 import type { Result } from "../types/Result";
 import type { WebfontOptions } from "../types/WebfontOptions";
@@ -36,9 +38,14 @@ export const renderTemplates = (
     hashOption = { hash: result.hash };
   }
 
+  const glyphs =
+    result.glyphsData
+      ?.map((glyph: GlyphData) => glyph.metadata)
+      .filter((metadata): metadata is GlyphMetadata => metadata !== undefined) ?? [];
+
   const nunjucksBaseOptions = deepmerge.all([
     {
-      glyphs: result.glyphsData?.map((glyph: GlyphData) => glyph.metadata) ?? [],
+      glyphs,
     },
     options,
     {
@@ -52,6 +59,9 @@ export const renderTemplates = (
       fonts: Object.fromEntries(
         new Map(formats.map((format: Format) => [format, () => getTemplateFontBase64(format, result)])),
       ),
+    },
+    {
+      unicodeRange: resolveTemplateUnicodeRange(options.unicodeRange, glyphs),
     },
   ]);
 

--- a/src/standalone/validateWebfontOptions.test.ts
+++ b/src/standalone/validateWebfontOptions.test.ts
@@ -73,6 +73,15 @@ describe("validateWebfontOptions", () => {
     ).toThrow("fontName must be a string");
   });
 
+  it("should reject invalid unicodeRange option types", () => {
+    expect(() =>
+      validateWebfontOptions({
+        ...baseOptions(),
+        unicodeRange: 123 as never,
+      }),
+    ).toThrow("unicodeRange must be a boolean or string");
+  });
+
   it("should accept template as an array (#158)", () => {
     expect(
       validateWebfontOptions({

--- a/src/standalone/validateWebfontOptions.ts
+++ b/src/standalone/validateWebfontOptions.ts
@@ -8,6 +8,12 @@ const assertStringOption = (name: string, value: unknown): void => {
   }
 };
 
+const assertBooleanOrStringOption = (name: string, value: unknown): void => {
+  if (value !== undefined && typeof value !== "boolean" && typeof value !== "string") {
+    throw new Error(`${name} must be a boolean or string`);
+  }
+};
+
 const assertFilesOption = (files: unknown): void => {
   if (typeof files === "string") {
     if (files.length === 0) {
@@ -40,6 +46,7 @@ export const validateWebfontOptions = (options: WebfontOptions): WebfontOptions 
   assertFilesOption(options.files);
   options.formats = assertFormatsOption(options.formats);
   assertStringOption("fontName", options.fontName);
+  assertBooleanOrStringOption("unicodeRange", options.unicodeRange);
   if (options.template !== undefined) {
     normalizeTemplateOption(options.template);
   }

--- a/src/types/OptionsBase.ts
+++ b/src/types/OptionsBase.ts
@@ -31,6 +31,7 @@ export type OptionsBase = {
   sort?: boolean;
   ligatures?: boolean;
   addHashInFontUrl?: boolean | unknown;
+  unicodeRange?: boolean | string | unknown;
   /** Alpha. SVG diagnostics and optional pre-conversion fixes. */
   svgTools?: SvgToolsOptions;
 };

--- a/src/types/WebfontOptions.ts
+++ b/src/types/WebfontOptions.ts
@@ -35,5 +35,6 @@ export interface WebfontOptions extends InitialOptions {
   templateFontPath: string;
   verbose: boolean;
   addHashInFontUrl?: boolean;
+  unicodeRange?: boolean | string;
   svgTools?: SvgToolsOptions;
 }

--- a/templates/template.css.njk
+++ b/templates/template.css.njk
@@ -3,6 +3,9 @@
   font-family: "{{ fontName }}";
   font-style: normal;
   font-weight: 400;
+  {% if unicodeRange %}
+  unicode-range: {{ unicodeRange }};
+  {% endif %}
   {% if formats.indexOf('eot')>-1 -%}
     src: url("{{ fontPath }}{{ fontName }}.eot?{{ cacheString }}{% if hash %}&v={{ hash }}{% endif %}");
   {%- endif %}

--- a/templates/template.html.njk
+++ b/templates/template.html.njk
@@ -51,6 +51,9 @@
         font-family: "{{ fontName }}";
         font-style: normal;
         font-weight: 400;
+        {% if unicodeRange %}
+        unicode-range: {{ unicodeRange }};
+        {% endif %}
         {% if formats.indexOf('eot')>-1 -%}
           src: url("{{ fontPath }}{{ fontName }}.eot?{{ cacheString }}{% if hash %}&v={{ hash }}{% endif %}");
         {%- endif %}

--- a/templates/template.scss.njk
+++ b/templates/template.scss.njk
@@ -7,6 +7,9 @@
   font-family: "{{ fontName }}";
   font-style: normal;
   font-weight: 400;
+  {% if unicodeRange %}
+  unicode-range: {{ unicodeRange }};
+  {% endif %}
   {% if formats.indexOf('eot')>-1 -%}
     src: url("{{ fontPath }}{{ fontName }}.eot?{{ cacheString }}{% if hash %}&v={{ hash }}{% endif %}");
   {%- endif -%}

--- a/templates/template.styl.njk
+++ b/templates/template.styl.njk
@@ -3,6 +3,9 @@
 {% endfor %}
 @font-face {
     font-family: {{ fontName }};
+    {% if unicodeRange %}
+    unicode-range: {{ unicodeRange }};
+    {% endif %}
     {% if formats.indexOf('eot')>-1 -%}
         src: url("{{ fontPath }}{{ fontName }}.eot{% if hash %}?v={{ hash }}{% endif %}");
     {%- endif -%}


### PR DESCRIPTION
## Summary

### Proposed changes

This PR brings the following changes:

- Add `unicodeRange` option (`boolean | string`, default auto-compute) and `resolveTemplateUnicodeRange` helper derived from glyph code points (ligature names excluded).
- Emit `unicode-range: U+<min>-<max>` in built-in `css`, `scss`, `styl`, and `html` `@font-face` rules when enabled.
- CLI: `--no-unicode-range` to omit the declaration; document API/CLI in README and FEATURES.
- Unit, standalone, and CLI integration tests; snapshot updates for built-in templates.

### Related issue

Closes #322

### Dependencies added/removed (if applicable)

N/A

---

### Testing

- [x] I have added or updated tests that prove my fix is effective or that my feature works (if applicable)
  - [x] Unit test
  - [x] Snapshot test

#### How to test

1. Run `npm test`.
2. Generate icons with built-in CSS: `webfont "icons/*.svg" -d dist -t css --formats woff2`.
3. Confirm `webfont.css` contains `unicode-range: U+EA01-...` matching allocated code points.
4. Run with `--no-unicode-range` and confirm the property is omitted.

#### Test configuration

N/A

---

## Checklist

- [ ] I have added corresponding labels to this PR (like bug, enhancement...);
- [x] My commits follow the [Conventional Commits 1.0 Guidelines](https://www.conventionalcommits.org/en/v1.0.0/);
- [x] My code follows the style guidelines of this project;
- [x] I have performed a self-review of my own code;
- [ ] I have mapped technical debts found on my changes;
- [x] I have made changes to the documentation (if applicable);
- [x] My changes generate no new warnings or errors;

Made with [Cursor](https://cursor.com)