### PR TITLE
ci(npm-publish): fix registry auth, deploy to npm + GitHub Packages environments, attach release assets

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -51,7 +51,7 @@ jobs:
       - name: Pack npm tarball and archive dist/
         id: pack
         run: |
-          version="$(node -p "require('./package.json').version")"
+          version="$(node -p 'require("./package.json").version')"
           echo "version=$version" >> "$GITHUB_OUTPUT"
           mkdir -p artifacts
           npm pack --ignore-scripts --pack-destination artifacts
@@ -99,7 +99,7 @@ jobs:
           ref: ${{ env.RELEASE_TAG }}
       - name: Resolve published version
         id: meta
-        run: echo "version=$(node -p "require('./package.json').version")" >> "$GITHUB_OUTPUT"
+        run: echo "version=$(node -p 'require("./package.json").version')" >> "$GITHUB_OUTPUT"
       - uses: actions/setup-node@v6
         with:
           node-version: 26.x

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -13,7 +13,7 @@ name: npm publish
 # `npm publish --ignore-scripts`, so `prepublishOnly` does not rebuild or
 # re-validate on the publish runners (avoids the duplicated build in #742).
 #
-# Auth: `npm` uses the NPM_TOKEN repository secret; `github-packages` uses the
+# Auth: `npm` uses the NODE_AUTH_TOKEN repository secret; `github-packages` uses the
 # built-in GITHUB_TOKEN (`packages: write`). Environment deployment URLs link to
 # each published package page. See CONTRIBUTING.md → "npm publishing".
 on:
@@ -112,13 +112,13 @@ jobs:
       # CI is non-interactive (no `npm login`): write ~/.npmrc so `npm publish`
       # reads the token from NODE_AUTH_TOKEN at runtime (npm expands
       # ${NODE_AUTH_TOKEN}); the raw token never touches disk or the logs.
-      # NPM_TOKEN must be an npm access token (npmjs.com -> Access Tokens),
-      # not a GitHub PAT — npmjs.org does not accept GitHub tokens.
+      # The NODE_AUTH_TOKEN secret must be an npm access token (npmjs.com ->
+      # Access Tokens), not a GitHub PAT — npmjs.org rejects GitHub tokens.
       - name: Write ~/.npmrc for npmjs.org
         run: printf '%s\n' 'registry=https://registry.npmjs.org/' '//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}' > "$HOME/.npmrc"
       - run: npm publish --ignore-scripts --access public
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NODE_AUTH_TOKEN }}
 
   publish-github-packages:
     needs: build

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -103,15 +103,22 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           node-version: 26.x
-          registry-url: https://registry.npmjs.org/
-          node-auth-token: ${{ secrets.NPM_TOKEN }}
           package-manager-cache: false
       - name: Download dist/ built by the build job
         uses: actions/download-artifact@v4
         with:
           name: dist
           path: dist
+      # CI is non-interactive (no `npm login`): write ~/.npmrc so `npm publish`
+      # reads the token from NODE_AUTH_TOKEN at runtime (npm expands
+      # ${NODE_AUTH_TOKEN}); the raw token never touches disk or the logs.
+      # NPM_TOKEN must be an npm access token (npmjs.com -> Access Tokens),
+      # not a GitHub PAT — npmjs.org does not accept GitHub tokens.
+      - name: Write ~/.npmrc for npmjs.org
+        run: printf '%s\n' 'registry=https://registry.npmjs.org/' '//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}' > "$HOME/.npmrc"
       - run: npm publish --ignore-scripts --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
   publish-github-packages:
     needs: build
@@ -129,8 +136,6 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           node-version: 26.x
-          registry-url: https://npm.pkg.github.com
-          scope: "@itgalaxy"
           package-manager-cache: false
       - name: Download dist/ built by the build job
         uses: actions/download-artifact@v4
@@ -142,6 +147,12 @@ jobs:
       # `@itgalaxy/webfont` alongside the unscoped `webfont` on npmjs.org.
       - name: Scope package to the repository owner
         run: npm pkg set name=@itgalaxy/webfont
+      # Non-interactive CI auth: write ~/.npmrc pointing the @itgalaxy scope at
+      # GitHub Packages, with the token read from NODE_AUTH_TOKEN at runtime.
+      # The built-in GITHUB_TOKEN (packages: write) works out of the box; swap
+      # for a PAT secret with `write:packages` if you prefer a personal token.
+      - name: Write ~/.npmrc for GitHub Packages
+        run: printf '%s\n' '@itgalaxy:registry=https://npm.pkg.github.com/' '//npm.pkg.github.com/:_authToken=${NODE_AUTH_TOKEN}' > "$HOME/.npmrc"
       - run: npm publish --ignore-scripts
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,14 +1,21 @@
 name: npm publish
 
-# Publishes with the NPM_TOKEN repository secret (see CONTRIBUTING.md).
-# Trusted Publishing (OIDC) may replace this when configured on npmjs.com.
+# Release pipeline. Triggered by a published GitHub Release (or manually with a
+# tag). It builds and validates once, then deploys to two environments:
+#
+#   - `npm`             → public registry (https://registry.npmjs.org, `webfont`)
+#   - `github-packages` → GitHub Packages (https://npm.pkg.github.com, `@itgalaxy/webfont`)
 #
 # The `build` job is the single place that builds `dist/`, runs the full test
 # suite, and validates the published surface (publint + attw + pack-smoke). It
-# uploads `dist/` as an artifact so `publish-npm` can ship the exact same build
-# without repeating it. `publish-npm` runs `npm publish --ignore-scripts`, so
-# `prepublishOnly` does not rebuild or re-validate on the publish runner
-# (avoids the duplicated build called out in #742).
+# uploads `dist/` and the release archives as artifacts so the deploy jobs ship
+# the exact same build without repeating it. Deploy jobs run
+# `npm publish --ignore-scripts`, so `prepublishOnly` does not rebuild or
+# re-validate on the publish runners (avoids the duplicated build in #742).
+#
+# Auth: `npm` uses the NPM_TOKEN repository secret; `github-packages` uses the
+# built-in GITHUB_TOKEN (`packages: write`). Environment deployment URLs link to
+# each published package page. See CONTRIBUTING.md → "npm publishing".
 on:
   release:
     types: [published]
@@ -27,6 +34,8 @@ permissions:
 jobs:
   build:
     runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.pack.outputs.version }}
     steps:
       - uses: actions/checkout@v7
         with:
@@ -39,21 +48,58 @@ jobs:
       - run: npm test
       - name: Validate published package surface (publint + attw + pack-smoke)
         run: npm run test:package
-      - name: Upload built dist/ for the publish job
+      - name: Pack npm tarball and archive dist/
+        id: pack
+        run: |
+          version="$(node -p "require('./package.json').version")"
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          mkdir -p artifacts
+          npm pack --ignore-scripts --pack-destination artifacts
+          ( cd dist && zip -r "../artifacts/webfont-dist-$version.zip" . )
+      - name: Upload built dist/ for the deploy jobs
         uses: actions/upload-artifact@v4
         with:
           name: dist
           path: dist
           if-no-files-found: error
           retention-days: 1
+      - name: Upload release archives (npm tarball + dist zip)
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-artifacts
+          path: artifacts
+          if-no-files-found: error
+          retention-days: 1
+
+  release-assets:
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Download release archives
+        uses: actions/download-artifact@v4
+        with:
+          name: release-artifacts
+          path: artifacts
+      - name: Attach archives to the GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh release upload "$RELEASE_TAG" artifacts/* --clobber --repo "$GITHUB_REPOSITORY"
 
   publish-npm:
     needs: build
     runs-on: ubuntu-latest
+    environment:
+      name: npm
+      url: https://www.npmjs.com/package/webfont/v/${{ steps.meta.outputs.version }}
     steps:
       - uses: actions/checkout@v7
         with:
           ref: ${{ env.RELEASE_TAG }}
+      - name: Resolve published version
+        id: meta
+        run: echo "version=$(node -p "require('./package.json').version")" >> "$GITHUB_OUTPUT"
       - uses: actions/setup-node@v6
         with:
           node-version: 26.x
@@ -65,7 +111,37 @@ jobs:
         with:
           name: dist
           path: dist
-      # `dist/` is prebuilt and validated by the build job. Skip lifecycle
-      # scripts so `prepublishOnly` (build + test:package + whoami) and the
-      # `prepare` hook do not run again here; no `npm ci` is needed to publish.
       - run: npm publish --ignore-scripts --access public
+
+  publish-github-packages:
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    environment:
+      name: github-packages
+      url: https://github.com/${{ github.repository }}/pkgs/npm/webfont
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ env.RELEASE_TAG }}
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 26.x
+          registry-url: https://npm.pkg.github.com
+          scope: "@itgalaxy"
+          package-manager-cache: false
+      - name: Download dist/ built by the build job
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist
+      # GitHub Packages requires a scope matching the repo owner. Rename in the
+      # checkout only (not committed) so the same build publishes as
+      # `@itgalaxy/webfont` alongside the unscoped `webfont` on npmjs.org.
+      - name: Scope package to the repository owner
+        run: npm pkg set name=@itgalaxy/webfont
+      - run: npm publish --ignore-scripts
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -208,12 +208,17 @@ Do not run local `npm version` or push version tags manually unless coordinating
 
 #### npm publishing
 
-Publishing from GitHub Actions deploys the same validated build to **two environments** — `npm` (public registry, `webfont`) and `github-packages` (GitHub Packages, `@itgalaxy/webfont`). The `npm` deploy uses the **`NPM_TOKEN`** repository secret (Automation/publish token on npmjs.com), passed to `actions/setup-node` as `node-auth-token`; the `github-packages` deploy uses the built-in `GITHUB_TOKEN` (`packages: write`) and needs no extra secret.
+Publishing from GitHub Actions deploys the same validated build to **two environments** — `npm` (public registry, `webfont`) and `github-packages` (GitHub Packages, `@itgalaxy/webfont`). CI is **non-interactive** — there is no `npm login`. Each deploy job writes `~/.npmrc` with `//<registry>/:_authToken=${NODE_AUTH_TOKEN}` and sets `NODE_AUTH_TOKEN` from a secret at the `npm publish` step, so npm expands the token at runtime and it never lands on disk or in the logs:
+
+- **`npm`** → `NODE_AUTH_TOKEN` = **`NPM_TOKEN`** repository secret (an npm access token from npmjs.com; a GitHub PAT does **not** authenticate to npmjs.org).
+- **`github-packages`** → `NODE_AUTH_TOKEN` = built-in **`GITHUB_TOKEN`** (`packages: write`); no extra secret. Swap for a PAT secret with `write:packages` if you prefer a personal token.
+
+> `actions/setup-node` has **no** `node-auth-token` input — `registry-url` only wires auth to read from `env.NODE_AUTH_TOKEN`. Passing a token to a non-existent input silently publishes unauthenticated (the `E404` in [#742](https://github.com/itgalaxy/webfont/issues/742)); writing `~/.npmrc` + setting `NODE_AUTH_TOKEN` is the fix.
 
 **One-time setup** (package maintainer):
 
-1. Create an npm **Automation** or **Publish** token for the `webfont` package (with publish access; OTP requirement disabled for automation if your org allows it).
-2. Add it as a GitHub repository secret named **`NPM_TOKEN`** ([Settings → Secrets and variables → Actions](https://github.com/itgalaxy/webfont/settings/secrets/actions)).
+1. Create an npm **Automation** or **Granular** access token for the `webfont` package (npmjs.com → **Access Tokens**) with publish permission (OTP/2FA-for-writes disabled for automation, or use a token type that bypasses it).
+2. Add it as a GitHub repository secret named **`NPM_TOKEN`** ([Settings → Secrets and variables → Actions](https://github.com/itgalaxy/webfont/settings/secrets/actions)). GitHub Packages needs no secret — it uses `GITHUB_TOKEN`.
 
 **After merging a Release PR:** the [`npm-publish`](.github/workflows/npm-publish.yml) workflow listens for `release: published`, but releases created with the default `GITHUB_TOKEN` usually **do not** trigger downstream workflows — use **Actions → npm publish → Run workflow** with the release tag (e.g. `v12.1.0`) if publish does not start automatically.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -210,7 +210,7 @@ Do not run local `npm version` or push version tags manually unless coordinating
 
 Publishing from GitHub Actions deploys the same validated build to **two environments** — `npm` (public registry, `webfont`) and `github-packages` (GitHub Packages, `@itgalaxy/webfont`). CI is **non-interactive** — there is no `npm login`. Each deploy job writes `~/.npmrc` with `//<registry>/:_authToken=${NODE_AUTH_TOKEN}` and sets `NODE_AUTH_TOKEN` from a secret at the `npm publish` step, so npm expands the token at runtime and it never lands on disk or in the logs:
 
-- **`npm`** → `NODE_AUTH_TOKEN` = **`NPM_TOKEN`** repository secret (an npm access token from npmjs.com; a GitHub PAT does **not** authenticate to npmjs.org).
+- **`npm`** → `NODE_AUTH_TOKEN` = **`NODE_AUTH_TOKEN`** repository secret (an npm access token from npmjs.com; a GitHub PAT does **not** authenticate to npmjs.org).
 - **`github-packages`** → `NODE_AUTH_TOKEN` = built-in **`GITHUB_TOKEN`** (`packages: write`); no extra secret. Swap for a PAT secret with `write:packages` if you prefer a personal token.
 
 > `actions/setup-node` has **no** `node-auth-token` input — `registry-url` only wires auth to read from `env.NODE_AUTH_TOKEN`. Passing a token to a non-existent input silently publishes unauthenticated (the `E404` in [#742](https://github.com/itgalaxy/webfont/issues/742)); writing `~/.npmrc` + setting `NODE_AUTH_TOKEN` is the fix.
@@ -218,11 +218,11 @@ Publishing from GitHub Actions deploys the same validated build to **two environ
 **One-time setup** (package maintainer):
 
 1. Create an npm **Automation** or **Granular** access token for the `webfont` package (npmjs.com → **Access Tokens**) with publish permission (OTP/2FA-for-writes disabled for automation, or use a token type that bypasses it).
-2. Add it as a GitHub repository secret named **`NPM_TOKEN`** ([Settings → Secrets and variables → Actions](https://github.com/itgalaxy/webfont/settings/secrets/actions)). GitHub Packages needs no secret — it uses `GITHUB_TOKEN`.
+2. Add it as a GitHub repository secret named **`NODE_AUTH_TOKEN`** ([Settings → Secrets and variables → Actions](https://github.com/itgalaxy/webfont/settings/secrets/actions)). GitHub Packages needs no secret — it uses `GITHUB_TOKEN`.
 
 **After merging a Release PR:** the [`npm-publish`](.github/workflows/npm-publish.yml) workflow listens for `release: published`, but releases created with the default `GITHUB_TOKEN` usually **do not** trigger downstream workflows — use **Actions → npm publish → Run workflow** with the release tag (e.g. `v12.1.0`) if publish does not start automatically.
 
-**Future:** [npm Trusted Publishing](https://docs.npmjs.com/trusted-publishers) (OIDC) can replace `NPM_TOKEN` when a maintainer configures it on npmjs.com for workflow `npm-publish.yml`.
+**Future:** [npm Trusted Publishing](https://docs.npmjs.com/trusted-publishers) (OIDC) can replace the `NODE_AUTH_TOKEN` secret when a maintainer configures it on npmjs.com for workflow `npm-publish.yml`.
 
 ##### Deployment environments and GitHub Packages
 
@@ -230,7 +230,7 @@ The workflow runs two deploy jobs after `build`, each mapped to a GitHub **Envir
 
 | Environment | Registry | Package | Auth | Deploy URL |
 |-------------|----------|---------|------|------------|
-| `npm` | `registry.npmjs.org` | `webfont` | `NPM_TOKEN` secret | `npmjs.com/package/webfont/v/<version>` |
+| `npm` | `registry.npmjs.org` | `webfont` | `NODE_AUTH_TOKEN` secret | `npmjs.com/package/webfont/v/<version>` |
 | `github-packages` | `npm.pkg.github.com` | `@itgalaxy/webfont` | `GITHUB_TOKEN` (`packages: write`) | repo **Packages** page |
 
 GitHub Packages requires a scope matching the repo owner, so the `publish-github-packages` job renames the package to `@itgalaxy/webfont` in the checkout only (via `npm pkg set name=…`, never committed) — the unscoped `webfont` on npmjs.org is unaffected.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -208,7 +208,7 @@ Do not run local `npm version` or push version tags manually unless coordinating
 
 #### npm publishing
 
-Publishing from GitHub Actions uses the **`NPM_TOKEN`** repository secret (Automation/publish token on npmjs.com). The [`npm-publish`](.github/workflows/npm-publish.yml) workflow passes it to `actions/setup-node` as `node-auth-token`.
+Publishing from GitHub Actions deploys the same validated build to **two environments** — `npm` (public registry, `webfont`) and `github-packages` (GitHub Packages, `@itgalaxy/webfont`). The `npm` deploy uses the **`NPM_TOKEN`** repository secret (Automation/publish token on npmjs.com), passed to `actions/setup-node` as `node-auth-token`; the `github-packages` deploy uses the built-in `GITHUB_TOKEN` (`packages: write`) and needs no extra secret.
 
 **One-time setup** (package maintainer):
 
@@ -218,6 +218,31 @@ Publishing from GitHub Actions uses the **`NPM_TOKEN`** repository secret (Autom
 **After merging a Release PR:** the [`npm-publish`](.github/workflows/npm-publish.yml) workflow listens for `release: published`, but releases created with the default `GITHUB_TOKEN` usually **do not** trigger downstream workflows — use **Actions → npm publish → Run workflow** with the release tag (e.g. `v12.1.0`) if publish does not start automatically.
 
 **Future:** [npm Trusted Publishing](https://docs.npmjs.com/trusted-publishers) (OIDC) can replace `NPM_TOKEN` when a maintainer configures it on npmjs.com for workflow `npm-publish.yml`.
+
+##### Deployment environments and GitHub Packages
+
+The workflow runs two deploy jobs after `build`, each mapped to a GitHub **Environment** so every release appears under the repo's **Deployments** with a link to the published package:
+
+| Environment | Registry | Package | Auth | Deploy URL |
+|-------------|----------|---------|------|------------|
+| `npm` | `registry.npmjs.org` | `webfont` | `NPM_TOKEN` secret | `npmjs.com/package/webfont/v/<version>` |
+| `github-packages` | `npm.pkg.github.com` | `@itgalaxy/webfont` | `GITHUB_TOKEN` (`packages: write`) | repo **Packages** page |
+
+GitHub Packages requires a scope matching the repo owner, so the `publish-github-packages` job renames the package to `@itgalaxy/webfont` in the checkout only (via `npm pkg set name=…`, never committed) — the unscoped `webfont` on npmjs.org is unaffected.
+
+Add protection rules (required reviewers, wait timers) per environment in **Settings → Environments** if you want manual approval to gate a deploy.
+
+**Install from GitHub Packages** (needs a GitHub token with `read:packages`):
+
+```shell
+echo "@itgalaxy:registry=https://npm.pkg.github.com" >> .npmrc
+echo "//npm.pkg.github.com/:_authToken=\${GITHUB_TOKEN}" >> .npmrc
+npm install @itgalaxy/webfont
+```
+
+##### Release assets
+
+The `release-assets` job attaches two archives to each GitHub Release: the npm tarball **`webfont-<version>.tgz`** (the exact published package) and **`webfont-dist-<version>.zip`** (the built `dist/` only). It needs `contents: write` and uploads with `gh release upload "$RELEASE_TAG" --clobber`.
 
 **Manual publish** from a maintainer machine (browser/web auth or local npm login) is still supported:
 


### PR DESCRIPTION
## Summary

> [!NOTE]
> Stacked on top of #756 (base branch `ci/dedupe-npm-publish-build`). GitHub will retarget this PR to `master` once #756 merges. Review/merge #756 first.

### Proposed changes

Builds on the "build once" pipeline from #756: fixes registry authentication, deploys to two registries as GitHub **Environments**, and attaches release assets.

- **Fix npm auth / E404 (#742, part 1)**: `actions/setup-node` has **no** `node-auth-token` input, so the old `node-auth-token: ${{ secrets.NPM_TOKEN }}` was silently ignored and `npm publish` ran unauthenticated → `E404` on the registry PUT. Both deploy jobs now write `~/.npmrc` **non-interactively** (no `npm login`) with `//<registry>/:_authToken=${NODE_AUTH_TOKEN}` and set `NODE_AUTH_TOKEN` on the publish step from a secret — npm expands the token at runtime, so it never lands on disk or in the logs.
  - `publish-npm` → `NODE_AUTH_TOKEN` = **`NODE_AUTH_TOKEN`** secret (an npm access token; a GitHub PAT does not authenticate to npmjs.org).
  - `publish-github-packages` → `NODE_AUTH_TOKEN` = built-in `GITHUB_TOKEN` (`packages: write`); swappable for a `write:packages` PAT.
- **Release assets** (`release-assets` job): attaches **`webfont-<version>.tgz`** (exact published package) and **`webfont-dist-<version>.zip`** (built `dist/` only) to the GitHub Release via `gh release upload --clobber` (`contents: write`). Both are produced once in `build` and passed as artifacts.
- **GitHub Packages** (`publish-github-packages` job): publishes the same build as **`@itgalaxy/webfont`** to `npm.pkg.github.com`. The owner scope is set in the checkout only via `npm pkg set name=@itgalaxy/webfont` (never committed); the unscoped `webfont` on npmjs.org is unchanged.
- **Environments + deploy links**: `publish-npm` → environment `npm` (URL → `npmjs.com/package/webfont/v/<version>`); `publish-github-packages` → environment `github-packages` (URL → repo Packages page). Releases show under **Deployments** with links.
- **Docs**: `CONTRIBUTING.md` documents the `~/.npmrc` auth (and the setup-node input pitfall), both environments, the GitHub Packages install steps, and the release assets.

### Related issue

Addresses **part 1** of #742 (the `E404` auth failure) by fixing token passing, and extends the pipeline from #756. Does not add OIDC (#703 remains the long-term option).

> [!IMPORTANT]
> The **`NODE_AUTH_TOKEN`** repository secret must be a valid **npm access token** (npmjs.com → Access Tokens) with publish rights to `webfont`. Set/rotate it in **Settings → Secrets and variables → Actions**.

### Dependencies added/removed (if applicable)

N/A — no `package.json` changes.

---

### Testing

- [x] I have added or updated tests that prove my fix is effective or that my feature works (if applicable)
  - CI-only change; no runtime code. Workflow YAML validated (parses; 4 jobs, two environments, correct permissions, and `NODE_AUTH_TOKEN` wired on both publish steps).

#### How to test

1. Set/verify the `NODE_AUTH_TOKEN` secret (npm access token with publish rights).
2. On a release (or **Actions → npm publish → Run workflow** with a tag): `publish-npm` authenticates via `~/.npmrc` + `NODE_AUTH_TOKEN` and publishes `webfont`; `publish-github-packages` publishes `@itgalaxy/webfont` with `GITHUB_TOKEN`; `release-assets` attaches the `.tgz` + dist `.zip`.
3. Confirm repo **Deployments** shows `npm` and `github-packages` with URLs, and no token appears in logs.

#### Test configuration

- N/A

---

## Checklist

- [ ] I have added corresponding labels to this PR (like bug, enhancement...);
- [x] My commits follow the [Conventional Commits 1.0 Guidelines](https://www.conventionalcommits.org/en/v1.0.0/);
- [x] My code follows the style guidelines of this project;
- [x] I have performed a self-review of my own code;
- [x] I have made changes to the documentation (if applicable);
- [x] My changes generate no new warnings or errors;