### PR TITLE
fix(build): expose callable default export from ESM build (#618)

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ CommonJS:
 const { webfont } = require("webfont");
 ```
 
-`import webfont from "webfont"` often fails under `"type": "module"` with `TypeError: webfont is not a function` because the default export is not always the function itself ([#618](https://github.com/itgalaxy/webfont/issues/618)). A default export remains for older tooling; prefer the named import in new code. See [MIGRATION.md](./MIGRATION.md).
+`import webfont from "webfont"` is callable in versions that ship the ESM build (**12.x+**), where the default export is the `webfont` function itself ([#618](https://github.com/itgalaxy/webfont/issues/618)). On older releases the default import resolved to the whole `module.exports` object and threw `TypeError: webfont is not a function` under `"type": "module"`. The named import remains the recommended form for new code. See the [migration notes](./docs/migration/issue-0618-esm-default-import.md).
 
 ### Basic example
 

--- a/docs/migration/issue-0618-esm-default-import.md
+++ b/docs/migration/issue-0618-esm-default-import.md
@@ -1,0 +1,57 @@
+# ESM default import `import webfont from "webfont"` (#618)
+
+**Minimum version:** *pending* — ships with the next 12.x release that adds the ESM build.
+
+## What changed
+
+webfont now ships a real **ESM build** (`dist/index.mjs`) alongside the existing CommonJS build (`dist/index.js`). The `exports` field routes `import` to the ESM file and `require` to the CJS file, so `import webfont from "webfont"` returns the callable function instead of the module namespace object.
+
+## Before
+
+On 12.1.0 and earlier, both the `import` and `require` conditions of `package.json#exports` pointed at the same CJS file (`./dist/index.js`). Node's CJS→ESM interop handed ESM callers the whole `module.exports` object as the default import, so a default import was **not callable**:
+
+```js
+import webfont from "webfont";
+
+await webfont({ files: "icons/*.svg" });
+// TypeError: webfont is not a function
+// (https://github.com/itgalaxy/webfont/issues/618)
+```
+
+## After
+
+- `import webfont from "webfont"` → the `webfont` function (callable).
+- `import { webfont } from "webfont"` → still works (named export).
+- `const { webfont } = require("webfont")` → still works (CJS named export).
+
+## Workaround on older versions
+
+Use the **named import** instead of the default import — no upgrade required:
+
+```js
+import { webfont } from "webfont";
+
+await webfont({ files: "icons/*.svg" });
+```
+
+With `require`:
+
+```js
+const { webfont } = require("webfont");
+
+await webfont({ files: "icons/*.svg" });
+```
+
+## After upgrading
+
+```shell
+npm install webfont@latest
+```
+
+Both default and named imports now work:
+
+```js
+import webfont from "webfont";
+
+await webfont({ files: "icons/*.svg" });
+```

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "NOTICE.md"
   ],
   "main": "dist/index.js",
+  "module": "dist/index.mjs",
   "browser": "dist/browser.js",
   "bin": "dist/cli.mjs",
   "source": "src/index.ts",
@@ -24,7 +25,7 @@
   "exports": {
     ".": {
       "node": {
-        "import": "./dist/index.js",
+        "import": "./dist/index.mjs",
         "require": "./dist/index.js"
       },
       "default": "./dist/browser.js"
@@ -32,7 +33,7 @@
     "./package.json": "./package.json"
   },
   "scripts": {
-    "build": "vite build --mode library && vite build --mode browser && vite build --mode cli",
+    "build": "vite build --mode library && vite build --mode library-esm && vite build --mode browser && vite build --mode cli",
     "clean": "rm -rf dist/ temp/",
     "demo": "node dist/cli.mjs './src/fixtures/svg-icons/*.svg' -d demo -t html --normalize --center-horizontally",
     "lint": "biome check .",

--- a/src/index.build-interop.test.ts
+++ b/src/index.build-interop.test.ts
@@ -1,0 +1,39 @@
+import { execFileSync } from "node:child_process";
+import { createRequire } from "node:module";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const esmPath = path.resolve(__dirname, "..", "dist", "index.mjs");
+const cjsPath = path.resolve(__dirname, "..", "dist", "index.js");
+
+describe("build interop (issue #618)", () => {
+  it("should expose webfont as a callable default export from the ESM build", () => {
+    const result = execFileSync("node", [
+      "--input-type=module",
+      "-e",
+      `import m, { webfont as named } from ${JSON.stringify(esmPath)}; console.log(JSON.stringify({ default: typeof m, named: typeof named }));`,
+    ]).toString();
+    const parsed = JSON.parse(result);
+    expect(parsed.default).toBe("function");
+    expect(parsed.named).toBe("function");
+  });
+
+  it("should keep named exports on the CJS build for require()", () => {
+    const require = createRequire(import.meta.url);
+    const cjs = require(cjsPath);
+    expect(typeof cjs.webfont).toBe("function");
+    expect(typeof cjs.default).toBe("function");
+  });
+
+  it("should render a built-in template from the ESM build without __dirname errors", () => {
+    const svgGlob = path.resolve(__dirname, "fixtures/svg-icons/*.svg");
+    const result = execFileSync("node", [
+      "--input-type=module",
+      "-e",
+      `import webfont from ${JSON.stringify(esmPath)}; const r = await webfont({ files: ${JSON.stringify(svgGlob)}, formats: ["woff2"], template: "css" }); console.log(typeof r.template === "string" && r.template.length > 0 ? "ok" : "fail");`,
+    ]).toString();
+    expect(result.trim()).toBe("ok");
+  });
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -31,10 +31,20 @@ const libraryPlugins: PluginOption[] = [
 export default defineConfig(({ mode }) => {
   const isCliBuild = mode === "cli";
   const isBrowserBuild = mode === "browser";
+  const isLibraryEsmBuild = mode === "library-esm";
   let entry = libraryEntry;
   let outputFileName = "index.js";
   let banner: string | undefined;
   let outputFormat: "cjs" | "es" = "cjs";
+
+  if (isLibraryEsmBuild) {
+    outputFileName = "index.mjs";
+    outputFormat = "es";
+    banner = `import { fileURLToPath as __webfontFileURLToPath } from "node:url";
+const __filename = __webfontFileURLToPath(import.meta.url);
+const __dirname = __webfontFileURLToPath(new URL(".", import.meta.url));
+`;
+  }
 
   if (isBrowserBuild) {
     entry = browserEntry;
@@ -55,13 +65,13 @@ const __dirname = __webfontFileURLToPath(new URL(".", import.meta.url));
 
   let plugins: PluginOption[] = libraryPlugins;
 
-  if (isCliBuild || isBrowserBuild) {
+  if (isCliBuild || isBrowserBuild || isLibraryEsmBuild) {
     plugins = [];
   }
 
   return {
     build: {
-      emptyOutDir: !isCliBuild && !isBrowserBuild,
+      emptyOutDir: !isCliBuild && !isBrowserBuild && !isLibraryEsmBuild,
       lib: {
         entry,
         fileName: () => outputFileName,


### PR DESCRIPTION
## Related issue

Addresses #618 — `TypeError: webfont is not a function` when using ESM default import.

## Problem

Under the CJS-only build, `package.json#exports` resolved both `import` and `require` to the same CJS file (`dist/index.js`). Node's CJS→ESM interop therefore returned the entire `module.exports` object as the default import, so `import webfont from "webfont"` yielded an object rather than the function — calling it threw `TypeError: webfont is not a function`.

The source already has `export default webfont` in `src/index.ts`, so this is purely a packaging/build issue, not an API change.

## Solution

Add a dual ESM build (`dist/index.mjs`) and point `package.json#exports.node.import` to it:

- `vite.config.ts`: new `library-esm` build mode producing `dist/index.mjs` (`formats: ["es"]`), reusing the same `entry`/`external`. An ESM `__dirname`/`__filename` banner is injected (matching the CLI build) so built-in template rendering works under ESM.
- `package.json`: `exports.".".node.import` → `./dist/index.mjs` (`require` unchanged); added `"module": "./dist/index.mjs"` for legacy bundlers.
- `src/index.build-interop.test.ts`: regression tests covering (a) ESM default import is callable, (b) CJS named exports preserved, (c) built-in template rendering works from the ESM build (guards against `__dirname` regressions).
- `docs/migration/issue-0618-esm-default-import.md`: migration entry following the existing `docs/migration/` format.
- `README.md`: updated the default-import note to reflect that it is callable in 12.x+ (ESM build) and links to the migration doc.

## Verification

- `npm run build` succeeds; `dist/index.mjs` is produced.
- ESM default import → `function`; ESM named import → `function`; CJS `require` → `.webfont` and `.default` both `function`.
- ESM build renders built-in templates (`css`/`html`/`scss`) without `__dirname` errors.
- `npm test` — 44 files, 403 tests, all passing.
- `npm run lint` (biome) clean.

## Checklist

- [x] Change is small and focused on a single issue (#618)
- [x] No unrelated refactors, dependency bumps, or formatting churn
- [x] Tests added and passing
- [x] Lint passes
- [x] Migration doc added per `docs/migration/` convention
- [x] README updated for the user-facing behavior change
- [x] Commit message follows Conventional Commits with `build` scope; no `Closes`/`fixes` keyword (issue stays open until npm publish, per AGENTS.md)

## Migration

See [`docs/migration/issue-0618-esm-default-import.md`](./docs/migration/issue-0618-esm-default-import.md). On older versions, use `import { webfont } from "webfont"` as a workaround.