### PR TITLE
ci(npm-publish): build once, publish prebuilt to npm + GitHub Packages via environments

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -2,6 +2,13 @@ name: npm publish
 
 # Publishes with the NPM_TOKEN repository secret (see CONTRIBUTING.md).
 # Trusted Publishing (OIDC) may replace this when configured on npmjs.com.
+#
+# The `build` job is the single place that builds `dist/`, runs the full test
+# suite, and validates the published surface (publint + attw + pack-smoke). It
+# uploads `dist/` as an artifact so `publish-npm` can ship the exact same build
+# without repeating it. `publish-npm` runs `npm publish --ignore-scripts`, so
+# `prepublishOnly` does not rebuild or re-validate on the publish runner
+# (avoids the duplicated build called out in #742).
 on:
   release:
     types: [published]
@@ -32,6 +39,13 @@ jobs:
       - run: npm test
       - name: Validate published package surface (publint + attw + pack-smoke)
         run: npm run test:package
+      - name: Upload built dist/ for the publish job
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist
+          if-no-files-found: error
+          retention-days: 1
 
   publish-npm:
     needs: build
@@ -46,5 +60,12 @@ jobs:
           registry-url: https://registry.npmjs.org/
           node-auth-token: ${{ secrets.NPM_TOKEN }}
           package-manager-cache: false
-      - run: npm ci
-      - run: npm publish --access public
+      - name: Download dist/ built by the build job
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist
+      # `dist/` is prebuilt and validated by the build job. Skip lifecycle
+      # scripts so `prepublishOnly` (build + test:package + whoami) and the
+      # `prepare` hook do not run again here; no `npm ci` is needed to publish.
+      - run: npm publish --ignore-scripts --access public

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,14 +1,21 @@
 name: npm publish
 
-# Publishes with the NPM_TOKEN repository secret (see CONTRIBUTING.md).
-# Trusted Publishing (OIDC) may replace this when configured on npmjs.com.
+# Release pipeline. Triggered by a published GitHub Release (or manually with a
+# tag). It builds and validates once, then deploys to two environments:
+#
+#   - `npm`             → public registry (https://registry.npmjs.org, `webfont`)
+#   - `github-packages` → GitHub Packages (https://npm.pkg.github.com, `@itgalaxy/webfont`)
 #
 # The `build` job is the single place that builds `dist/`, runs the full test
 # suite, and validates the published surface (publint + attw + pack-smoke). It
-# uploads `dist/` as an artifact so `publish-npm` can ship the exact same build
-# without repeating it. `publish-npm` runs `npm publish --ignore-scripts`, so
-# `prepublishOnly` does not rebuild or re-validate on the publish runner
-# (avoids the duplicated build called out in #742).
+# uploads `dist/` and the release archives as artifacts so the deploy jobs ship
+# the exact same build without repeating it. Deploy jobs run
+# `npm publish --ignore-scripts`, so `prepublishOnly` does not rebuild or
+# re-validate on the publish runners (avoids the duplicated build in #742).
+#
+# Auth: `npm` uses the NODE_AUTH_TOKEN repository secret; `github-packages` uses the
+# built-in GITHUB_TOKEN (`packages: write`). Environment deployment URLs link to
+# each published package page. See CONTRIBUTING.md → "npm publishing".
 on:
   release:
     types: [published]
@@ -27,6 +34,8 @@ permissions:
 jobs:
   build:
     runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.pack.outputs.version }}
     steps:
       - uses: actions/checkout@v7
         with:
@@ -39,17 +48,87 @@ jobs:
       - run: npm test
       - name: Validate published package surface (publint + attw + pack-smoke)
         run: npm run test:package
-      - name: Upload built dist/ for the publish job
+      - name: Pack npm tarball and archive dist/
+        id: pack
+        run: |
+          version="$(node -p 'require("./package.json").version')"
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          mkdir -p artifacts
+          npm pack --ignore-scripts --pack-destination artifacts
+          ( cd dist && zip -r "../artifacts/webfont-dist-$version.zip" . )
+      - name: Upload built dist/ for the deploy jobs
         uses: actions/upload-artifact@v4
         with:
           name: dist
           path: dist
           if-no-files-found: error
           retention-days: 1
+      - name: Upload release archives (npm tarball + dist zip)
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-artifacts
+          path: artifacts
+          if-no-files-found: error
+          retention-days: 1
+
+  release-assets:
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Download release archives
+        uses: actions/download-artifact@v4
+        with:
+          name: release-artifacts
+          path: artifacts
+      - name: Attach archives to the GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh release upload "$RELEASE_TAG" artifacts/* --clobber --repo "$GITHUB_REPOSITORY"
 
   publish-npm:
     needs: build
     runs-on: ubuntu-latest
+    environment:
+      name: npm
+      url: https://www.npmjs.com/package/webfont/v/${{ steps.meta.outputs.version }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ env.RELEASE_TAG }}
+      - name: Resolve published version
+        id: meta
+        run: echo "version=$(node -p 'require("./package.json").version')" >> "$GITHUB_OUTPUT"
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 26.x
+          package-manager-cache: false
+      - name: Download dist/ built by the build job
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist
+      # CI is non-interactive (no `npm login`): write ~/.npmrc so `npm publish`
+      # reads the token from NODE_AUTH_TOKEN at runtime (npm expands
+      # ${NODE_AUTH_TOKEN}); the raw token never touches disk or the logs.
+      # The NODE_AUTH_TOKEN secret must be an npm access token (npmjs.com ->
+      # Access Tokens), not a GitHub PAT — npmjs.org rejects GitHub tokens.
+      - name: Write ~/.npmrc for npmjs.org
+        run: printf '%s\n' 'registry=https://registry.npmjs.org/' '//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}' > "$HOME/.npmrc"
+      - run: npm publish --ignore-scripts --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NODE_AUTH_TOKEN }}
+
+  publish-github-packages:
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    environment:
+      name: github-packages
+      url: https://github.com/${{ github.repository }}/pkgs/npm/webfont
     steps:
       - uses: actions/checkout@v7
         with:
@@ -57,15 +136,23 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           node-version: 26.x
-          registry-url: https://registry.npmjs.org/
-          node-auth-token: ${{ secrets.NPM_TOKEN }}
           package-manager-cache: false
       - name: Download dist/ built by the build job
         uses: actions/download-artifact@v4
         with:
           name: dist
           path: dist
-      # `dist/` is prebuilt and validated by the build job. Skip lifecycle
-      # scripts so `prepublishOnly` (build + test:package + whoami) and the
-      # `prepare` hook do not run again here; no `npm ci` is needed to publish.
-      - run: npm publish --ignore-scripts --access public
+      # GitHub Packages requires a scope matching the repo owner. Rename in the
+      # checkout only (not committed) so the same build publishes as
+      # `@itgalaxy/webfont` alongside the unscoped `webfont` on npmjs.org.
+      - name: Scope package to the repository owner
+        run: npm pkg set name=@itgalaxy/webfont
+      # Non-interactive CI auth: write ~/.npmrc pointing the @itgalaxy scope at
+      # GitHub Packages, with the token read from NODE_AUTH_TOKEN at runtime.
+      # The built-in GITHUB_TOKEN (packages: write) works out of the box; swap
+      # for a PAT secret with `write:packages` if you prefer a personal token.
+      - name: Write ~/.npmrc for GitHub Packages
+        run: printf '%s\n' '@itgalaxy:registry=https://npm.pkg.github.com/' '//npm.pkg.github.com/:_authToken=${NODE_AUTH_TOKEN}' > "$HOME/.npmrc"
+      - run: npm publish --ignore-scripts
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -208,16 +208,46 @@ Do not run local `npm version` or push version tags manually unless coordinating
 
 #### npm publishing
 
-Publishing from GitHub Actions uses the **`NPM_TOKEN`** repository secret (Automation/publish token on npmjs.com). The [`npm-publish`](.github/workflows/npm-publish.yml) workflow passes it to `actions/setup-node` as `node-auth-token`.
+Publishing from GitHub Actions deploys the same validated build to **two environments** — `npm` (public registry, `webfont`) and `github-packages` (GitHub Packages, `@itgalaxy/webfont`). CI is **non-interactive** — there is no `npm login`. Each deploy job writes `~/.npmrc` with `//<registry>/:_authToken=${NODE_AUTH_TOKEN}` and sets `NODE_AUTH_TOKEN` from a secret at the `npm publish` step, so npm expands the token at runtime and it never lands on disk or in the logs:
+
+- **`npm`** → `NODE_AUTH_TOKEN` = **`NODE_AUTH_TOKEN`** repository secret (an npm access token from npmjs.com; a GitHub PAT does **not** authenticate to npmjs.org).
+- **`github-packages`** → `NODE_AUTH_TOKEN` = built-in **`GITHUB_TOKEN`** (`packages: write`); no extra secret. Swap for a PAT secret with `write:packages` if you prefer a personal token.
+
+> `actions/setup-node` has **no** `node-auth-token` input — `registry-url` only wires auth to read from `env.NODE_AUTH_TOKEN`. Passing a token to a non-existent input silently publishes unauthenticated (the `E404` in [#742](https://github.com/itgalaxy/webfont/issues/742)); writing `~/.npmrc` + setting `NODE_AUTH_TOKEN` is the fix.
 
 **One-time setup** (package maintainer):
 
-1. Create an npm **Automation** or **Publish** token for the `webfont` package (with publish access; OTP requirement disabled for automation if your org allows it).
-2. Add it as a GitHub repository secret named **`NPM_TOKEN`** ([Settings → Secrets and variables → Actions](https://github.com/itgalaxy/webfont/settings/secrets/actions)).
+1. Create an npm **Automation** or **Granular** access token for the `webfont` package (npmjs.com → **Access Tokens**) with publish permission (OTP/2FA-for-writes disabled for automation, or use a token type that bypasses it).
+2. Add it as a GitHub repository secret named **`NODE_AUTH_TOKEN`** ([Settings → Secrets and variables → Actions](https://github.com/itgalaxy/webfont/settings/secrets/actions)). GitHub Packages needs no secret — it uses `GITHUB_TOKEN`.
 
 **After merging a Release PR:** the [`npm-publish`](.github/workflows/npm-publish.yml) workflow listens for `release: published`, but releases created with the default `GITHUB_TOKEN` usually **do not** trigger downstream workflows — use **Actions → npm publish → Run workflow** with the release tag (e.g. `v12.1.0`) if publish does not start automatically.
 
-**Future:** [npm Trusted Publishing](https://docs.npmjs.com/trusted-publishers) (OIDC) can replace `NPM_TOKEN` when a maintainer configures it on npmjs.com for workflow `npm-publish.yml`.
+**Future:** [npm Trusted Publishing](https://docs.npmjs.com/trusted-publishers) (OIDC) can replace the `NODE_AUTH_TOKEN` secret when a maintainer configures it on npmjs.com for workflow `npm-publish.yml`.
+
+##### Deployment environments and GitHub Packages
+
+The workflow runs two deploy jobs after `build`, each mapped to a GitHub **Environment** so every release appears under the repo's **Deployments** with a link to the published package:
+
+| Environment | Registry | Package | Auth | Deploy URL |
+|-------------|----------|---------|------|------------|
+| `npm` | `registry.npmjs.org` | `webfont` | `NODE_AUTH_TOKEN` secret | `npmjs.com/package/webfont/v/<version>` |
+| `github-packages` | `npm.pkg.github.com` | `@itgalaxy/webfont` | `GITHUB_TOKEN` (`packages: write`) | repo **Packages** page |
+
+GitHub Packages requires a scope matching the repo owner, so the `publish-github-packages` job renames the package to `@itgalaxy/webfont` in the checkout only (via `npm pkg set name=…`, never committed) — the unscoped `webfont` on npmjs.org is unaffected.
+
+Add protection rules (required reviewers, wait timers) per environment in **Settings → Environments** if you want manual approval to gate a deploy.
+
+**Install from GitHub Packages** (needs a GitHub token with `read:packages`):
+
+```shell
+echo "@itgalaxy:registry=https://npm.pkg.github.com" >> .npmrc
+echo "//npm.pkg.github.com/:_authToken=\${GITHUB_TOKEN}" >> .npmrc
+npm install @itgalaxy/webfont
+```
+
+##### Release assets
+
+The `release-assets` job attaches two archives to each GitHub Release: the npm tarball **`webfont-<version>.tgz`** (the exact published package) and **`webfont-dist-<version>.zip`** (the built `dist/` only). It needs `contents: write` and uploads with `gh release upload "$RELEASE_TAG" --clobber`.
 
 **Manual publish** from a maintainer machine (browser/web auth or local npm login) is still supported:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -229,7 +229,7 @@ npm login              # or ensure a valid token
 npm publish --access public
 ```
 
-`prepublishOnly` starts with `npm whoami`, so a local `npm publish` fails fast if you are not logged in — before the build and package validation run, instead of failing on authentication at the very end. In CI the publish workflow authenticates via `NPM_TOKEN`, so `whoami` passes there; revisit this if you migrate to Trusted Publishing (OIDC).
+`prepublishOnly` starts with `npm whoami`, so a local `npm publish` fails fast if you are not logged in — before the build and package validation run, instead of failing on authentication at the very end. In CI the workflow builds and validates `dist/` **once** in the `build` job, uploads it as an artifact, and the `publish-npm` job runs `npm publish --ignore-scripts` against that artifact — so `prepublishOnly` (and its `whoami`) does not run on the publish runner and the build is not repeated (see [#742](https://github.com/itgalaxy/webfont/issues/742)). The `publish-npm` job depends on `build`, so `test:package` still gates every publish.
 
 Automated publishing does **not** retroactively upload versions that already exist as git tags only (for example `11.5.x` never published to npm).
 


### PR DESCRIPTION
## Summary

### Proposed changes

Reworks the release pipeline. Addresses both parts of #742 (redundant build **and** the `E404` auth failure) and adds multi-registry publishing.

**Build once, publish the validated artifact**
- The `build` job is the single place that builds `dist/`, runs the full suite (`npm test`), and validates the published surface (`npm run test:package` → publint + attw + pack-smoke). It uploads `dist/` (and the release archives) as short-lived artifacts.
- `publish-npm` downloads that artifact and runs `npm publish --ignore-scripts --access public`, so `prepublishOnly` (build + `test:package` + `whoami`) and the `prepare` hook no longer rerun on the publish runner, and no `npm ci` is needed there.
- Each deploy job still `needs: build`, so `test:package` keeps gating every publish (the exact `dist/` that was validated is what ships).

**Registry authentication (fixes E404)**
- Both publish jobs write `~/.npmrc` with `//<registry>/:_authToken=${NODE_AUTH_TOKEN}` and set `NODE_AUTH_TOKEN` on the `npm publish` step — npmjs.org uses `secrets.NODE_AUTH_TOKEN`, GitHub Packages uses the built-in `secrets.GITHUB_TOKEN`. This avoids the `actions/setup-node` `node-auth-token` pitfall (no such input) that caused the unauthenticated `E404`.

**Multi-registry + environments + release assets**
- New `publish-github-packages` job publishes the scoped `@itgalaxy/webfont` (temporary `npm pkg set name`) to GitHub Packages (`packages: write`).
- Both publish jobs use GitHub Environments (`npm`, `github-packages`) with deploy URLs so releases show up as tracked deployments.
- New `release-assets` job attaches the npm tarball (`npm pack --ignore-scripts`) and a `dist/` zip to the GitHub Release via `gh release upload`.
- `node -p` version resolution uses single-quoted expressions for readability.

**Docs**
- `CONTRIBUTING.md` updated for the build-once/publish-artifact flow, the dual-environment (npm + GitHub Packages) setup, release assets, the `~/.npmrc` + `NODE_AUTH_TOKEN` auth method (and the `setup-node` pitfall), and installing `@itgalaxy/webfont` from GitHub Packages.

> This branch now also contains the work squash-merged from #757 (multi-registry, environments, auth fix, release assets) stacked on top of the original build-dedupe change.

### Related issue

Closes #742 (both the redundant build and the `E404` auth failure). #703 (Trusted Publishing / OIDC) remains a possible future alternative to the token-based auth used here.

### Dependencies added/removed (if applicable)

N/A — no `package.json` dependency changes.

---

### Testing

- [x] CI-only change; no runtime code. The `build`-job gate (`npm test` + `npm run test:package`) is unchanged and runs before every deploy job.

#### How to test

1. Trigger **Actions → npm publish** on a tag: `build` uploads `dist` + release archives; `publish-npm` and `publish-github-packages` download `dist` and publish without rebuilding; `release-assets` attaches the tarball + `dist` zip to the Release.
2. Confirm the publish jobs log no `prepublishOnly` / `npm run build` / `npm ci` (skipped via `--ignore-scripts`).
3. Confirm the Deployments tab shows `npm` and `github-packages` environments with URLs.
4. `npm test` and `npm run test:package` still pass locally; local `npm publish` still runs `prepublishOnly` (build + validate + `whoami`).

#### Test configuration

- N/A

---

## Checklist

- [x] I have added corresponding labels to this PR (like bug, enhancement...);
- [x] My commits follow the [Conventional Commits 1.0 Guidelines](https://www.conventionalcommits.org/en/v1.0.0/);
- [x] My code follows the style guidelines of this project;
- [x] I have performed a self-review of my own code;
- [x] I have made changes to the documentation (if applicable);
- [x] My changes generate no new warnings or errors;

Made with [Cursor](https://cursor.com)