### PR TITLE
build(deps): use globby directly in tests; drop fast-glob stub

### DIFF
--- a/knip.json
+++ b/knip.json
@@ -5,13 +5,12 @@
     "src/cli/index.ts",
     "src/types/index.ts",
     "templates/index.ts",
-    "vitest/globby-stub.ts",
     "src/fixtures/config-discovery/js-config/webfont.config.js",
     "src/fixtures/configs/webfont.config-cli.js",
     "src/fixtures/config-discovery/js-rc/.webfontrc.js",
     "src/fixtures/config-package/index.js"
   ],
-  "project": ["src/**/*.{ts,js}", "templates/**/*.{ts,js}", "vitest/**/*.ts"],
+  "project": ["src/**/*.{ts,js}", "templates/**/*.{ts,js}"],
   "exclude": ["duplicates"],
   "ignoreExportsUsedInFile": {
     "interface": true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,7 +40,6 @@
         "@types/wawoff2": "1.0.2",
         "@types/xml2js": "0.4.14",
         "@vitest/coverage-v8": "4.1.9",
-        "fast-glob": "3.2.12",
         "is-eot": "latest",
         "is-svg": "6.1.0",
         "is-ttf": "latest",
@@ -2501,15 +2500,16 @@
       "license": "MIT"
     },
     "node_modules/fast-glob": {
-      "version": "3.2.12",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.12.tgz",
-      "integrity": "sha512-DVj4CQIYYow0BlaelwK1pHl5n5cRSJfM60UA0zK891sVInoPri2Ekj7+e1CT3/3qxXenpI+nBBmQAcJPJgaj4w==",
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
+      "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
+      "license": "MIT",
       "dependencies": {
         "@nodelib/fs.stat": "^2.0.2",
         "@nodelib/fs.walk": "^1.2.3",
         "glob-parent": "^5.1.2",
         "merge2": "^1.3.0",
-        "micromatch": "^4.0.4"
+        "micromatch": "^4.0.8"
       },
       "engines": {
         "node": ">=8.6.0"
@@ -6903,15 +6903,15 @@
       "dev": true
     },
     "fast-glob": {
-      "version": "3.2.12",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.12.tgz",
-      "integrity": "sha512-DVj4CQIYYow0BlaelwK1pHl5n5cRSJfM60UA0zK891sVInoPri2Ekj7+e1CT3/3qxXenpI+nBBmQAcJPJgaj4w==",
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
+      "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
       "requires": {
         "@nodelib/fs.stat": "^2.0.2",
         "@nodelib/fs.walk": "^1.2.3",
         "glob-parent": "^5.1.2",
         "merge2": "^1.3.0",
-        "micromatch": "^4.0.4"
+        "micromatch": "^4.0.8"
       }
     },
     "fastq": {
@@ -7019,7 +7019,7 @@
       "integrity": "sha512-QrJia2qDf5BB/V6HYlDTs0I0lBahyjLzpGQg3KT7FnCdTonAyPy2RtY802m2k4ALx6Dp752f82WsOczEVr3l6Q==",
       "requires": {
         "@sindresorhus/merge-streams": "^4.0.0",
-        "fast-glob": "3.2.12",
+        "fast-glob": "^3.3.3",
         "ignore": "^7.0.5",
         "is-path-inside": "^4.0.0",
         "slash": "^5.1.0",

--- a/package.json
+++ b/package.json
@@ -98,7 +98,6 @@
     "@types/wawoff2": "1.0.2",
     "@types/xml2js": "0.4.14",
     "@vitest/coverage-v8": "4.1.9",
-    "fast-glob": "3.2.12",
     "is-eot": "latest",
     "is-svg": "6.1.0",
     "is-ttf": "latest",
@@ -115,7 +114,6 @@
     "vitest": "4.1.9"
   },
   "overrides": {
-    "fast-glob": "3.2.12",
     "minimatch": "10.2.5",
     "test-exclude": "7.0.2",
     "woff2sfnt-sfnt2woff": "1.0.0"

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -2,6 +2,7 @@ import path from "node:path";
 import { defineConfig } from "vitest/config";
 
 const esmNodeModules = [
+  "globby",
   "meow",
   "p-limit",
   "svgicons2svgfont",
@@ -19,7 +20,6 @@ const esmNodeModules = [
 export default defineConfig({
   resolve: {
     alias: {
-      globby: path.resolve(__dirname, "vitest/globby-stub.ts"),
       "@file-type/xml": path.resolve(__dirname, "node_modules/@file-type/xml/lib/index.js"),
     },
   },

--- a/vitest/globby-stub.ts
+++ b/vitest/globby-stub.ts
@@ -1,5 +1,0 @@
-import fg from "fast-glob";
-
-export function globby(patterns: string | readonly string[]): Promise<string[]> {
-  return fg([].concat(patterns as string | string[]));
-}


### PR DESCRIPTION
## Summary

### Proposed changes

This PR brings the following changes:

- Exercise the **real** `globby` in the test suite instead of a hand-written stub. `vitest.config.ts` now inlines `globby` via `server.deps.inline` (the same mechanism already used for `meow`, `is-svg`, `svgicons2svgfont`, …) and drops the `globby` → stub alias.
- Delete `vitest/globby-stub.ts` (the only file under `vitest/`).
- Remove `fast-glob` from `devDependencies` **and** from `overrides`.
- `knip.json`: drop the stub entry and the now-empty `vitest/` project glob.

### Related issue

- Follow-up to the dependency-hygiene review that also produced #740 (remove `rimraf`). No dedicated issue.

### Dependencies added/removed (if applicable)

- Remove: `fast-glob` (was a devDependency used only by the test stub; still present transitively via `globby`).
- Remove override: `fast-glob@3.2.12`.

---

## Why

The `globby` stub dates back to the Jest era, when loading the ESM-only `globby` in the test runner was painful. Vitest 4 inlines ESM-only dependencies natively, so the stub is no longer needed. Using the real `globby` means the in-process tests (`standalone()`, `resolveInputSources`) now cover the **actual production dependency** rather than a `fast-glob` stand-in — previously the real `globby` only ran in the CLI child-process integration tests.

Removing the `fast-glob` override is also a correctness win: it pinned `fast-glob` to `3.2.12` across the whole tree, **downgrading** `globby@16`'s own requirement (`^3.3.3`). After this change `globby` resolves `fast-glob@3.3.3` as intended.

### Testing

- [x] Unit + integration: full suite green (409 tests) with the real `globby` inlined — no test changes required.
- [x] `npm run depcheck` (knip) — clean after dropping the stub entry.
- [x] `npm run lint` (biome) — clean.

#### How to test

1. `npm install` (confirm `fast-glob` is gone from `package.json` and only present transitively under `globby` in the lockfile at `3.3.3`).
2. `npm test` — full suite passes; `src/standalone/index.test.ts` and `src/lib/inputSource.test.ts` now hit the real `globby`.
3. `npm run depcheck` — no unused/unlisted dependencies.

#### Test configuration

- Node.js version: 24.x and 26.x (CI matrix).

---

## Checklist

- [x] My commits follow the Conventional Commits 1.0 Guidelines;
- [x] My code follows the style guidelines of this project;
- [x] I have performed a self-review of my own code;
- [x] I have mapped technical debts found on my changes;
- [x] I have made changes to the documentation (if applicable) — N/A (test infra + devDependency; ADRs 0002/0005/0008 remain as historical records of the former stub);
- [x] My changes generate no new warnings or errors;

Made with [Cursor](https://cursor.com)