### PR TITLE
refactor: forbid non-null assertions and enforce noNonNullAssertion as error

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -169,6 +169,10 @@ See also [CONTRIBUTING.md](./CONTRIBUTING.md) — “User-facing changes and doc
   - Mocks: import the `__mocks__` module for assertions, or a small helper type when a cast is unavoidable (`as unknown as MockType`).
   - Expected rejections: `await expect(fn()).rejects.toThrow(...)` (not `try/catch` + conditional expects).
   - Unused parameters: `_name` prefix on the parameter or property.
+- **No non-null assertions (`!`).** The `style/noNonNullAssertion` Biome rule is `error` with **no per-file override** (including tests). Narrow the value instead:
+  - `assert(value)` from `node:assert` before use — turns `T | undefined` into `T` and fails the test with a clear message if the assumption ever breaks.
+  - Optional chaining (`value?.prop`) when the branch tolerates `undefined`.
+  - Typed fixtures/factories (e.g. `makeResultConfig`) so the value is never `undefined` in the first place.
 - **No `ignoreDeprecations` in `tsconfig.json` (or any tsconfig).** On TypeScript upgrades, migrate deprecated compiler options and fix type errors instead of silencing warnings (see [CONTRIBUTING.md](./CONTRIBUTING.md)).
 - **Enforced automatically.** `npm run lint:suppressions` (`scripts/check-no-suppressions.mjs`) scans tracked source files for banned suppressions and fails the build. It runs on **Lefthook pre-commit** and in **CI** (`.github/workflows/pr.yml`), so reintroducing an `eslint-disable`, `@ts-ignore`, `@ts-expect-error`, `@ts-nocheck`, or `ignoreDeprecations` blocks the commit/PR. After edits you can run it directly; `biome-ignore` remains allowed only when a rule cannot be satisfied by a small code change.
 

--- a/biome.json
+++ b/biome.json
@@ -77,7 +77,7 @@
         "noNamespace": "error",
         "noNegationElse": "error",
         "noNestedTernary": "error",
-        "noNonNullAssertion": "warn",
+        "noNonNullAssertion": "error",
         "noParameterAssign": "error",
         "noRestrictedGlobals": "error",
         "noRestrictedImports": "error",
@@ -149,9 +149,6 @@
         "rules": {
           "complexity": {
             "noExcessiveLinesPerFunction": "off"
-          },
-          "style": {
-            "noNonNullAssertion": "off"
           }
         }
       }

--- a/src/lib/ttf2eot/index.test.ts
+++ b/src/lib/ttf2eot/index.test.ts
@@ -1,3 +1,4 @@
+import assert from "node:assert";
 import crypto from "crypto";
 import isEot from "is-eot";
 import standalone from "../../standalone";
@@ -12,7 +13,9 @@ describe("ttf2eot", () => {
       formats: ["ttf"],
     });
 
-    const eot = convertTtfToEot(ttf!);
+    assert(ttf);
+
+    const eot = convertTtfToEot(ttf);
 
     expect(isEot(eot)).toBe(true);
     expect(eot.length).toBeGreaterThan(0);
@@ -24,7 +27,9 @@ describe("ttf2eot", () => {
       formats: ["ttf"],
     });
 
-    const hash = crypto.createHash("md5").update(convertTtfToEot(ttf!)).digest("hex");
+    assert(ttf);
+
+    const hash = crypto.createHash("md5").update(convertTtfToEot(ttf)).digest("hex");
 
     expect(hash).toBe("0da1e32d0196eceb273968727af10d99");
   });
@@ -35,6 +40,8 @@ describe("ttf2eot", () => {
       formats: ["ttf", "eot"],
     });
 
-    expect(convertTtfToEot(ttf!)).toEqual(eot);
+    assert(ttf);
+
+    expect(convertTtfToEot(ttf)).toEqual(eot);
   });
 });

--- a/src/standalone/index.test.ts
+++ b/src/standalone/index.test.ts
@@ -1,3 +1,4 @@
+import assert from "node:assert";
 import crypto from "crypto";
 import * as fsPromise from "fs/promises";
 import isEot from "is-eot";
@@ -71,11 +72,17 @@ describe("standalone", () => {
     expect(isWoff(result.woff)).toBe(true);
     expect(isWoff2(result.woff2)).toBe(true);
 
-    const svgHash = crypto.createHash("md5").update(result.svg!).digest("hex");
-    const ttfHash = crypto.createHash("md5").update(result.ttf!).digest("hex");
-    const eotHash = crypto.createHash("md5").update(result.eot!).digest("hex");
-    const woffHash = crypto.createHash("md5").update(result.woff!).digest("hex");
-    const woff2Hash = crypto.createHash("md5").update(result.woff2!).digest("hex");
+    assert(result.svg);
+    assert(result.ttf);
+    assert(result.eot);
+    assert(result.woff);
+    assert(result.woff2);
+
+    const svgHash = crypto.createHash("md5").update(result.svg).digest("hex");
+    const ttfHash = crypto.createHash("md5").update(result.ttf).digest("hex");
+    const eotHash = crypto.createHash("md5").update(result.eot).digest("hex");
+    const woffHash = crypto.createHash("md5").update(result.woff).digest("hex");
+    const woff2Hash = crypto.createHash("md5").update(result.woff2).digest("hex");
 
     expect(svgHash).toBe("ead2b6f69fc603bf1cbd00bf9f8a8a33");
     expect(ttfHash).toBe("d1517f20c3988b9e084047462dd28787");
@@ -183,8 +190,9 @@ describe("standalone", () => {
     expect(isEot(result.eot)).toBe(true);
     expect(isWoff(result.woff)).toBe(true);
     expect(isWoff2(result.woff2)).toBe(true);
+    assert(result.config);
     expect((result.config as DiscoveredRcConfig).foo).toBe("bar");
-    expect(result.config!.filePath).toBe(path.resolve(configFile));
+    expect(result.config.filePath).toBe(path.resolve(configFile));
   });
 
   it("should load config and respect `template` option with build-in template value", async () => {
@@ -201,7 +209,8 @@ describe("standalone", () => {
     expect(isEot(result.eot)).toBe(true);
     expect(isWoff(result.woff)).toBe(true);
     expect(isWoff2(result.woff2)).toBe(true);
-    expect(result.config!.template).toBe("scss");
+    assert(result.config);
+    expect(result.config.template).toBe("scss");
     expect(result.template).toMatchSnapshot();
   });
 
@@ -217,7 +226,8 @@ describe("standalone", () => {
     expect(isEot(result.eot)).toBe(true);
     expect(isWoff(result.woff)).toBe(true);
     expect(isWoff2(result.woff2)).toBe(true);
-    expect(result.config!.template).toBe("src/fixtures/templates/template.css");
+    assert(result.config);
+    expect(result.config.template).toBe("src/fixtures/templates/template.css");
     expect(result.template).toMatchSnapshot();
   });
 
@@ -253,7 +263,9 @@ describe("standalone", () => {
     });
 
     const actual = templateOutput.replace(/\s/gu, "");
-    const expected = result.template!.replace(/\s/gu, "");
+    assert(result.template);
+
+    const expected = result.template.replace(/\s/gu, "");
 
     expect(actual).toBe(expected);
   });
@@ -333,8 +345,10 @@ describe("standalone", () => {
       glyphContentTransformFn: () => filledContents,
     });
 
-    expect(withTransform.glyphsData![0]?.contents).toBe(filledContents);
-    expect(withTransform.ttf!.length).toBeGreaterThan(1400);
+    assert(withTransform.glyphsData);
+    assert(withTransform.ttf);
+    expect(withTransform.glyphsData[0]?.contents).toBe(filledContents);
+    expect(withTransform.ttf.length).toBeGreaterThan(1400);
     expect(isTtf(withTransform.ttf)).toBe(true);
   });
 
@@ -388,8 +402,9 @@ describe("standalone", () => {
       optimizeSvg: true,
     });
 
-    expect(result.glyphsData![0]?.contents).not.toContain("Inkscape export cruft");
-    expect(result.glyphsData![0]?.contents).not.toContain("<metadata>");
+    assert(result.glyphsData);
+    expect(result.glyphsData[0]?.contents).not.toContain("Inkscape export cruft");
+    expect(result.glyphsData[0]?.contents).not.toContain("<metadata>");
     expect(isWoff2(result.woff2)).toBe(true);
   });
 
@@ -547,7 +562,8 @@ describe("standalone", () => {
     expect(isEot(result.eot)).toBe(true);
     expect(isWoff(result.woff)).toBe(true);
     expect(isWoff2(result.woff2)).toBe(true);
-    expect(result.config!.template).toBe("css");
+    assert(result.config);
+    expect(result.config.template).toBe("css");
     expect(result.usedBuildInTemplate).toBe(true);
     expect(result.template).toMatchSnapshot();
   });
@@ -619,7 +635,8 @@ describe("standalone", () => {
     });
 
     expect(result.usedBuildInTemplate).toBe(true);
-    expect(JSON.parse(result.template!)).toMatchSnapshot();
+    assert(result.template);
+    expect(JSON.parse(result.template)).toMatchSnapshot();
     expect(result.template).toMatchSnapshot();
   });
 
@@ -701,8 +718,9 @@ describe("standalone", () => {
       template: "css",
     });
 
+    assert(result.glyphsData);
     expect(Array.isArray(result.glyphsData)).toBe(true);
-    expect(result.glyphsData!.length > 0).toBe(true);
+    expect(result.glyphsData.length > 0).toBe(true);
   });
 
   it("should remove ligature unicode when `ligatures` set to `false`", async () => {
@@ -712,10 +730,11 @@ describe("standalone", () => {
       template: "css",
     });
 
+    assert(result.glyphsData);
     expect(Array.isArray(result.glyphsData)).toBe(true);
-    expect(result.glyphsData!.length > 0).toBe(true);
+    expect(result.glyphsData.length > 0).toBe(true);
 
-    result.glyphsData!.forEach((glyph) => {
+    result.glyphsData.forEach((glyph) => {
       expect(glyph.metadata?.unicode).toHaveLength(1);
     });
   });
@@ -772,8 +791,9 @@ describe("standalone", () => {
       template: `${fixturesGlob}/templates/template-fonts-base64.njk`,
     });
 
-    expect(result.template!.length).toBeGreaterThan(0);
-    expect(Buffer.from(result.template!, "base64").length).toBeGreaterThan(0);
+    assert(result.template);
+    expect(result.template.length).toBeGreaterThan(0);
+    expect(Buffer.from(result.template, "base64").length).toBeGreaterThan(0);
   });
 
   it("should throw when template rendering requests a missing font buffer", async () => {


### PR DESCRIPTION
## Summary

### Proposed changes

This PR brings the following changes:

- Bump the Biome `style/noNonNullAssertion` rule from `warn` to `error` and remove the per-test override that disabled it, so the `!` non-null assertion operator is banned **everywhere**, including tests;
- Replace all 23 `!` assertions in `src/standalone/index.test.ts` (20) and `src/lib/ttf2eot/index.test.ts` (3) with `assert(value)` from `node:assert`, which narrows `T | undefined` to `T` and fails the test with a clear message if the value is unexpectedly `undefined`;
- Document the ban (and the sanctioned alternatives: `node:assert`, optional chaining, typed fixtures) in `AGENTS.md` under **Lint and type hygiene**.

### Related issue

N/A — follow-up hardening after the test typecheck work (#752), where `!` had been introduced to satisfy strict null checks.

### Dependencies added/removed (if applicable)

N/A — no `package.json` changes.

---

### Testing

- [x] I have added or updated tests that prove my fix is effective or that my feature works (if applicable)
  - [x] Unit test — existing suites refactored to assert-then-use; runtime coverage unchanged

#### How to test

1. `npx biome check .` → exits `0`, no `noNonNullAssertion` diagnostics.
2. `rg '[\w\])]!([^=]|$)' src --glob '*.test.ts'` → no matches.
3. `npm run typecheck` → passes (no `!` needed to satisfy strict null checks).
4. `npm test` → 45 files, 416 tests pass.

#### Test configuration

- N/A (not version-sensitive)

---

## Checklist

- [x] I have added corresponding labels to this PR (like bug, enhancement...);
- [x] My commits follow the [Conventional Commits 1.0 Guidelines](https://www.conventionalcommits.org/en/v1.0.0/);
- [x] My code follows the style guidelines of this project;
- [x] I have performed a self-review of my own code;
- [x] I have made changes to the documentation (if applicable);
- [x] My changes generate no new warnings or errors;

Made with [Cursor](https://cursor.com)