### PR TITLE
feat(svg): add opt-in SVGO optimization before font generation (#724)

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -165,10 +165,14 @@ Canonical list of product capabilities. **Update this file in the same PR** when
   - `metadataProvider`: replace default SVG metadata lookup.
   - `glyphTransformFn`: transform metadata after load (SVG mode only).
   - `glyphContentTransformFn`: transform SVG glyph contents before font generation (SVG mode only; e.g. stroke-to-fill via `svg-outline-stroke`, #144).
+  - `optimizeSvg`: optional conservative SVGO pass before `glyphContentTransformFn` (default off; #724). Does not fix stroke-only SVGs alone (#327).
+  - `svgoConfig`: optional SVGO `Config` when `optimizeSvg` is enabled.
 - **Test Criteria**:
   - [x] `glyphTransformFn` applied before font generation
   - [x] `glyphContentTransformFn` applied before font generation (#144)
   - [x] `metadataProvider` error paths unit-tested (`glyphsData`)
+  - [x] `optimizeSvg` strips comments/metadata without breaking default fixtures (#724)
+  - [x] Empty SVG font glyph paths reject with guidance (#327)
 
 ### svgicons2svgfont options
 

--- a/NOTICE.md
+++ b/NOTICE.md
@@ -116,6 +116,7 @@ webfont depends on the following **runtime** npm packages (direct dependencies).
 | [nunjucks](https://github.com/mozilla/nunjucks) | BSD-2-Clause | CSS / SCSS / Styl templates |
 | [p-limit](https://github.com/sindresorhus/p-limit) | MIT | Concurrency limiting |
 | [resolve-from](https://github.com/sindresorhus/resolve-from) | MIT | Module resolution |
+| [svgo](https://github.com/svg/svgo) | MIT | Optional SVG optimization (`optimizeSvg`) |
 | [svg2ttf](https://github.com/fontello/svg2ttf) | MIT | SVG font → TTF |
 | [svgicons2svgfont](https://github.com/nfroidure/svgicons2svgfont) | MIT | SVG icons → SVG font |
 | [ttf2eot](https://github.com/fontello/ttf2eot) | MIT | TTF → EOT |

--- a/README.md
+++ b/README.md
@@ -362,6 +362,27 @@ Do **not** use `Math.random()` in `fontName` — that renames both font files an
 
   For better trace quality with `svg-outline-stroke`, use a larger `width` / `height` / `viewBox` on the source SVG (see the library README).
 
+#### `optimizeSvg`
+
+- Type: `boolean`
+- Default: `false`
+- Description: When `true`, run a **conservative** [SVGO](https://github.com/svg/svgo) pass on each SVG **after** diagnostics and **before** `glyphContentTransformFn`. Removes editor cruft (comments, metadata, doctype) without rewriting paths or removing `viewBox`. Does **not** convert stroke-only artwork to fills — pair with [`glyphContentTransformFn`](#glyphcontenttransformfn) for stroke icons ([#327](https://github.com/itgalaxy/webfont/issues/327), [#724](https://github.com/itgalaxy/webfont/issues/724)).
+- CLI: `--optimize-svg`
+- Optional: `svgoConfig` — SVGO `Config` object; when `plugins` is set, it replaces the built-in conservative plugin list.
+
+  ```js
+  import webfont from "webfont";
+
+  await webfont({
+    files: "src/icons/**/*.svg",
+    optimizeSvg: true,
+    glyphContentTransformFn: async (glyph) => {
+      // optional: stroke-to-fill after SVGO cleanup
+      return glyph.contents;
+    },
+  });
+  ```
+
 #### `svgTools` (alpha)
 
 - Type: `{ diagnose?: boolean; onMessage?: (message: string) => void }`

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -287,7 +287,9 @@ On **older releases**, the command may exit successfully but the icon is **invis
 
 3. **Scan sources before converting:** `webfont icons/*.svg --svg-diagnose` (or `svgTools: { diagnose: true }` in the API) logs stroke-only and unsupported-element warnings without changing files.
 
-4. **Optimize with SVGO** only after strokes are outlines — SVGO alone does not fix stroke-only artwork for icon fonts.
+4. **Optional SVGO cleanup:** `webfont icons/*.svg --optimize-svg` (or `optimizeSvg: true`) removes comments and editor metadata before conversion — it does **not** convert strokes. Use **before** `glyphContentTransformFn` when you need both cleanup and stroke outlining ([#724](https://github.com/itgalaxy/webfont/issues/724)).
+
+5. **Optimize with SVGO** only after strokes are outlines — aggressive SVGO presets alone do not fix stroke-only artwork for icon fonts.
 
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "resolve-from": "^5.0.0",
         "svg2ttf": "^6.1.0",
         "svgicons2svgfont": "^16.0.0",
+        "svgo": "4.0.1",
         "ttf2eot": "3.1.0",
         "ttf2woff": "^3.0.0",
         "wawoff2": "2.0.0",
@@ -1862,6 +1863,12 @@
         "node": "18 || 20 || >=22"
       }
     },
+    "node_modules/boolbase": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+      "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
+      "license": "ISC"
+    },
     "node_modules/brace-expansion": {
       "version": "5.0.7",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
@@ -1902,6 +1909,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/commander": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-11.1.0.tgz",
+      "integrity": "sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
       }
     },
     "node_modules/compare-versions": {
@@ -1979,6 +1995,80 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
+    "node_modules/css-select": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.2.2.tgz",
+      "integrity": "sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0",
+        "css-what": "^6.1.0",
+        "domhandler": "^5.0.2",
+        "domutils": "^3.0.1",
+        "nth-check": "^2.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
+    "node_modules/css-what": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.2.2.tgz",
+      "integrity": "sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">= 6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/csso": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/csso/-/csso-5.0.5.tgz",
+      "integrity": "sha512-0LrrStPOdJj+SPCCrGhzryycLjwcgUSHBtxNA8aIDxf0GLsRh1cKYhB00Gd1lDOS4yGH69+SNn13+TWbVHETFQ==",
+      "license": "MIT",
+      "dependencies": {
+        "css-tree": "~2.2.0"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/csso/node_modules/css-tree": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-2.2.1.tgz",
+      "integrity": "sha512-OA0mILzGc1kCOCSJerOeqDxDQ4HOh+G8NbOJFOTgOCzpw7fCBubk0fEyxp8AgOL/jvLgYA/uV0cMbe43ElF1JA==",
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.0.28",
+        "source-map-js": "^1.0.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/csso/node_modules/mdn-data": {
+      "version": "2.0.28",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.28.tgz",
+      "integrity": "sha512-aylIc7Z9y4yzHYAJNuESG3hfhC+0Ibp/MAMiaOZgNv4pmEdFyfZhhhny4MNiAfWdBQ1RQ2mfDWmM1x8SvGyp8g==",
+      "license": "CC0-1.0"
+    },
     "node_modules/cubic2quad": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/cubic2quad/-/cubic2quad-1.2.1.tgz",
@@ -2018,6 +2108,73 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/dom-serializer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.2",
+        "entities": "^4.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/domelementtype": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/domhandler": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "domelementtype": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/domutils": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
+      "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "dom-serializer": "^2.0.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domutils?sponsor=1"
+      }
+    },
+    "node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/env-paths": {
@@ -3035,6 +3192,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "license": "CC0-1.0"
+    },
     "node_modules/meow": {
       "version": "14.1.0",
       "resolved": "https://registry.npmjs.org/meow/-/meow-14.1.0.tgz",
@@ -3151,6 +3314,18 @@
       },
       "engines": {
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/nth-check": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
+      "integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/nth-check?sponsor=1"
       }
     },
     "node_modules/nunjucks": {
@@ -3651,7 +3826,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
       "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
-      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
@@ -3799,6 +3973,31 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/svgo": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/svgo/-/svgo-4.0.1.tgz",
+      "integrity": "sha512-XDpWUOPC6FEibaLzjfe0ucaV0YrOjYotGJO1WpF0Zd+n6ZGEQUsSugaoLq9QkEZtAfQIxT42UChcssDVPP3+/w==",
+      "license": "MIT",
+      "dependencies": {
+        "commander": "^11.1.0",
+        "css-select": "^5.1.0",
+        "css-tree": "^3.0.1",
+        "css-what": "^6.1.0",
+        "csso": "^5.0.5",
+        "picocolors": "^1.1.1",
+        "sax": "^1.5.0"
+      },
+      "bin": {
+        "svgo": "bin/svgo.js"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/svgo"
       }
     },
     "node_modules/svgpath": {
@@ -5605,6 +5804,11 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
       "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="
     },
+    "boolbase": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+      "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww=="
+    },
     "brace-expansion": {
       "version": "5.0.7",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
@@ -5631,6 +5835,11 @@
       "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
       "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
       "dev": true
+    },
+    "commander": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-11.1.0.tgz",
+      "integrity": "sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ=="
     },
     "compare-versions": {
       "version": "6.1.1",
@@ -5676,6 +5885,56 @@
         }
       }
     },
+    "css-select": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.2.2.tgz",
+      "integrity": "sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==",
+      "requires": {
+        "boolbase": "^1.0.0",
+        "css-what": "^6.1.0",
+        "domhandler": "^5.0.2",
+        "domutils": "^3.0.1",
+        "nth-check": "^2.0.1"
+      }
+    },
+    "css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "requires": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "css-what": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.2.2.tgz",
+      "integrity": "sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA=="
+    },
+    "csso": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/csso/-/csso-5.0.5.tgz",
+      "integrity": "sha512-0LrrStPOdJj+SPCCrGhzryycLjwcgUSHBtxNA8aIDxf0GLsRh1cKYhB00Gd1lDOS4yGH69+SNn13+TWbVHETFQ==",
+      "requires": {
+        "css-tree": "~2.2.0"
+      },
+      "dependencies": {
+        "css-tree": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-2.2.1.tgz",
+          "integrity": "sha512-OA0mILzGc1kCOCSJerOeqDxDQ4HOh+G8NbOJFOTgOCzpw7fCBubk0fEyxp8AgOL/jvLgYA/uV0cMbe43ElF1JA==",
+          "requires": {
+            "mdn-data": "2.0.28",
+            "source-map-js": "^1.0.1"
+          }
+        },
+        "mdn-data": {
+          "version": "2.0.28",
+          "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.28.tgz",
+          "integrity": "sha512-aylIc7Z9y4yzHYAJNuESG3hfhC+0Ibp/MAMiaOZgNv4pmEdFyfZhhhny4MNiAfWdBQ1RQ2mfDWmM1x8SvGyp8g=="
+        }
+      }
+    },
     "cubic2quad": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/cubic2quad/-/cubic2quad-1.2.1.tgz",
@@ -5699,6 +5958,44 @@
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
       "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
       "dev": true
+    },
+    "dom-serializer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+      "requires": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.2",
+        "entities": "^4.2.0"
+      }
+    },
+    "domelementtype": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw=="
+    },
+    "domhandler": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+      "requires": {
+        "domelementtype": "^2.3.0"
+      }
+    },
+    "domutils": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
+      "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
+      "requires": {
+        "dom-serializer": "^2.0.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3"
+      }
+    },
+    "entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="
     },
     "env-paths": {
       "version": "2.2.1",
@@ -6295,6 +6592,11 @@
         "semver": "^7.5.3"
       }
     },
+    "mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ=="
+    },
     "meow": {
       "version": "14.1.0",
       "resolved": "https://registry.npmjs.org/meow/-/meow-14.1.0.tgz",
@@ -6373,6 +6675,14 @@
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
       "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
       "dev": true
+    },
+    "nth-check": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
+      "integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
+      "requires": {
+        "boolbase": "^1.0.0"
+      }
     },
     "nunjucks": {
       "version": "3.2.4",
@@ -6686,8 +6996,7 @@
     "source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
-      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
-      "dev": true
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="
     },
     "stackback": {
       "version": "0.0.2",
@@ -6780,6 +7089,20 @@
             "path-scurry": "^2.0.2"
           }
         }
+      }
+    },
+    "svgo": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/svgo/-/svgo-4.0.1.tgz",
+      "integrity": "sha512-XDpWUOPC6FEibaLzjfe0ucaV0YrOjYotGJO1WpF0Zd+n6ZGEQUsSugaoLq9QkEZtAfQIxT42UChcssDVPP3+/w==",
+      "requires": {
+        "commander": "^11.1.0",
+        "css-select": "^5.1.0",
+        "css-tree": "^3.0.1",
+        "css-what": "^6.1.0",
+        "csso": "^5.0.5",
+        "picocolors": "^1.1.1",
+        "sax": "^1.5.0"
       }
     },
     "svgpath": {

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "resolve-from": "^5.0.0",
     "svg2ttf": "^6.1.0",
     "svgicons2svgfont": "^16.0.0",
+    "svgo": "4.0.1",
     "ttf2eot": "3.1.0",
     "ttf2woff": "^3.0.0",
     "wawoff2": "2.0.0",

--- a/src/cli/index.test.ts
+++ b/src/cli/index.test.ts
@@ -529,6 +529,16 @@ describe("cli", () => {
     expect(output.stdout).toContain("wave.svg");
   });
 
+  it("should optimize messy SVGs when --optimize-svg is enabled (#724)", async () => {
+    const output = await execCLI(
+      `${fixturesGlob}/svg-icons-messy/triangle.svg -d ${destination} -f woff2 --optimize-svg`,
+    );
+
+    expect(output.code).toBe(0);
+    expect(output.stderr).toBe("");
+    expect(output.files).toEqual(["webfont.hash", "webfont.woff2"]);
+  });
+
   it("should create dest directory if it does not exist and --dest-create flag is provided", async () => {
     const nonExistentDestination = `${destination}/that/does/not/exist`;
     const output = await execCLI(`${source} -d ${nonExistentDestination} --dest-create`);

--- a/src/cli/meow/cliOptions.ts
+++ b/src/cli/meow/cliOptions.ts
@@ -8,6 +8,7 @@ export const WEBFONT_CLI_HELP_MARKERS = [
   "--no-ligatures",
   "--no-unicode-range",
   "--addHashInFontUrl",
+  "--optimize-svg",
   "svg-diagnose",
 ] as const;
 
@@ -101,6 +102,11 @@ export const webfontCliHelpText = `
         --no-unicode-range
 
             Omit unicode-range from built-in @font-face rules
+
+        --optimize-svg
+
+            Run a conservative SVGO pass on each SVG before font generation
+            (does not convert strokes to fills; use glyphContentTransformFn for that)
 
         --verbose
 
@@ -262,6 +268,10 @@ export const webfontMeowFlags = {
     type: "string",
   },
   addHashInFontUrl: {
+    default: false,
+    type: "boolean",
+  },
+  optimizeSvg: {
     default: false,
     type: "boolean",
   },

--- a/src/cli/meow/index.test.ts
+++ b/src/cli/meow/index.test.ts
@@ -23,6 +23,7 @@ const PROGRAM_CLI_FLAG_KEYS = [
   "ligatures",
   "metadata",
   "normalize",
+  "optimizeSvg",
   "prependUnicode",
   "round",
   "sort",
@@ -100,6 +101,7 @@ describe("cli/meow", () => {
       expect(cli.flags.verbose).toBe(false);
       expect(cli.flags.destCreate).toBe(false);
       expect(cli.flags.addHashInFontUrl).toBe(false);
+      expect(cli.flags.optimizeSvg).toBe(false);
       expect(cli.flags.templateCacheString).toBe("");
     });
 

--- a/src/cli/program.ts
+++ b/src/cli/program.ts
@@ -35,6 +35,7 @@ export type CliLike = {
     ligatures?: boolean;
     metadata?: string;
     normalize?: boolean;
+    optimizeSvg?: boolean;
     prependUnicode?: boolean;
     round?: string;
     sort?: boolean;
@@ -132,6 +133,10 @@ export const buildOptionsBase = (cli: CliLike): OptionsBase => {
 
   if (cli.flags.normalize) {
     optionsBase.normalize = cli.flags.normalize;
+  }
+
+  if (cli.flags.optimizeSvg) {
+    optionsBase.optimizeSvg = cli.flags.optimizeSvg;
   }
 
   if (cli.flags.fontHeight) {

--- a/src/fixtures/svg-icons-messy/triangle.svg
+++ b/src/fixtures/svg-icons-messy/triangle.svg
@@ -1,0 +1,5 @@
+<!-- Inkscape export cruft -->
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+  <metadata>dummy</metadata>
+  <path d="M12 2L2 22h20L12 2z" fill="#333"/>
+</svg>

--- a/src/lib/applyOptimizeSvgToGlyphs.ts
+++ b/src/lib/applyOptimizeSvgToGlyphs.ts
@@ -1,0 +1,9 @@
+import type { Config } from "svgo";
+import type { GlyphData } from "../types/GlyphData";
+import { optimizeSvgContents } from "./optimizeSvgGlyphs";
+
+export const applyOptimizeSvgToGlyphs = (glyphs: GlyphData[], svgoConfig?: Config): GlyphData[] =>
+  glyphs.map((glyph) => ({
+    ...glyph,
+    contents: optimizeSvgContents(glyph.contents, glyph.srcPath, svgoConfig),
+  }));

--- a/src/lib/optimizeSvgGlyphs.test.ts
+++ b/src/lib/optimizeSvgGlyphs.test.ts
@@ -1,0 +1,61 @@
+import type { Config } from "svgo";
+import type { GlyphData } from "../types/GlyphData";
+import { applyOptimizeSvgToGlyphs } from "./applyOptimizeSvgToGlyphs";
+import { defaultWebfontSvgoConfig, optimizeSvgContents } from "./optimizeSvgGlyphs";
+
+describe("optimizeSvgGlyphs", () => {
+  it("should expose a conservative default plugin list without preset-default", () => {
+    const config = defaultWebfontSvgoConfig();
+
+    expect(config.plugins).toEqual([
+      "removeDoctype",
+      "removeXMLProcInst",
+      "removeComments",
+      "removeMetadata",
+      "removeEditorsNSData",
+      "removeDesc",
+      "cleanupAttrs",
+      "removeUnusedNS",
+    ]);
+  });
+
+  it("should remove comments and metadata from SVG contents", () => {
+    const input = `<?xml version="1.0" encoding="UTF-8"?>
+<!-- editor comment -->
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+  <metadata>ignore</metadata>
+  <path d="M0 0h24v24H0z" fill="#000"/>
+</svg>`;
+
+    const output = optimizeSvgContents(input, "icon.svg");
+
+    expect(output).not.toContain("editor comment");
+    expect(output).not.toContain("<metadata>");
+    expect(output).toContain('viewBox="0 0 24 24"');
+    expect(output).toContain('d="M0 0h24v24H0z"');
+  });
+
+  it("should use caller plugins when svgoConfig.plugins is set", () => {
+    const input = '<svg xmlns="http://www.w3.org/2000/svg"><path d="M0 0"/></svg>';
+    const config: Config = { plugins: ["removeComments"] };
+
+    expect(optimizeSvgContents(input, "plain.svg", config)).toBe(input);
+  });
+});
+
+describe("applyOptimizeSvgToGlyphs", () => {
+  it("should optimize each glyph contents in place", () => {
+    const glyphs: GlyphData[] = [
+      {
+        contents: `<!-- c --><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 8 8"><path d="M0 0h8v8H0z"/></svg>`,
+        srcPath: "a.svg",
+        metadata: { name: "a" },
+      },
+    ];
+
+    const optimized = applyOptimizeSvgToGlyphs(glyphs);
+
+    expect(optimized[0]?.contents).not.toContain("<!-- c -->");
+    expect(optimized[0]?.srcPath).toBe("a.svg");
+  });
+});

--- a/src/lib/optimizeSvgGlyphs.ts
+++ b/src/lib/optimizeSvgGlyphs.ts
@@ -1,0 +1,40 @@
+import type { Config } from "svgo";
+import { optimize } from "svgo";
+
+/** Conservative SVGO preset: cleanup cruft without rewriting paths or removing viewBox. */
+export const defaultWebfontSvgoConfig = (): Config => ({
+  multipass: false,
+  plugins: [
+    "removeDoctype",
+    "removeXMLProcInst",
+    "removeComments",
+    "removeMetadata",
+    "removeEditorsNSData",
+    "removeDesc",
+    "cleanupAttrs",
+    "removeUnusedNS",
+  ],
+});
+
+const resolveSvgoConfig = (userConfig?: Config): Config => {
+  const defaults = defaultWebfontSvgoConfig();
+
+  if (!userConfig) {
+    return defaults;
+  }
+
+  return {
+    ...defaults,
+    ...userConfig,
+    plugins: userConfig.plugins ?? defaults.plugins,
+  };
+};
+
+export const optimizeSvgContents = (contents: string, srcPath: string, config?: Config): string => {
+  const result = optimize(contents, {
+    ...resolveSvgoConfig(config),
+    path: srcPath,
+  });
+
+  return result.data;
+};

--- a/src/standalone/index.test.ts
+++ b/src/standalone/index.test.ts
@@ -381,6 +381,28 @@ describe("standalone", () => {
     ).rejects.toThrow(/Empty glyph path\(s\) in SVG font output/u);
   });
 
+  it("should optimize messy SVGs when optimizeSvg is enabled (#724)", async () => {
+    const result = await standalone({
+      files: `${fixturesGlob}/svg-icons-messy/*.svg`,
+      formats: ["woff2"],
+      optimizeSvg: true,
+    });
+
+    expect(result.glyphsData[0]?.contents).not.toContain("Inkscape export cruft");
+    expect(result.glyphsData[0]?.contents).not.toContain("<metadata>");
+    expect(isWoff2(result.woff2)).toBe(true);
+  });
+
+  it("should still reject stroke-only SVGs when optimizeSvg is enabled (#327)", async () => {
+    await expect(
+      standalone({
+        files: `${fixturesGlob}/svg-icons-stroke-only/*.svg`,
+        formats: ["woff2"],
+        optimizeSvg: true,
+      }),
+    ).rejects.toThrow(/Empty glyph path\(s\) in SVG font output/u);
+  });
+
   it("should create css selectors with transform titles through function", async () => {
     const glyphTransformFn: GlyphTransformFn = (obj) => {
       obj.name += "_transform";

--- a/src/standalone/runSvgPipeline.ts
+++ b/src/standalone/runSvgPipeline.ts
@@ -1,4 +1,5 @@
 import crypto from "crypto";
+import { applyOptimizeSvgToGlyphs } from "../lib/applyOptimizeSvgToGlyphs";
 import { assertNonEmptySvgFontGlyphs } from "../lib/svgFontOutput/emptyGlyphPaths";
 import { applySvgToolsToGlyphs } from "../lib/svgTools/applySvgTools";
 import { encodeTtfToEot, encodeTtfToWoff, encodeTtfToWoff2 } from "../lib/ttfEncode";
@@ -39,6 +40,10 @@ export const runSvgPipeline = async (glyphsData: GlyphData[], options: WebfontOp
   });
 
   let pipelineGlyphs = diagnosedGlyphs;
+
+  if (options.optimizeSvg) {
+    pipelineGlyphs = applyOptimizeSvgToGlyphs(pipelineGlyphs, options.svgoConfig);
+  }
 
   if (options.glyphContentTransformFn) {
     const glyphContentTransformFn = options.glyphContentTransformFn;

--- a/src/standalone/validateWebfontOptions.test.ts
+++ b/src/standalone/validateWebfontOptions.test.ts
@@ -82,6 +82,22 @@ describe("validateWebfontOptions", () => {
     ).toThrow("unicodeRange must be a boolean or string");
   });
 
+  it("should reject invalid optimizeSvg and svgoConfig option types", () => {
+    expect(() =>
+      validateWebfontOptions({
+        ...baseOptions(),
+        optimizeSvg: "yes" as never,
+      }),
+    ).toThrow("optimizeSvg must be a boolean");
+
+    expect(() =>
+      validateWebfontOptions({
+        ...baseOptions(),
+        svgoConfig: "invalid" as never,
+      }),
+    ).toThrow("svgoConfig must be an object");
+  });
+
   it("should accept template as an array (#158)", () => {
     expect(
       validateWebfontOptions({

--- a/src/standalone/validateWebfontOptions.ts
+++ b/src/standalone/validateWebfontOptions.ts
@@ -14,6 +14,18 @@ const assertBooleanOrStringOption = (name: string, value: unknown): void => {
   }
 };
 
+const assertBooleanOption = (name: string, value: unknown): void => {
+  if (value !== undefined && typeof value !== "boolean") {
+    throw new Error(`${name} must be a boolean`);
+  }
+};
+
+const assertObjectOption = (name: string, value: unknown): void => {
+  if (value !== undefined && (typeof value !== "object" || value === null || Array.isArray(value))) {
+    throw new Error(`${name} must be an object`);
+  }
+};
+
 const assertFilesOption = (files: unknown): void => {
   if (typeof files === "string") {
     if (files.length === 0) {
@@ -47,6 +59,8 @@ export const validateWebfontOptions = (options: WebfontOptions): WebfontOptions 
   options.formats = assertFormatsOption(options.formats);
   assertStringOption("fontName", options.fontName);
   assertBooleanOrStringOption("unicodeRange", options.unicodeRange);
+  assertBooleanOption("optimizeSvg", options.optimizeSvg);
+  assertObjectOption("svgoConfig", options.svgoConfig);
   if (options.template !== undefined) {
     normalizeTemplateOption(options.template);
   }

--- a/src/types/OptionsBase.ts
+++ b/src/types/OptionsBase.ts
@@ -32,6 +32,8 @@ export type OptionsBase = {
   ligatures?: boolean;
   addHashInFontUrl?: boolean | unknown;
   unicodeRange?: boolean | string | unknown;
+  optimizeSvg?: boolean | unknown;
+  svgoConfig?: unknown;
   /** Alpha. SVG diagnostics and optional pre-conversion fixes. */
   svgTools?: SvgToolsOptions;
 };

--- a/src/types/WebfontOptions.ts
+++ b/src/types/WebfontOptions.ts
@@ -1,3 +1,4 @@
+import type { Config as SvgoConfig } from "svgo";
 import type { TemplateOption } from "../lib/parseTemplateOption";
 import type { Formats, FormatsOptions } from "./Format";
 import type { GlyphContentTransformFn } from "./GlyphContentTransformFn";
@@ -36,5 +37,7 @@ export interface WebfontOptions extends InitialOptions {
   verbose: boolean;
   addHashInFontUrl?: boolean;
   unicodeRange?: boolean | string;
+  optimizeSvg?: boolean;
+  svgoConfig?: SvgoConfig;
   svgTools?: SvgToolsOptions;
 }


### PR DESCRIPTION
## Summary

### Proposed changes

- Add `svgo@4.0.1` and `optimizeSvg` / `svgoConfig` options (default **off**).
- Conservative built-in SVGO preset: remove comments, metadata, doctype, etc. — **no** `preset-default` path rewriting.
- Pipeline order: diagnostics → `optimizeSvg` → `glyphContentTransformFn` → font generation.
- CLI: `--optimize-svg`
- Fixture `svg-icons-messy/triangle.svg`; unit, standalone, and CLI tests.
- README, FEATURES.md, TROUBLESHOOTING.md, NOTICE.md.

Stroke-only SVGs (#327) still fail with the empty-glyph error; SVGO does not convert strokes. Users can combine `--optimize-svg` with `glyphContentTransformFn` for cleanup + stroke outlining.

### Related issue

#724

Also helps reporters of #327 (cleanup before preprocessing); does not close #327.

### Dependencies added/removed (if applicable)

- Add: `svgo@4.0.1` (MIT)

---

### Testing

- [x] I have added or updated tests that prove my fix is effective or that my feature works (if applicable)
  - [x] Unit test
  - [x] Manual test

#### How to test

1. Run `npm test` (390 tests).
2. `npm audit` → 0 vulnerabilities.
3. `webfont src/fixtures/svg-icons-messy/triangle.svg -d /tmp/out -f woff2 --optimize-svg` → success.
4. Same with `src/fixtures/svg-icons-stroke-only/wave.svg` → fails with `Empty glyph path` (with or without `--optimize-svg`).

#### Test configuration

N/A

---

## Checklist

- [ ] I have added corresponding labels to this PR (like bug, enhancement...);
- [x] My commits follow the [Conventional Commits 1.0 Guidelines](https://www.conventionalcommits.org/en/v1.0.0/);
- [x] My code follows the style guidelines of this project;
- [x] I have performed a self-review of my own code;
- [ ] I have mapped technical debts found on my changes;
- [x] I have made changes to the documentation (if applicable);
- [x] My changes generate no new warnings or errors;

Made with [Cursor](https://cursor.com)