### PR TITLE
fix(ligatures): warn on large fonts; document browser slowdown (#558)

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -156,9 +156,11 @@ Canonical list of product capabilities. **Update this file in the same PR** when
   - `template` accepts a string or array of built-in names (`css`, `html`, `scss`, `styl`, `json`) or custom template paths.
   - `result.templates` lists each rendered output; `result.template` remains the first entry for backward compatibility.
   - Built-in `html` preview: `templateFontLigatures` (default on) adds `font-feature-settings: "liga"` for the Ligature section; if `unicodeRange` is also enabled, HTML omits PUA-only `unicode-range` on `@font-face` so ASCII ligature names use the icon font.
+  - `ligatures` default on; for **>2k glyphs** use `--no-ligatures` to avoid browser hangs ([#558](https://github.com/itgalaxy/webfont/issues/558)); runtime warning when threshold exceeded.
 - **Test Criteria**:
   - [x] Standalone and CLI tests for `template: ['html', 'scss']` (#158)
   - [x] HTML template enables `liga` CSS by default; omits `unicode-range` when both ligature preview and `unicodeRange` are enabled
+  - [x] Large-font ligature warning unit tests ([#558](https://github.com/itgalaxy/webfont/issues/558))
 
 ### Glyph metadata hooks
 

--- a/README.md
+++ b/README.md
@@ -314,6 +314,7 @@ Do **not** use `Math.random()` in `fontName` — that renames both font files an
 - Default: `true`
 - Description: When `true`, each glyph gets a second unicode entry: the icon name with hyphens replaced by underscores (for example `phone-call` → `phone_call`). Browsers can map that character sequence to the icon glyph when OpenType ligatures are enabled (`font-feature-settings: "liga"`).
 - CLI: `--no-ligatures` to disable ligature glyphs in the font.
+- **Large icon fonts (thousands of glyphs):** ligature tables can make **Firefox on Windows** (DirectWrite) extremely slow or hang when the font loads ([#558](https://github.com/itgalaxy/webfont/issues/558)). Material Design Icons and similar sets should use **`ligatures: false`** / `--no-ligatures` and class + codepoint CSS instead. webfont prints a warning when glyph count exceeds 2000 with ligatures enabled.
 
 #### `templateFontLigatures`
 

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -367,12 +367,20 @@ Bundlers fail while building client code with errors such as:
 Module not found: Error: Can't resolve 'fs'
 ```
 
-The stack trace often includes `globby`, `fast-glob`, `cosmiconfig`, or `webfont/dist/standalone.js` ([#198](https://github.com/itgalaxy/webfont/issues/198)).
+Or at **runtime** in the browser (often with older `webfont` versions bundled into the app):
+
+```text
+TypeError: Cannot read property 'dirname' of undefined
+    at .../node_modules/glob-parent/index.js
+```
+
+The stack trace often includes `globby`, `fast-glob`, `glob-parent`, `cosmiconfig`, or `webfont/dist/standalone.js` ([#198](https://github.com/itgalaxy/webfont/issues/198), [#496](https://github.com/itgalaxy/webfont/issues/496)).
 
 ### Why it usually happens
 
 - **`webfont` is Node.js-only.** It reads SVG files from disk, runs `globby`, and uses other Node built-ins. It is meant for **build time**, not inside browser/React component bundles.
-- **The package was imported from client code** (for example `import webfont from "webfont"` in `App.js`). Webpack/Vite tries to bundle the full Node implementation and fails on `fs`.
+- **The package was imported from client code** (for example `import webfont from "webfont"` in `App.js`). Webpack/Vite tries to bundle the full Node implementation. Without Node’s `path` module, dependencies such as `glob-parent` throw **`Cannot read property 'dirname' of undefined`** ([#496](https://github.com/itgalaxy/webfont/issues/496)).
+- **From webfont 12.x**, the package `browser` / `exports` default entry resolves to a small stub that rejects with a clear message instead of pulling in `globby` — but you must still **not** call `webfont()` from client code; generate fonts in Node and ship the output files.
 
 ### Steps to try to resolve
 
@@ -394,7 +402,7 @@ The stack trace often includes `globby`, `fast-glob`, `cosmiconfig`, or `webfont
 
    Run this from a `.mjs` script, `vite.config.ts`, or webpack config — never from React components loaded in the browser.
 
-4. **If a dependency still pulls `webfont` into the client bundle**, mark it external or move the import to a Node-only file. With webpack 5+, the package `browser` field resolves to a stub that throws a clear error instead of pulling in `fs`.
+4. **If a dependency still pulls `webfont` into the client bundle**, mark it external or move the import to a Node-only file. With **webfont 12.x** and webpack 5+ / modern Vite, the package `browser` field and `exports` default resolve to `dist/browser.js`, which throws a clear error instead of bundling `fs` / `glob-parent`. On **11.x** or webpack 4 without `browser` resolution, you may see `dirname of undefined` until you stop importing `webfont` from client code.
 
 5. **Browser-based generation** is not supported on the current release; see [#708](https://github.com/itgalaxy/webfont/issues/708) for a possible future Web Worker spike.
 

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -357,6 +357,46 @@ There is often **no error**. The built-in **`html`** preview lists icon names un
 
 ---
 
+## Browser hangs or extreme slowdown (large icon webfont, Firefox on Windows)
+
+### What error appeared
+
+There is often **no build error**. After upgrading `webfont` (for example v9 → v11+) and shipping a **large** icon font (thousands of glyphs — Material Design Icons, Tabler, etc.), users report:
+
+- Firefox on **Windows** freezing for seconds when opening a tab or switching tabs
+- High CPU in **DirectWrite** / `LigatureSubstitution` during layout reflow
+- Chrome slower than before; macOS/Linux often less affected
+
+See [#558](https://github.com/itgalaxy/webfont/issues/558), [MaterialDesign#6519](https://github.com/Templarian/MaterialDesign/issues/6519), and [tabler-icons#1327](https://github.com/tabler/tabler-icons/issues/1327).
+
+### Why it usually happens
+
+- From webfont **10+**, **`ligatures` default to `true`**: each icon name is also encoded as an OpenType ligature (for example `phone_call` → glyph).
+- **Thousands of ligatures** produce a very large GSUB table. Windows Firefox uses DirectWrite to process ligature lookups during layout — reflow can take seconds per tab switch.
+- **WOFF2 is not the root cause** — the same ligature-heavy TTF/WOFF triggers the behavior. Older builds without ligatures (or with `--no-ligatures`) perform normally.
+
+### Steps to try to resolve
+
+1. **Disable ligatures for large icon sets** (recommended for MDI-scale fonts):
+
+   ```shell
+   webfont "icons/*.svg" -d dist/fonts --no-ligatures
+   ```
+
+   ```js
+   await webfont({ files: "icons/**/*.svg", ligatures: false });
+   ```
+
+2. **Use class + codepoint CSS** in the app (`.mdi-phone::before { content: "\\f001"; }`) — not ligature-by-name text.
+
+3. **In CSS**, if you cannot regenerate the font yet, try `font-variant-ligatures: none` on icon classes — this helps only when the page does not rely on `liga` for icons; regenerating without ligatures is more reliable.
+
+4. **webfont warns** when glyph count exceeds **2000** with ligatures enabled (stdout). Treat it as a signal to pass `--no-ligatures`.
+
+5. Prefer **`@mdi/svg` / SVG or JS icon packages** for web apps when the upstream project documents webfont alternatives.
+
+---
+
 ## Can't resolve `fs` (webpack / React / Vite client bundle)
 
 ### What error appeared

--- a/docs/migration/issue-0558-large-font-ligatures.md
+++ b/docs/migration/issue-0558-large-font-ligatures.md
@@ -1,0 +1,41 @@
+# Large icon fonts and browser slowdown ([#558](https://github.com/itgalaxy/webfont/issues/558))
+
+**Minimum version:** *pending* (runtime warning); workaround works on all releases with `--no-ligatures`
+
+## What changed
+
+webfont **10+** enables **ligatures by default**. For icon sets with **thousands** of glyphs, the generated font’s ligature tables can make browsers — especially **Firefox on Windows** — hang or slow dramatically during layout.
+
+A future release prints a **warning** when glyph count exceeds **2000** with ligatures enabled.
+
+## Before
+
+Material Design Icons and similar toolchains on **webfont 9.x** (ligatures off or absent) produced WOFF2 files that loaded quickly in Firefox on Windows.
+
+## After
+
+**webfont 11+** with default `ligatures: true` on ~5k–7k icons produces fonts that trigger expensive DirectWrite ligature processing ([#558](https://github.com/itgalaxy/webfont/issues/558), [MaterialDesign#6519](https://github.com/Templarian/MaterialDesign/issues/6519)).
+
+## Workaround on older versions
+
+On **any** webfont version that supports `--no-ligatures` / `ligatures: false`:
+
+```shell
+webfont "svg/**/*.svg" -d dist --no-ligatures -f woff2
+```
+
+```js
+import { webfont } from "webfont";
+
+await webfont({
+  files: "svg/**/*.svg",
+  ligatures: false,
+  formats: ["woff2"],
+});
+```
+
+Use **class + private-use codepoint** CSS in your app; do not type icon names with `font-feature-settings: "liga"` for large sets.
+
+## After upgrading
+
+Keep `ligatures: false` in `webfont.config.js` / CI for large icon fonts. See [TROUBLESHOOTING.md](../../TROUBLESHOOTING.md) — “Browser hangs or extreme slowdown”.

--- a/src/lib/largeFontLigatures.test.ts
+++ b/src/lib/largeFontLigatures.test.ts
@@ -1,0 +1,21 @@
+import {
+  formatLargeFontLigatureWarning,
+  LARGE_FONT_LIGATURE_GLYPH_THRESHOLD,
+  shouldWarnLargeFontLigatures,
+} from "./largeFontLigatures";
+
+describe("largeFontLigatures", () => {
+  it("should warn above the glyph threshold when ligatures are enabled (#558)", () => {
+    expect(LARGE_FONT_LIGATURE_GLYPH_THRESHOLD).toBe(2000);
+    expect(shouldWarnLargeFontLigatures(2000, true)).toBe(false);
+    expect(shouldWarnLargeFontLigatures(2001, true)).toBe(true);
+    expect(shouldWarnLargeFontLigatures(7000, true)).toBe(true);
+    expect(shouldWarnLargeFontLigatures(7000, false)).toBe(false);
+  });
+
+  it("should format a warning that points to docs and the issue", () => {
+    expect(formatLargeFontLigatureWarning(5000)).toContain("5000 glyphs");
+    expect(formatLargeFontLigatureWarning(5000)).toContain("--no-ligatures");
+    expect(formatLargeFontLigatureWarning(5000)).toContain("issues/558");
+  });
+});

--- a/src/lib/largeFontLigatures.ts
+++ b/src/lib/largeFontLigatures.ts
@@ -1,0 +1,8 @@
+/** Glyph count above which OpenType ligatures often hurt browser layout (Firefox / DirectWrite). */
+export const LARGE_FONT_LIGATURE_GLYPH_THRESHOLD = 2000;
+
+export const shouldWarnLargeFontLigatures = (glyphCount: number, ligaturesEnabled: boolean): boolean =>
+  ligaturesEnabled && glyphCount > LARGE_FONT_LIGATURE_GLYPH_THRESHOLD;
+
+export const formatLargeFontLigatureWarning = (glyphCount: number): string =>
+  `Warning: ${glyphCount} glyphs with ligatures enabled may cause severe browser slowdown or hangs (especially Firefox on Windows). Disable ligatures for large icon fonts: --no-ligatures or ligatures: false. See TROUBLESHOOTING.md and https://github.com/itgalaxy/webfont/issues/558`;

--- a/src/standalone/runSvgPipeline.ts
+++ b/src/standalone/runSvgPipeline.ts
@@ -1,5 +1,6 @@
 import crypto from "crypto";
 import { applyOptimizeSvgToGlyphs } from "../lib/applyOptimizeSvgToGlyphs";
+import { formatLargeFontLigatureWarning, shouldWarnLargeFontLigatures } from "../lib/largeFontLigatures";
 import { assertNonEmptySvgFontGlyphs } from "../lib/svgFontOutput/emptyGlyphPaths";
 import { applySvgToolsToGlyphs } from "../lib/svgTools/applySvgTools";
 import { encodeTtfToEot, encodeTtfToWoff, encodeTtfToWoff2 } from "../lib/ttfEncode";
@@ -71,6 +72,11 @@ export const runSvgPipeline = async (glyphsData: GlyphData[], options: WebfontOp
         };
       }),
     );
+  }
+
+  if (shouldWarnLargeFontLigatures(pipelineGlyphs.length, options.ligatures)) {
+    // biome-ignore lint/suspicious/noConsole: user-facing performance warning (#558)
+    console.log(formatLargeFontLigatureWarning(pipelineGlyphs.length));
   }
 
   let ttfOptions = {};


### PR DESCRIPTION
## Summary

### Proposed changes

- Root cause for [#558](https://github.com/itgalaxy/webfont/issues/558): default **ligatures** on large icon fonts (~7k MDI glyphs) trigger expensive DirectWrite ligature layout on Firefox/Windows — not a WOFF2 encoder bug.
- **Workaround (all current releases):** `ligatures: false` / `--no-ligatures` + class/codepoint CSS.
- Runtime **stdout warning** when glyph count > 2000 with ligatures enabled.
- TROUBLESHOOTING, README, FEATURES, and `docs/migration/issue-0558-large-font-ligatures.md`.
- Issue thread updated; issue stays open until npm publish.

### Related issue

https://github.com/itgalaxy/webfont/issues/558

### Dependencies added/removed (if applicable)

N/A

---

### Testing

- [x] I have added or updated tests that prove my fix is effective or that my feature works (if applicable)
  - [x] Unit test

#### How to test

1. `npm test`
2. Build a font with >2000 SVGs and ligatures on — expect stdout warning.
3. Same with `--no-ligatures` — no warning; verify Firefox/Windows perf with MDI-scale fonts (manual).

#### Test configuration

N/A

---

## Checklist

- [x] I have added corresponding labels to this PR (like bug, enhancement...);
- [x] My commits follow the [Conventional Commits 1.0 Guidelines](https://www.conventionalcommits.org/en/v1.0.0/);
- [x] My code follows the style guidelines of this project;
- [x] I have performed a self-review of my own code;
- [x] I have mapped technical debts found on my changes;
- [x] I have made changes to the documentation (if applicable);
- [x] My changes generate no new warnings or errors;

Made with [Cursor](https://cursor.com)