### PR TITLE
test(cli): cover --config with JavaScript config files (#480)

### DIFF
--- a/knip.json
+++ b/knip.json
@@ -7,6 +7,7 @@
     "templates/index.ts",
     "vitest/globby-stub.ts",
     "src/fixtures/config-discovery/js-config/webfont.config.js",
+    "src/fixtures/configs/webfont.config-cli.js",
     "src/fixtures/config-discovery/js-rc/.webfontrc.js",
     "src/fixtures/config-package/index.js"
   ],

--- a/src/cli/index.test.ts
+++ b/src/cli/index.test.ts
@@ -333,6 +333,15 @@ describe("cli", () => {
     expect(output.stderr).toBe("");
   });
 
+  it("should load a JavaScript config via --config (#480)", async () => {
+    const configPath = `${fixturesGlob}/configs/webfont.config-cli.js`;
+    const output = await execCLI(`${source} -d ${destination} --config ${configPath}`);
+
+    expect(output.files).toEqual(["cli-config-js-font.hash", "cli-config-js-font.woff2"]);
+    expect(output.code).toBe(0);
+    expect(output.stderr).toBe("");
+  });
+
   it("should load config via --config with an absolute path", async () => {
     const configPath = path.resolve(fixturesGlob, "configs/.webfontrc-cli.json");
     const output = await execCLI(`${source} -d ${destination} --config ${configPath}`);

--- a/src/fixtures/configs/webfont.config-cli.js
+++ b/src/fixtures/configs/webfont.config-cli.js
@@ -1,0 +1,4 @@
+module.exports = {
+  fontName: "cli-config-js-font",
+  formats: ["woff2"],
+};

--- a/src/standalone/cosmiconfig.test.ts
+++ b/src/standalone/cosmiconfig.test.ts
@@ -161,5 +161,17 @@ describe("cosmiconfig", () => {
       expect(result.config?.filePath).toBe(path.resolve(configFile));
       expect((result.config as DiscoveredRcConfig).foo).toBe("bar");
     });
+
+    it("should load webfont.config.js via configFile (#480)", async () => {
+      const configFile = path.join(configsRoot, "webfont.config-cli.js");
+      const result = await standalone({
+        configFile,
+        files: svgFiles,
+      });
+
+      expect(result.config?.fontName).toBe("cli-config-js-font");
+      expect(result.config?.filePath).toBe(path.resolve(configFile));
+      expect(isWoff2(result.woff2)).toBe(true);
+    });
   });
 });


### PR DESCRIPTION
## Summary

### Proposed changes

- Add `webfont.config-cli.js` fixture and CLI integration test for `--config` with a `.js` file ([#480](https://github.com/itgalaxy/webfont/issues/480)).
- Add cosmiconfig `configFile` test for the same fixture.
- Register fixture in `knip.json` entry list.
- Issue thread updated: root cause (old Rollup CLI), fixed on current npm, release cadence explained; issue closed.

### Related issue

https://github.com/itgalaxy/webfont/issues/480

### Dependencies added/removed (if applicable)

N/A

---

### Testing

- [x] I have added or updated tests that prove my fix is effective or that my feature works (if applicable)
  - [x] Unit test

#### How to test

1. `npm test`
2. `webfont icons/*.svg -d /tmp/out --config src/fixtures/configs/webfont.config-cli.js`

#### Test configuration

N/A

---

## Checklist

- [x] I have added corresponding labels to this PR (like bug, enhancement...);
- [x] My commits follow the [Conventional Commits 1.0 Guidelines](https://www.conventionalcommits.org/en/v1.0.0/);
- [x] My code follows the style guidelines of this project;
- [x] I have performed a self-review of my own code;
- [x] I have mapped technical debts found on my changes;
- [x] I have made changes to the documentation (if applicable);
- [x] My changes generate no new warnings or errors;

Made with [Cursor](https://cursor.com)