### PR TITLE
build(deps): bump wawoff2 to 2.0.1; add ttfEncode tests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -153,7 +153,7 @@ See also [CONTRIBUTING.md](./CONTRIBUTING.md) — “User-facing changes and doc
 
 - Follow [CONTRIBUTING.md](./CONTRIBUTING.md) and existing ADRs under `docs/adr/`.
 - Run `npm run depcheck` (Knip) when changing imports or `package.json` dependencies; see [ADR 0008](docs/adr/0008-knip-instead-of-depcheck.md). The **pre-push** Lefthook runs `depcheck` before `npm test`.
-- Use conventional commits (`feat`, `fix`, `test`, `docs`, `chore`, `refactor`, `ci`).
+- Use conventional commits (`feat`, `fix`, `test`, `docs`, `chore`, `refactor`, `ci`, `build`). Prefer **`build(deps):`** or **`chore(deps):`** when the PR changes `package.json` / lockfile dependencies — even if the diff is mostly tests or docs (see [Pull requests](#pull-requests)).
 - Releases are handled by Release Please on `master`; do not bump `package.json` version in feature PRs (see [ADR 0004](docs/adr/0004-release-please-instead-of-standard-version.md)). Release git tags use **`v{semver}`** (`v12.0.0`); `release-please-config.json` sets `include-component-in-tag: false` — do not use `webfont-v*` tags.
 - Keep changes focused; match surrounding code style and tooling (Biome, Vitest, Lefthook).
 - Do not commit unless explicitly asked.
@@ -221,7 +221,7 @@ When a task produces branch changes intended for review (features, fixes, CI, do
 2. **Create a branch** from `master` using a **lowercase** name (for example `docs/pr-workflow`, `test/xml2js-guards`, `fix/cli-formats`). The entire branch name must stay lowercase — no camelCase or uppercase segments (avoid names like `test/toTtf-unit-tests`).
 3. **Read** [`.github/pull_request_template.md`](./.github/pull_request_template.md) and use it as the PR body structure (do not substitute a shorter custom format).
 4. **Push** the branch to `origin` (`git push -u origin HEAD`) without asking first.
-5. **Open a PR** with `gh pr create` (title + body in English, base `master`) without asking first. Pass the body via HEREDOC so headings and checklists match the template. **PR title must follow [Conventional Commits](https://www.conventionalcommits.org/)** (`type: description`, optional scope — e.g. `chore(deps): bump svg2ttf to 6.1.0`). Strip bot prefixes (`[Snyk]`, `[Dependabot]`) and rewrite to the correct type.
+5. **Open a PR** with `gh pr create` (title + body in English, base `master`) without asking first. Pass the body via HEREDOC so headings and checklists match the template. **PR title must follow [Conventional Commits](https://www.conventionalcommits.org/)** (`type: description`, optional scope). Strip bot prefixes (`[Snyk]`, `[Dependabot]`) and rewrite to the correct type — use **`build(deps):`** or **`chore(deps):`** when dependencies change (see **Dependency bumps** under Scope, title, and description).
 6. **Return the PR URL** in the final response.
 
 **Squash merge only.** Routine merges to `master` use **Squash and merge** so the PR title is the single commit on `master` (Release Please depends on this). Do not use merge commits or rebase-merge unless a maintainer explicitly requests it.
@@ -276,7 +276,8 @@ Keep the template **headings and order**, but write each section critically — 
 
 ### Scope, title, and description
 
-- **PR title = Conventional Commits.** Match commit style (`feat:`, `fix:`, `chore(deps):`, `docs:`, `test:`, `ci:`, …). When the PR is open and the title is wrong, fix it with `gh pr edit` before ending the task.
+- **PR title = Conventional Commits.** Match commit style (`feat:`, `fix:`, `build(deps):`, `chore(deps):`, `docs:`, `test:`, `ci:`, …). When the PR is open and the title is wrong, fix it with `gh pr edit` before ending the task. Squash merge puts the title on `master`; Release Please reads it.
+- **Dependency bumps set the type.** If the PR updates **`package.json` / `package-lock.json` dependencies**, the title must be **`build(deps):`** or **`chore(deps):`** — not `test:`, `docs:`, or `refactor:` even when most of the diff is new tests. Example: `build(deps): bump wawoff2 to 2.0.1; add ttfEncode tests`. Strip `[Dependabot]` / `[Snyk]` prefixes and rewrite.
 - **Re-read the PR title and body whenever the branch scope changes.** After adding commits, update the title and **Proposed changes** section so reviewers see the full picture — not just the first commit message.
 - **Split when it grows too much.** If a branch picks up unrelated fixes, large test extractions, or docs on top of the original goal, prefer **separate PRs** for follow-up work rather than one ever-growing branch. This PR accumulated extra scope before that rule was written; use smaller PRs from here on.
 - **Explain why when closing a PR.** Leave an English comment (superseded, obsolete, duplicate, out of scope, etc.) — do not close without context. See [CONTRIBUTING.md](./CONTRIBUTING.md) (“Closing pull requests”).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -80,11 +80,12 @@ Agents and automation should follow the same rule — see [AGENTS.md](./AGENTS.m
 
 ### Pull request title and description
 
-- **Use [Conventional Commits](https://www.conventionalcommits.org/) for the PR title** — the same format as commit messages (`feat:`, `fix:`, `chore(deps):`, `docs:`, `test:`, `ci:`, etc.). The title should describe the **overall** change in the PR, not bot prefixes like `[Snyk]` or `[Dependabot]`.
+- **Use [Conventional Commits](https://www.conventionalcommits.org/) for the PR title** — the same format as commit messages (`feat:`, `fix:`, `build(deps):`, `chore(deps):`, `docs:`, `test:`, `ci:`, etc.). The title should describe the **overall** change in the PR, not bot prefixes like `[Snyk]` or `[Dependabot]`.
+- **Dependency updates drive the PR type.** If the PR changes **`package.json` or `package-lock.json` dependencies**, use **`build(deps):`** or **`chore(deps):`** in the title — not `test:` or `docs:` even when the diff is mostly new tests or migration notes. Example: `build(deps): bump wawoff2 to 2.0.1; add ttfEncode tests`. Release Please reads the squash-merge title on `master`.
 - **Merge pull requests with squash.** The PR title becomes the commit message on `master` (Release Please reads it). Do not merge with merge commits or rebase-merge for routine work.
 - **Write pull request titles, descriptions, and review comments in English** (commits and code comments in English as well).
 - **Keep the PR title and body in sync with the actual diff.** When new commits change what the PR does (extra fixes, tests, docs, refactors), update the title and description before asking for review — do not leave a narrow title like “enable strictNullChecks” on a PR that also ships CLI bug fixes and README changes.
-- **Rename non-conforming PR titles** before review when the title uses vendor labels (`[Snyk]`, `[Dependabot]`), plain prose, or the wrong type. Example: `chore(deps): bump svg2ttf from 6.0.3 to 6.1.0` instead of `[Snyk] Security upgrade svg2ttf from 6.0.3 to 6.1.0`.
+- **Rename non-conforming PR titles** before review when the title uses vendor labels (`[Snyk]`, `[Dependabot]`), plain prose, the wrong type, or **`test:` / `docs:` on a dependency bump**. Example: `build(deps): bump svg2ttf from 6.0.3 to 6.1.0` instead of `[Snyk] Security upgrade svg2ttf from 6.0.3 to 6.1.0` or `test: add coverage after svg2ttf bump`.
 - **Prefer focused PRs.** If the scope keeps growing (unrelated fixes, large test refactors, docs, and feature work in one branch), stop stacking and **split follow-up work into separate PRs** instead. Land the original change first, then open new branches for the rest.
 
 See [AGENTS.md](./AGENTS.md) (“Pull requests”) for agents and automation.

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "svgo": "4.0.1",
         "ttf2eot": "3.1.0",
         "ttf2woff": "^3.0.0",
-        "wawoff2": "2.0.0",
+        "wawoff2": "2.0.1",
         "xml2js": "0.6.2"
       },
       "bin": {
@@ -4660,9 +4660,10 @@
       }
     },
     "node_modules/wawoff2": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/wawoff2/-/wawoff2-2.0.0.tgz",
-      "integrity": "sha512-5gjFj+fyQO9cMrg5vYaVM7+T37xSHpqUWM/S6UCEiBx8wRmfpvuhYjPM3toB2UujpmWQt1hSPKRo/jIRE/j9Eg==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/wawoff2/-/wawoff2-2.0.1.tgz",
+      "integrity": "sha512-r0CEmvpH63r4T15ebFqeOjGqU4+EgTx4I510NtK35EMciSdcTxCw3Byy3JnBonz7iyIFZ0AbVo0bbFpEVuhCYA==",
+      "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
       },
@@ -7414,9 +7415,9 @@
       "dev": true
     },
     "wawoff2": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/wawoff2/-/wawoff2-2.0.0.tgz",
-      "integrity": "sha512-5gjFj+fyQO9cMrg5vYaVM7+T37xSHpqUWM/S6UCEiBx8wRmfpvuhYjPM3toB2UujpmWQt1hSPKRo/jIRE/j9Eg==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/wawoff2/-/wawoff2-2.0.1.tgz",
+      "integrity": "sha512-r0CEmvpH63r4T15ebFqeOjGqU4+EgTx4I510NtK35EMciSdcTxCw3Byy3JnBonz7iyIFZ0AbVo0bbFpEVuhCYA==",
       "requires": {
         "argparse": "^2.0.1"
       },

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "svgo": "4.0.1",
     "ttf2eot": "3.1.0",
     "ttf2woff": "^3.0.0",
-    "wawoff2": "2.0.0",
+    "wawoff2": "2.0.1",
     "xml2js": "0.6.2"
   },
   "devDependencies": {

--- a/src/lib/ttfEncode.test.ts
+++ b/src/lib/ttfEncode.test.ts
@@ -1,0 +1,65 @@
+import crypto from "crypto";
+import fontverter from "fontverter";
+import * as fsPromise from "fs/promises";
+import isEot from "is-eot";
+import isTtf from "is-ttf";
+import isWoff from "is-woff";
+import isWoff2 from "is-woff2";
+import wawoff2 from "wawoff2";
+import { encodeTtfToEot, encodeTtfToWoff, encodeTtfToWoff2 } from "./ttfEncode";
+
+const fixtureTtf = "src/fixtures/fonts/iconfont.ttf";
+
+describe("ttfEncode", () => {
+  describe("encodeTtfToWoff2 (wawoff2.compress)", () => {
+    it("should compress a ttf buffer to a valid woff2 buffer", async () => {
+      const ttf = await fsPromise.readFile(fixtureTtf);
+      const woff2 = await encodeTtfToWoff2(ttf);
+
+      expect(isWoff2(woff2)).toBe(true);
+      expect(woff2.length).toBeGreaterThan(0);
+    });
+
+    it("should produce deterministic woff2 output for fixture icons", async () => {
+      const ttf = await fsPromise.readFile(fixtureTtf);
+      const woff2 = await encodeTtfToWoff2(ttf);
+      const hash = crypto.createHash("md5").update(woff2).digest("hex");
+
+      expect(hash).toBe("2ad812a7b330c471a908eba3df6de6a2");
+    });
+
+    it("should round-trip through wawoff2.decompress to valid ttf", async () => {
+      const ttf = await fsPromise.readFile(fixtureTtf);
+      const woff2 = await encodeTtfToWoff2(ttf);
+      const roundTrip = Buffer.from(await wawoff2.decompress(woff2));
+
+      expect(isTtf(roundTrip)).toBe(true);
+    });
+
+    it("should round-trip through fontverter (webfont WOFF2 decompress path)", async () => {
+      const ttf = await fsPromise.readFile(fixtureTtf);
+      const woff2 = await encodeTtfToWoff2(ttf);
+      const sfnt = Buffer.from(await fontverter.convert(woff2, "sfnt"));
+
+      expect(isTtf(sfnt)).toBe(true);
+    });
+  });
+
+  describe("encodeTtfToWoff (ttf2woff)", () => {
+    it("should encode a ttf buffer to a valid woff buffer", async () => {
+      const ttf = await fsPromise.readFile(fixtureTtf);
+      const woff = encodeTtfToWoff(ttf);
+
+      expect(isWoff(woff)).toBe(true);
+    });
+  });
+
+  describe("encodeTtfToEot (ttf2eot adapter)", () => {
+    it("should encode a ttf buffer to a valid eot buffer", async () => {
+      const ttf = await fsPromise.readFile(fixtureTtf);
+      const eot = encodeTtfToEot(ttf);
+
+      expect(isEot(eot)).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

### Proposed changes

This PR brings the following changes:

- Add `src/lib/ttfEncode.test.ts` with focused coverage for `encodeTtfToWoff2` (`wawoff2.compress`): valid WOFF2 output, deterministic MD5 on fixture TTF, round-trip via `wawoff2.decompress`, and round-trip via `fontverter` (same path as WOFF2 input decompression).
- Smoke tests for `encodeTtfToWoff` and `encodeTtfToEot` in the same module.
- Bump **wawoff2** `2.0.0` → **`2.0.1`** (supersedes Dependabot #718 — patch keeps Node `unhandledRejection` handlers intact per [wawoff2 changelog](https://github.com/fontello/wawoff2/blob/master/CHANGELOG.md)).

### Related issue

Supersedes https://github.com/itgalaxy/webfont/pull/718

### Dependencies added/removed (if applicable)

- Update: `wawoff2` `2.0.0` → `2.0.1`

---

### Testing

- [x] I have added or updated tests that prove my fix is effective or that my feature works (if applicable)
  - [x] Unit test

#### How to test

1. `npm test` — 406 tests pass (6 new in `ttfEncode.test.ts`).

#### Test configuration

N/A

---

## Checklist

- [x] I have added corresponding labels to this PR (like bug, enhancement...);
- [x] My commits follow the [Conventional Commits 1.0 Guidelines](https://www.conventionalcommits.org/en/v1.0.0/);
- [x] My code follows the style guidelines of this project;
- [x] I have performed a self-review of my own code;
- [x] I have mapped technical debts found on my changes;
- [x] I have made changes to the documentation (if applicable);
- [x] My changes generate no new warnings or errors;

Made with [Cursor](https://cursor.com)