### PR TITLE
fix(svg): reject empty glyph paths from stroke-only SVGs (#327)

### DIFF
--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -261,6 +261,36 @@ See also [MDN: fill-rule](https://developer.mozilla.org/en-US/docs/Web/SVG/Attri
 
 ---
 
+## Stroke-only SVGs produce blank icons
+
+### What error appeared
+
+On releases **after** the [#327](https://github.com/itgalaxy/webfont/issues/327) fix, webfont **fails the run** with a message similar to:
+
+```text
+Empty glyph path(s) in SVG font output for: wave (icons/wave.svg). Stroke-only SVGs (fill="none" with stroke) often produce empty glyphs because svgicons2svgfont does not convert strokes. ...
+```
+
+On **older releases**, the command may exit successfully but the icon is **invisible** in the browser — the font file exists, yet the glyph path is empty (`d=""`).
+
+### Why it usually happens
+
+- The SVG uses **strokes** instead of **filled paths** (`fill="none"` with `stroke`, or `<line>` / `<polyline>` elements).
+- **svgicons2svgfont** (the library that merges SVGs into a font) does **not** convert strokes to outlines. Stroke geometry is dropped, so the exported glyph has no path data.
+- Design tools and browsers still preview the SVG correctly; only the font export is affected.
+
+### Steps to try to resolve
+
+1. **Convert strokes to fills** in your design tool (Outline Stroke / Expand / Object to Path) before export.
+
+2. **Preprocess in your build** with [`glyphContentTransformFn`](./README.md#glyphcontenttransformfn) — for example [`svg-outline-stroke`](https://github.com/elrumordelaluz/outline-stroke) or [svg-fixer](https://github.com/oslllo/svg-fixer) installed in your project (see [ADR 0011](docs/adr/0011-no-svg-outline-stroke-dependency.md)).
+
+3. **Scan sources before converting:** `webfont icons/*.svg --svg-diagnose` (or `svgTools: { diagnose: true }` in the API) logs stroke-only and unsupported-element warnings without changing files.
+
+4. **Optimize with SVGO** only after strokes are outlines — SVGO alone does not fix stroke-only artwork for icon fonts.
+
+---
+
 ## Can't resolve `fs` (webpack / React / Vite client bundle)
 
 ### What error appeared

--- a/docs/migration/issue-0327-stroke-only-empty-glyphs.md
+++ b/docs/migration/issue-0327-stroke-only-empty-glyphs.md
@@ -1,0 +1,50 @@
+# Empty glyph paths for stroke-only SVGs ([#327](https://github.com/itgalaxy/webfont/issues/327))
+
+**Minimum version:** *pending*
+
+## What changed
+
+After SVG font generation, webfont checks that each `<glyph>` in the SVG font output has non-empty path data (`d`). **Stroke-only** sources that previously produced a font file with **blank** glyphs now **fail** with an explicit error and TROUBLESHOOTING guidance.
+
+## Before
+
+`webfont icons/wave.svg` could exit `0` while the WOFF/WOFF2 glyph path was empty (`d=""`). Icons did not render in the browser with no clear error.
+
+## After
+
+The run fails before writing outputs:
+
+```text
+Empty glyph path(s) in SVG font output for: wave (icons/wave.svg). Stroke-only SVGs (fill="none" with stroke) often produce empty glyphs ...
+```
+
+Use `--svg-diagnose` or `svgTools: { diagnose: true }` for compatibility warnings; preprocess strokes with `glyphContentTransformFn` or convert to fills in your design tool.
+
+## Workaround on older versions
+
+On releases before the fix:
+
+1. **Inspect the SVG font** (enable `formats: ["svg"]`) and search for `d=""` on `<glyph>` elements.
+2. **Convert strokes to filled paths** before running webfont (design tool or `glyphContentTransformFn` with svg-outline-stroke / svg-fixer).
+3. Run with **`--svg-diagnose`** to flag stroke-only sources early (does not fix them).
+
+## After upgrading
+
+```shell
+npm install webfont@<version>
+webfont "icons/*.svg" --svg-diagnose -d dist/icons
+```
+
+Fix stroke-only sources, then regenerate:
+
+```js
+import { webfont } from "webfont";
+import outlineStroke from "svg-outline-stroke";
+
+await webfont({
+  files: "icons/**/*.svg",
+  glyphContentTransformFn: async (glyph) => outlineStroke(glyph.contents),
+});
+```
+
+See [TROUBLESHOOTING.md](../../TROUBLESHOOTING.md) — “Stroke-only SVGs produce blank icons”.

--- a/src/cli/index.test.ts
+++ b/src/cli/index.test.ts
@@ -515,8 +515,18 @@ describe("cli", () => {
     );
 
     expect(output.stdout).toContain("stroke-based paths");
-    expect(output.code).toBe(0);
+    expect(output.stdout).toContain("Empty glyph path");
+    expect(output.code).toBe(1);
     expect(output.stderr).toBe("");
+  });
+
+  it("should fail when stroke-only SVGs produce empty glyph paths (#327)", async () => {
+    const output = await execCLI(`${fixturesGlob}/svg-icons-stroke-only/wave.svg -d ${destination} -f woff2`);
+
+    expect(output.code).toBe(1);
+    expect(output.stderr).toBe("");
+    expect(output.stdout).toContain("Empty glyph path");
+    expect(output.stdout).toContain("wave.svg");
   });
 
   it("should create dest directory if it does not exist and --dest-create flag is provided", async () => {

--- a/src/fixtures/svg-icons-stroke-only/wave.svg
+++ b/src/fixtures/svg-icons-stroke-only/wave.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="53.227" height="21.668" viewBox="0 0 53.227 21.668">
+    <path d="M0,33.434a10.826,10.826,0,0,0,7.791-3.346,10.779,10.779,0,0,0,15.613,0,10.78,10.78,0,0,0,15.614,0A10.767,10.767,0,0,0,52.9,31.555" transform="translate(0 -12.356)" fill="none" stroke="#033252" stroke-width="2"/>
+    <path d="M45.142,7.028,40.237,1S34.2.861,20.271,9.293" transform="translate(-8.324 -0.411)" fill="none" stroke="#033252" stroke-width="2"/>
+    <line x2="3.902" y2="5.398" transform="translate(26.675 1.728)" fill="none" stroke="#033252" stroke-width="2"/>
+    <path d="M4.424,27.347,1.867,20.188l51.3-3.346a21.632,21.632,0,0,1-9.932,10.229" transform="translate(-0.767 -6.916)" fill="none" stroke="#033252" stroke-width="2"/>
+    <path d="M5.652,17.883l1.371-2.672A2.23,2.23,0,0,1,8.8,14.01l28.926-2.728a19.957,19.957,0,0,1,2.772-.01,51.817,51.817,0,0,1,14.227,3.266" transform="translate(-2.321 -4.611)" fill="none" stroke="#033252" stroke-width="2"/>
+</svg>

--- a/src/lib/svgFontOutput/emptyGlyphPaths.test.ts
+++ b/src/lib/svgFontOutput/emptyGlyphPaths.test.ts
@@ -1,0 +1,30 @@
+import { assertNonEmptySvgFontGlyphs, findEmptySvgFontGlyphNames } from "./emptyGlyphPaths";
+
+describe("emptyGlyphPaths", () => {
+  it("should list glyph names with empty d attributes", () => {
+    const svgFont = `<glyph glyph-name="wave" unicode="&#xEA01;" d="" />
+<glyph glyph-name="filled" unicode="&#xEA02;" d="M0 0 L1 1" />`;
+
+    expect(findEmptySvgFontGlyphNames(svgFont)).toEqual(["wave"]);
+  });
+
+  it("should ignore missing-glyph without glyph-name", () => {
+    const svgFont = `<missing-glyph horiz-adv-x="0" />
+<glyph glyph-name="icon" d="M0 0" />`;
+
+    expect(findEmptySvgFontGlyphNames(svgFont)).toEqual([]);
+  });
+
+  it("should throw with src paths when SVG font glyphs have no path data (#327)", () => {
+    const svgFont = `<glyph glyph-name="wave" unicode="&#xEA01;" d="" />`;
+
+    expect(() =>
+      assertNonEmptySvgFontGlyphs(svgFont, [
+        {
+          metadata: { name: "wave", unicode: [String.fromCodePoint(0xea01)] },
+          srcPath: "icons/wave.svg",
+        },
+      ]),
+    ).toThrow(/Empty glyph path\(s\) in SVG font output for: wave \(icons\/wave\.svg\)/u);
+  });
+});

--- a/src/lib/svgFontOutput/emptyGlyphPaths.ts
+++ b/src/lib/svgFontOutput/emptyGlyphPaths.ts
@@ -1,0 +1,85 @@
+import type { GlyphData } from "../../types/GlyphData";
+
+const GLYPH_TAG_PATTERN = /<glyph\b([^>/]*)(?:\/>|>)/giu;
+const GLYPH_NAME_PATTERN = /\bglyph-name=["']([^"']+)["']/iu;
+const GLYPH_D_PATTERN = /\bd=["']([^"']*)["']/iu;
+
+export const findEmptySvgFontGlyphNames = (svgFont: string): string[] => {
+  const emptyNames: string[] = [];
+
+  for (const match of svgFont.matchAll(GLYPH_TAG_PATTERN)) {
+    const attributes = match[1] ?? "";
+    const nameMatch = GLYPH_NAME_PATTERN.exec(attributes);
+
+    if (nameMatch) {
+      const pathMatch = GLYPH_D_PATTERN.exec(attributes);
+      const pathData = pathMatch?.[1] ?? "";
+
+      if (pathData.trim().length === 0) {
+        emptyNames.push(nameMatch[1]);
+      }
+    }
+  }
+
+  return emptyNames;
+};
+
+const resolveSrcPathForGlyphName = (
+  glyphName: string,
+  glyphsData: ReadonlyArray<Pick<GlyphData, "metadata" | "srcPath">>,
+): string | undefined => {
+  for (const glyph of glyphsData) {
+    const name = glyph.metadata?.name;
+
+    if (name && (glyphName === name || glyphName.startsWith(`${name}-`))) {
+      return glyph.srcPath;
+    }
+  }
+
+  return undefined;
+};
+
+const formatEmptyGlyphLocations = (
+  emptyGlyphNames: string[],
+  glyphsData: ReadonlyArray<Pick<GlyphData, "metadata" | "srcPath">>,
+): string => {
+  const seen = new Set<string>();
+  const parts: string[] = [];
+
+  for (const glyphName of emptyGlyphNames) {
+    const srcPath = resolveSrcPathForGlyphName(glyphName, glyphsData);
+    const key = srcPath ?? glyphName;
+
+    if (!seen.has(key)) {
+      seen.add(key);
+
+      if (srcPath) {
+        parts.push(`${glyphName} (${srcPath})`);
+      } else {
+        parts.push(glyphName);
+      }
+    }
+  }
+
+  return parts.join("; ");
+};
+
+export const assertNonEmptySvgFontGlyphs = (
+  svgFont: string,
+  glyphsData: ReadonlyArray<Pick<GlyphData, "metadata" | "srcPath">>,
+): void => {
+  const emptyGlyphNames = findEmptySvgFontGlyphNames(svgFont);
+
+  if (emptyGlyphNames.length === 0) {
+    return;
+  }
+
+  const locations = formatEmptyGlyphLocations(emptyGlyphNames, glyphsData);
+
+  throw new Error(
+    `Empty glyph path(s) in SVG font output for: ${locations}. ` +
+      'Stroke-only SVGs (fill="none" with stroke) often produce empty glyphs because svgicons2svgfont does not convert strokes. ' +
+      "Convert strokes to filled paths in your design tool, preprocess with glyphContentTransformFn (for example svg-outline-stroke), " +
+      'or run with --svg-diagnose for compatibility warnings. See TROUBLESHOOTING.md ("Stroke-only SVGs produce blank icons").',
+  );
+};

--- a/src/standalone/index.test.ts
+++ b/src/standalone/index.test.ts
@@ -315,13 +315,16 @@ describe("standalone", () => {
 
   it("should transform SVG glyph contents before font generation (#144)", async () => {
     const strokedPath = `${fixturesGlob}/svg-stroke-icons/stroked-plus.svg`;
-    const filledContents = await fsPromise.readFile(`${fixturesGlob}/svg-stroke-icons/plus-filled.svg`, "utf8");
+    const filledPath = `${fixturesGlob}/svg-stroke-icons/plus-filled.svg`;
+    const filledContents = await fsPromise.readFile(filledPath, "utf8");
 
-    const withoutTransform = await standalone({
-      files: strokedPath,
-      formats: ["ttf"],
-      fontName: "plus",
-    });
+    await expect(
+      standalone({
+        files: strokedPath,
+        formats: ["ttf"],
+        fontName: "plus",
+      }),
+    ).rejects.toThrow(/Empty glyph path/u);
 
     const withTransform = await standalone({
       files: strokedPath,
@@ -330,11 +333,8 @@ describe("standalone", () => {
       glyphContentTransformFn: () => filledContents,
     });
 
-    const hash = (buffer: Buffer) => crypto.createHash("md5").update(buffer).digest("hex");
-
     expect(withTransform.glyphsData[0]?.contents).toBe(filledContents);
-    expect(hash(withTransform.ttf)).not.toBe(hash(withoutTransform.ttf));
-    expect(withTransform.ttf.length).toBeGreaterThan(withoutTransform.ttf.length);
+    expect(withTransform.ttf.length).toBeGreaterThan(1500);
     expect(isTtf(withTransform.ttf)).toBe(true);
   });
 
@@ -358,17 +358,27 @@ describe("standalone", () => {
     const logSpy = vi.spyOn(console, "log").mockImplementation(() => undefined);
 
     try {
-      const result = await standalone({
-        files: `${fixturesGlob}/svg-stroke-icons/stroked-plus.svg`,
-        formats: ["ttf"],
-        svgTools: { diagnose: true },
-      });
+      await expect(
+        standalone({
+          files: `${fixturesGlob}/svg-stroke-icons/stroked-plus.svg`,
+          formats: ["ttf"],
+          svgTools: { diagnose: true },
+        }),
+      ).rejects.toThrow(/Empty glyph path/u);
 
       expect(logSpy).toHaveBeenCalledWith(expect.stringContaining("stroke-based paths"));
-      expect(result.svgDiagnostics?.some((entry) => entry.code === "stroke-only")).toBe(true);
     } finally {
       logSpy.mockRestore();
     }
+  });
+
+  it("should reject stroke-only SVGs that produce empty glyph paths (#327)", async () => {
+    await expect(
+      standalone({
+        files: `${fixturesGlob}/svg-icons-stroke-only/*.svg`,
+        formats: ["woff2"],
+      }),
+    ).rejects.toThrow(/Empty glyph path\(s\) in SVG font output/u);
   });
 
   it("should create css selectors with transform titles through function", async () => {

--- a/src/standalone/runSvgPipeline.ts
+++ b/src/standalone/runSvgPipeline.ts
@@ -1,4 +1,5 @@
 import crypto from "crypto";
+import { assertNonEmptySvgFontGlyphs } from "../lib/svgFontOutput/emptyGlyphPaths";
 import { applySvgToolsToGlyphs } from "../lib/svgTools/applySvgTools";
 import { encodeTtfToEot, encodeTtfToWoff, encodeTtfToWoff2 } from "../lib/ttfEncode";
 import type { GlyphData, WebfontOptions } from "../types";
@@ -74,6 +75,7 @@ export const runSvgPipeline = async (glyphsData: GlyphData[], options: WebfontOp
   }
 
   const svg = await generateSvgFont(pipelineGlyphs, options);
+  assertNonEmptySvgFontGlyphs(svg, pipelineGlyphs);
   const ttf = toTtf(svg, ttfOptions);
 
   const result: Result = {


### PR DESCRIPTION
## Summary

### Proposed changes

- After SVG font generation, assert each `<glyph>` has non-empty path data (`d`).
- Fail with an actionable error when stroke-only sources produce blank glyphs (the #327 report).
- Fixture `src/fixtures/svg-icons-stroke-only/wave.svg` from the issue; unit + standalone + CLI tests.
- TROUBLESHOOTING section “Stroke-only SVGs produce blank icons”; migration file `docs/migration/issue-0327-stroke-only-empty-glyphs.md`.
- Update #144 / `--svg-diagnose` tests: stroke-only runs now fail after diagnostics are logged.

### Related issue

#327

### Dependencies added/removed (if applicable)

N/A

---

### Testing

- [x] I have added or updated tests that prove my fix is effective or that my feature works (if applicable)
  - [x] Unit test
  - [x] Manual test

#### How to test

1. Run `npm test`.
2. `webfont src/fixtures/svg-icons-stroke-only/wave.svg -d /tmp/out -f woff2` → exit `1`, stdout mentions `Empty glyph path`.
3. `webfont src/fixtures/svg-icons/**/*.svg -d /tmp/out` → exit `0` as before.

#### Test configuration

N/A

---

## Checklist

- [x] I have added corresponding labels to this PR (like bug, enhancement...);
- [x] My commits follow the [Conventional Commits 1.0 Guidelines](https://www.conventionalcommits.org/en/v1.0.0/);
- [x] My code follows the style guidelines of this project;
- [x] I have performed a self-review of my own code;
- [x] I have mapped technical debts found on my changes;
- [x] I have made changes to the documentation (if applicable);
- [x] My changes generate no new warnings or errors;

Made with [Cursor](https://cursor.com)