### PR TITLE
docs: named import examples; diagnose <use> refs (#612)

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -194,7 +194,7 @@ Canonical list of product capabilities. **Update this file in the same PR** when
 - **Stability**: alpha
 - **Description**: Scan SVG icon sources for icon-font incompatibilities before font generation. Stroke-to-fill and other SVG repairs are **out of scope** — use `glyphContentTransformFn` (see [ADR 0011](docs/adr/0011-no-svg-outline-stroke-dependency.md)).
 - **Properties**:
-  - `svgTools.diagnose`: warn about `fill-rule: evenodd`, stroke-only paths, and unsupported SVG elements; populate `result.svgDiagnostics`.
+  - `svgTools.diagnose`: warn about `fill-rule: evenodd`, stroke-only paths, `<use>` references ([#612](https://github.com/itgalaxy/webfont/issues/612)), and unsupported SVG elements; populate `result.svgDiagnostics`.
   - CLI flag: `--svg-diagnose` (alpha).
   - `--verbose` still logs evenodd warnings for backward compatibility.
   - Programmatic helpers: `diagnoseSvgContents`, `diagnoseGlyphsData` exported from the package entry.

--- a/README.md
+++ b/README.md
@@ -85,8 +85,26 @@ npm install --save-dev webfont
 
 Node.js only — do not import from client-side app code ([#198](https://github.com/itgalaxy/webfont/issues/198)).
 
+### Import (ESM and CommonJS)
+
+Use the **named export** — required for native ESM and recommended since webfont **10+**:
+
 ```js
-import webfont from "webfont";
+import { webfont } from "webfont";
+```
+
+CommonJS:
+
+```js
+const { webfont } = require("webfont");
+```
+
+`import webfont from "webfont"` often fails under `"type": "module"` with `TypeError: webfont is not a function` because the default export is not always the function itself ([#618](https://github.com/itgalaxy/webfont/issues/618)). A default export remains for older tooling; prefer the named import in new code. See [MIGRATION.md](./MIGRATION.md).
+
+### Basic example
+
+```js
+import { webfont } from "webfont";
 
 webfont({
   files: "src/svg-icons/**/*.svg",
@@ -106,7 +124,7 @@ webfont({
 or
 
 ```js
-const webfont = require("webfont").default;
+const { webfont } = require("webfont");
 
 webfont({
   files: "src/svg-icons/**/*.svg",
@@ -126,7 +144,7 @@ webfont({
 ### TTF encoding examples
 
 ```js
-import webfont from "webfont";
+import { webfont } from "webfont";
 
 // Single local TTF → WOFF + WOFF2 (default when formats unset)
 const encoded = await webfont({
@@ -150,7 +168,7 @@ const batch = await webfont({
 ### Webfont decompress examples
 
 ```js
-import webfont from "webfont";
+import { webfont } from "webfont";
 
 // Single local file
 const one = await webfont({
@@ -284,7 +302,7 @@ webfont "icons/*.svg" -d dist/icons -t scss --addHashInFontUrl
 ```
 
 ```js
-import webfont from "webfont";
+import { webfont } from "webfont";
 
 await webfont({
   files: "src/icons/**/*.svg",
@@ -332,7 +350,7 @@ Do **not** use `Math.random()` in `fontName` — that renames both font files an
 - Example:
 
   ```js
-  import webfont from "webfont";
+  import { webfont } from "webfont";
 
   webfont({
     files: "src/svg-icons/**/*.svg",
@@ -363,7 +381,7 @@ Do **not** use `Math.random()` in `fontName` — that renames both font files an
 
   ```js
   import outlineStroke from "svg-outline-stroke";
-  import webfont from "webfont";
+  import { webfont } from "webfont";
 
   await webfont({
     files: "src/svg-icons/**/*.svg",
@@ -382,7 +400,7 @@ Do **not** use `Math.random()` in `fontName` — that renames both font files an
 - Optional: `svgoConfig` — SVGO `Config` object; when `plugins` is set, it replaces the built-in conservative plugin list.
 
   ```js
-  import webfont from "webfont";
+  import { webfont } from "webfont";
 
   await webfont({
     files: "src/icons/**/*.svg",
@@ -399,13 +417,13 @@ Do **not** use `Math.random()` in `fontName` — that renames both font files an
 - Type: `{ diagnose?: boolean; onMessage?: (message: string) => void }`
 - Default: `undefined` (disabled)
 - Description: **Alpha.** Scan SVG sources for icon-font incompatibilities before font generation (SVG pipeline only). Does **not** modify SVGs — use [`glyphContentTransformFn`](#glyphcontenttransformfn) to preprocess (for example stroke-to-fill with [`svg-outline-stroke`](https://github.com/elrumordelaluz/outline-stroke), installed in your project). See [ADR 0011](docs/adr/0011-no-svg-outline-stroke-dependency.md).
-  - **`diagnose`:** log warnings for `fill-rule: evenodd`, stroke-only paths (`fill="none"` + `stroke`), and poorly supported elements (`<line>`, `<polyline>`, `<clipPath>`). Results are also returned on `result.svgDiagnostics` when enabled.
+  - **`diagnose`:** log warnings for `fill-rule: evenodd`, stroke-only paths (`fill="none"` + `stroke`), `<use>` symbol references ([#612](https://github.com/itgalaxy/webfont/issues/612)), and poorly supported elements (`<line>`, `<polyline>`, `<clipPath>`). Results are also returned on `result.svgDiagnostics` when enabled.
   - **`onMessage`:** optional sink for diagnostic log lines (tests, custom UIs).
 - CLI: `--svg-diagnose` (alpha).
 - Example:
 
   ```js
-  import webfont from "webfont";
+  import { webfont } from "webfont";
 
   const result = await webfont({
     files: "src/icons/**/*.svg",
@@ -424,7 +442,7 @@ Do **not** use `Math.random()` in `fontName` — that renames both font files an
 - Description: Custom callback to resolve glyph metadata for each source file. Receives the file path and a Node-style callback `(error, metadata)` where `metadata` is `{ name: string, unicode?: string | string[] }`. When omitted, webfont uses its default metadata reader.
 
   ```js
-  import webfont from "webfont";
+  import { webfont } from "webfont";
 
   webfont({
     files: "src/svg-icons/**/*.svg",

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -83,7 +83,7 @@ Font generation can finish before files are written. If the destination folder i
 6. **When using the programmatic API**, set `destCreate: true` if the folder may not exist yet:
 
    ```js
-   import webfont from "webfont";
+   import { webfont } from "webfont";
 
    await webfont({
      files: "src/icons/*.svg",
@@ -232,7 +232,7 @@ The same SVG looks correct in Inkscape, Illustrator, or Affinity Designer.
 
 Run with **`--verbose`** to log a warning when webfont detects `fill-rule: evenodd` in a source SVG.
 
-**Alpha — broader diagnostics:** use **`--svg-diagnose`** (CLI) or `svgTools: { diagnose: true }` (API) to also flag stroke-only SVGs and unsupported elements (`<line>`, `<polyline>`, `<clipPath>`). webfont does not auto-fix these — preprocess with [`glyphContentTransformFn`](./README.md#glyphcontenttransformfn) when needed (see [ADR 0011](docs/adr/0011-no-svg-outline-stroke-dependency.md)).
+**Alpha — broader diagnostics:** use **`--svg-diagnose`** (CLI) or `svgTools: { diagnose: true }` (API) to also flag stroke-only SVGs, `<use>` symbol references ([#612](https://github.com/itgalaxy/webfont/issues/612)), and unsupported elements (`<line>`, `<polyline>`, `<clipPath>`). webfont does not auto-fix these — preprocess with [`glyphContentTransformFn`](./README.md#glyphcontenttransformfn) when needed (see [ADR 0011](docs/adr/0011-no-svg-outline-stroke-dependency.md)).
 
 ### Steps to try to resolve
 
@@ -290,6 +290,51 @@ On **older releases**, the command may exit successfully but the icon is **invis
 4. **Optional SVGO cleanup:** `webfont icons/*.svg --optimize-svg` (or `optimizeSvg: true`) removes comments and editor metadata before conversion — it does **not** convert strokes. Use **before** `glyphContentTransformFn` when you need both cleanup and stroke outlining ([#724](https://github.com/itgalaxy/webfont/issues/724)).
 
 5. **Optimize with SVGO** only after strokes are outlines — aggressive SVGO presets alone do not fix stroke-only artwork for icon fonts.
+
+---
+
+## SVG transform and `<use>` references
+
+### What error appeared
+
+There is often **no build error**. The font generates, but a glyph is **empty**, **wrong**, or **missing a flip/offset** that looks correct in the browser. Source SVGs may look like:
+
+```xml
+<use transform="matrix(1 0 0 -1 0 21.985684)" xlink:href="#symbol-id"></use>
+```
+
+See [#612](https://github.com/itgalaxy/webfont/issues/612).
+
+### Why it usually happens
+
+- **svgicons2svgfont** (the library that merges SVGs into a font) converts **filled paths** on each icon file. It does **not** resolve **`<use>` / `<symbol>`** references or bake **`transform`** on those instances into standalone path data.
+- **`transform` on paths/groups** is experimental upstream; **`<use xlink:href="#…">`** is a separate limitation — the referenced geometry is never inlined.
+- Design tools and browsers render `<use>` + `transform` correctly; the font pipeline does not.
+
+### Steps to try to resolve
+
+1. **Flatten before webfont** — in Illustrator, Inkscape, or Figma export: **Expand / Flatten / Outline stroke**, or export **plain SVG** without symbols/instances.
+
+2. **SVGO** (in your build): plugins such as **`convertShapeToPath`** and **`cleanupIds`** help; use a preset that inlines or removes `<use>` where possible. webfont’s **`--optimize-svg`** does **not** inline `<use>` — run SVGO in `glyphContentTransformFn` if you need that step.
+
+3. **Scan sources:** `webfont icons/*.svg --svg-diagnose` warns when `<use>` is detected (**12.1.0+**).
+
+4. **Preprocess in code:**
+
+   ```js
+   import { webfont } from "webfont";
+   import { optimize } from "svgo";
+
+   await webfont({
+     files: "src/icons/**/*.svg",
+     glyphContentTransformFn: async (glyph) =>
+       optimize(glyph.contents, { plugins: ["preset-default"] }).data,
+   });
+   ```
+
+   Adjust SVGO plugins to your icons; test output glyphs in the HTML preview.
+
+See also [`docs/migration/issue-0612-svg-use-transform.md`](./docs/migration/issue-0612-svg-use-transform.md).
 
 ---
 

--- a/docs/migration/issue-0612-svg-use-transform.md
+++ b/docs/migration/issue-0612-svg-use-transform.md
@@ -1,0 +1,44 @@
+# SVG `<use>` and `transform` attributes (#612)
+
+**Minimum version:** 12.1.0 (diagnostic warning); flattening workaround on all versions
+
+## What changed
+
+webfont **does not convert** `<use xlink:href="#…">` references or apply **`transform`** on those instances when building icon fonts. **12.1.0+** adds an **`use-reference`** entry in `--svg-diagnose` / `svgTools.diagnose` output.
+
+## Before
+
+Icons that rely on `<symbol>` + `<use transform="…">` render correctly in browsers but may produce **empty or wrong glyphs** in the generated font ([#612](https://github.com/itgalaxy/webfont/issues/612)).
+
+## After
+
+- **`--svg-diagnose`** / `svgTools: { diagnose: true }` logs a warning when `<use>` is present.
+- [TROUBLESHOOTING.md](../../TROUBLESHOOTING.md) — “SVG transform and `<use>` references”.
+
+## Workaround on older versions
+
+Flatten icons before webfont:
+
+- Design tool: Expand / Flatten / export without symbol instances.
+- Build: run [SVGO](https://github.com/svg/svgo) (or similar) in `glyphContentTransformFn` to inline paths.
+
+```js
+import { webfont } from "webfont";
+
+await webfont({
+  files: "src/icons/**/*.svg",
+  glyphContentTransformFn: async (glyph) => {
+    // Your SVGO or flatten step here
+    return glyph.contents;
+  },
+});
+```
+
+## After upgrading
+
+```shell
+npm install webfont@latest
+webfont "icons/*.svg" --svg-diagnose
+```
+
+No automatic fix — diagnostics help you find `<use>` before shipping a broken font.

--- a/src/fixtures/svg-use-icons/use-transform.svg
+++ b/src/fixtures/svg-use-icons/use-transform.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 24 24">
+  <symbol id="shape" viewBox="0 0 24 24">
+    <path d="M12 2L2 22h20L12 2z" />
+  </symbol>
+  <use transform="matrix(1 0 0 -1 0 21.985684)" xlink:href="#shape" />
+</svg>

--- a/src/lib/svgDiagnostics/diagnoseSvgContents.test.ts
+++ b/src/lib/svgDiagnostics/diagnoseSvgContents.test.ts
@@ -1,7 +1,12 @@
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { hasEvenoddFillRule } from "../evenoddFillRule";
-import { diagnoseSvgContents, hasStrokeOnlySvg, hasUnsupportedSvgElements } from "./diagnoseSvgContents";
+import {
+  diagnoseSvgContents,
+  hasStrokeOnlySvg,
+  hasUnsupportedSvgElements,
+  hasUseReference,
+} from "./diagnoseSvgContents";
 
 const fixturesGlob = resolve(__dirname, "../../fixtures");
 
@@ -32,6 +37,18 @@ describe("diagnoseSvgContents", () => {
 
     expect(hasStrokeOnlySvg(svg)).toBe(false);
     expect(hasUnsupportedSvgElements(svg)).toBe(false);
+    expect(hasUseReference(svg)).toBe(false);
     expect(diagnoseSvgContents("plus-filled.svg", svg)).toEqual([]);
+  });
+
+  it("should detect <use> references with transform (#612)", () => {
+    const svg = readFileSync(`${fixturesGlob}/svg-use-icons/use-transform.svg`, "utf8");
+
+    expect(hasUseReference(svg)).toBe(true);
+
+    const diagnostics = diagnoseSvgContents("use-transform.svg", svg);
+
+    expect(diagnostics.some((entry) => entry.code === "use-reference")).toBe(true);
+    expect(diagnostics[0]?.message).toContain("612");
   });
 });

--- a/src/lib/svgDiagnostics/diagnoseSvgContents.ts
+++ b/src/lib/svgDiagnostics/diagnoseSvgContents.ts
@@ -4,6 +4,7 @@ import { hasEvenoddFillRule } from "../evenoddFillRule";
 const STROKE_ATTR_PATTERN = /\bstroke\s*=|\bstroke\s*:/iu;
 const FILL_NONE_PATTERN = /fill\s*=\s*["']none["']|fill\s*:\s*none/iu;
 const UNSUPPORTED_ELEMENT_PATTERN = /<(line|polyline|clipPath)\b/iu;
+const USE_REFERENCE_PATTERN = /<use\b/iu;
 
 export const hasStrokeOnlySvg = (svgContents: string): boolean => {
   if (!STROKE_ATTR_PATTERN.test(svgContents)) {
@@ -16,6 +17,8 @@ export const hasStrokeOnlySvg = (svgContents: string): boolean => {
 export const hasUnsupportedSvgElements = (svgContents: string): boolean =>
   UNSUPPORTED_ELEMENT_PATTERN.test(svgContents);
 
+export const hasUseReference = (svgContents: string): boolean => USE_REFERENCE_PATTERN.test(svgContents);
+
 const diagnosticMessage = (code: SvgDiagnosticCode, srcPath: string): string => {
   switch (code) {
     case "evenodd-fill-rule":
@@ -24,6 +27,8 @@ const diagnosticMessage = (code: SvgDiagnosticCode, srcPath: string): string => 
       return `[webfont:diagnose] ${srcPath} uses stroke-based paths (fill="none"). svgicons2svgfont ignores stroke; outlines may render as solid shapes or lose detail. Preprocess with glyphContentTransformFn (for example svg-outline-stroke) before conversion. See TROUBLESHOOTING.md ("Icon details missing after export").`;
     case "unsupported-element":
       return `[webfont:diagnose] ${srcPath} contains <line>, <polyline>, or <clipPath>. These elements are poorly supported in icon fonts; results may differ from the browser preview. Convert to filled paths or preprocess with glyphContentTransformFn.`;
+    case "use-reference":
+      return `[webfont:diagnose] ${srcPath} contains <use> (symbol/instance references). svgicons2svgfont does not resolve <use> or apply transform on references — the glyph may be empty or wrong. Flatten to paths in your editor, or preprocess with SVGO / glyphContentTransformFn before conversion. See TROUBLESHOOTING.md ("SVG transform and <use> references", #612).`;
     default: {
       const exhaustive: never = code;
       return exhaustive;
@@ -54,6 +59,14 @@ export const diagnoseSvgContents = (srcPath: string, svgContents: string): SvgGl
     diagnostics.push({
       code: "unsupported-element",
       message: diagnosticMessage("unsupported-element", srcPath),
+      srcPath,
+    });
+  }
+
+  if (hasUseReference(svgContents)) {
+    diagnostics.push({
+      code: "use-reference",
+      message: diagnosticMessage("use-reference", srcPath),
       srcPath,
     });
   }

--- a/src/types/SvgToolsOptions.ts
+++ b/src/types/SvgToolsOptions.ts
@@ -1,4 +1,4 @@
-export type SvgDiagnosticCode = "evenodd-fill-rule" | "stroke-only" | "unsupported-element";
+export type SvgDiagnosticCode = "evenodd-fill-rule" | "stroke-only" | "unsupported-element" | "use-reference";
 
 export type SvgGlyphDiagnostic = {
   code: SvgDiagnosticCode;


### PR DESCRIPTION
## Summary

### Proposed changes

This PR brings the following changes:

- README: prefer `import { webfont } from "webfont"` with ESM/CJS guidance ([#618](https://github.com/itgalaxy/webfont/issues/618)); update all code samples.
- TROUBLESHOOTING: named import in API example; new section “SVG transform and `<use>` references”.
- `--svg-diagnose` / `svgTools.diagnose`: new `use-reference` warning when SVG contains `<use>` ([#612](https://github.com/itgalaxy/webfont/issues/612)).
- Migration entry `docs/migration/issue-0612-svg-use-transform.md` and fixture for tests.

### Related issue

https://github.com/itgalaxy/webfont/issues/612

### Dependencies added/removed (if applicable)

N/A

---

### Testing

- [x] I have added or updated tests that prove my fix is effective or that my feature works (if applicable)
  - [x] Unit test

#### How to test

1. `npm test` — 400 tests pass.
2. `webfont src/fixtures/svg-use-icons/*.svg --svg-diagnose` — logs `use-reference` warning.

#### Test configuration

N/A

---

## Checklist

- [ ] I have added corresponding labels to this PR (like bug, enhancement...);
- [x] My commits follow the [Conventional Commits 1.0 Guidelines](https://www.conventionalcommits.org/en/v1.0.0/);
- [x] My code follows the style guidelines of this project;
- [x] I have performed a self-review of my own code;
- [ ] I have mapped technical debts found on my changes;
- [x] I have made changes to the documentation (if applicable);
- [x] My changes generate no new warnings or errors;

Made with [Cursor](https://cursor.com)