### PR TITLE
ci(npm): publish with NPM_TOKEN repository secret

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,7 +1,7 @@
 name: npm publish
 
-# Publishes via npm Trusted Publishing (OIDC). Configure the trusted publisher on
-# npmjs.com for workflow filename npm-publish.yml (see CONTRIBUTING.md).
+# Publishes with the NPM_TOKEN repository secret (see CONTRIBUTING.md).
+# Trusted Publishing (OIDC) may replace this when configured on npmjs.com.
 on:
   release:
     types: [published]
@@ -16,7 +16,6 @@ env:
 
 permissions:
   contents: read
-  id-token: write
 
 jobs:
   build:
@@ -43,6 +42,7 @@ jobs:
         with:
           node-version: 24.x
           registry-url: https://registry.npmjs.org/
+          node-auth-token: ${{ secrets.NPM_TOKEN }}
           package-manager-cache: false
       - run: npm ci
       - run: npm publish --access public

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -189,16 +189,16 @@ Do not run local `npm version` or push version tags manually unless coordinating
 
 #### npm publishing
 
-Publishing from GitHub Actions uses **[npm Trusted Publishing](https://docs.npmjs.com/trusted-publishers)** (OIDC) — not long-lived publish tokens with bypass 2FA.
+Publishing from GitHub Actions uses the **`NPM_TOKEN`** repository secret (Automation/publish token on npmjs.com). The [`npm-publish`](.github/workflows/npm-publish.yml) workflow passes it to `actions/setup-node` as `node-auth-token`.
 
-**One-time setup on npmjs.com** (package maintainer):
+**One-time setup** (package maintainer):
 
-1. Open [webfont package settings](https://www.npmjs.com/package/webfont) → **Trusted publishing** → **GitHub Actions**.
-2. Set **Repository** to `itgalaxy/webfont`.
-3. Set **Workflow filename** to `npm-publish.yml` (filename only, including `.yml`).
-4. Save. Allow action **npm publish** if prompted.
+1. Create an npm **Automation** or **Publish** token for the `webfont` package (with publish access; OTP requirement disabled for automation if your org allows it).
+2. Add it as a GitHub repository secret named **`NPM_TOKEN`** ([Settings → Secrets and variables → Actions](https://github.com/itgalaxy/webfont/settings/secrets/actions)).
 
-**Workflow:** [`.github/workflows/npm-publish.yml`](.github/workflows/npm-publish.yml) requests `id-token: write` and runs `npm publish` without `NPM_TOKEN`. Releases created by `github-actions[bot]` usually do not trigger downstream workflows — use **Actions → npm publish → Run workflow** with the release tag (e.g. `v12.0.1`) after merging a Release PR.
+**After merging a Release PR:** the [`npm-publish`](.github/workflows/npm-publish.yml) workflow listens for `release: published`, but releases created with the default `GITHUB_TOKEN` usually **do not** trigger downstream workflows — use **Actions → npm publish → Run workflow** with the release tag (e.g. `v12.1.0`) if publish does not start automatically.
+
+**Future:** [npm Trusted Publishing](https://docs.npmjs.com/trusted-publishers) (OIDC) can replace `NPM_TOKEN` when a maintainer configures it on npmjs.com for workflow `npm-publish.yml`.
 
 **Manual publish** from a maintainer machine (browser/web auth or local npm login) is still supported:
 
@@ -209,8 +209,6 @@ npm ci
 npm test
 npm publish --access public
 ```
-
-Do not create npm tokens with **bypass 2FA** for CI — npm flags that as insecure; use Trusted Publishing instead.
 
 Automated publishing does **not** retroactively upload versions that already exist as git tags only (for example `11.5.x` never published to npm).
 


### PR DESCRIPTION
## Summary

### Proposed changes

This PR brings the following changes:

- Pass `secrets.NPM_TOKEN` to `actions/setup-node` in `npm-publish.yml` so `npm publish` authenticates in CI.
- Remove `id-token: write` (Trusted Publishing / OIDC) until maintainers configure it on npmjs.com.
- Update CONTRIBUTING.md with `NPM_TOKEN` setup and note Trusted Publishing as a future option.

### Related issue

N/A

### Dependencies added/removed (if applicable)

N/A

---

### Testing

- [x] I have added or updated tests that prove my fix is effective or that my feature works (if applicable)

Docs/workflow-only change; `npm test` passes on pre-push.

#### How to test

1. Merge this PR before the next release publish attempt.
2. After merging Release PR #705, run **Actions → npm publish → Run workflow** with tag `v12.1.0`.
3. Confirm publish succeeds (requires `NPM_TOKEN` secret already configured).

#### Test configuration

N/A

---

## Checklist

- [ ] I have added corresponding labels to this PR (like bug, enhancement...);
- [x] My commits follow the [Conventional Commits 1.0 Guidelines](https://www.conventionalcommits.org/en/v1.0.0/);
- [x] My code follows the style guidelines of this project;
- [x] I have performed a self-review of my own code;
- [ ] I have mapped technical debts found on my changes;
- [x] I have made changes to the documentation (if applicable);
- [x] My changes generate no new warnings or errors;

Made with [Cursor](https://cursor.com)