### PR TITLE
feat: export Result and ResultConfig types from package entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -545,6 +545,24 @@ Do **not** use `Math.random()` in `fontName` — that renames both font files an
 
 `webfont()` resolves to an object with generated font buffers (and optional `template` output). The `config` property contains the **effective options** used for the run (defaults, discovered config, and any options you passed in), plus optional **output metadata** when a configuration file was found or loaded.
 
+#### TypeScript
+
+`Result` and `ResultConfig` are exported from the package entry, so you can annotate `webfont()` output directly instead of relying on `ReturnType` inference:
+
+```ts
+import { webfont, type Result, type ResultConfig } from "webfont";
+
+const result: Result = await webfont({
+  files: "src/svg-icons/**/*.svg",
+});
+
+const config: ResultConfig | undefined = result.config;
+
+if (config?.filePath) {
+  console.log(`Loaded config from ${config.filePath}`);
+}
+```
+
 #### `result.config.filePath`
 
 - Type: `string` | `undefined`

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,7 +1,17 @@
-import index from ".";
+import index, { type Result, type ResultConfig, webfont } from ".";
 
 describe("index", () => {
   it("should be exported", () => {
     expect(typeof index === "function").toBe(true);
+  });
+
+  it("should expose webfont as both the default and a named export", () => {
+    expect(index).toBe(webfont);
+  });
+
+  it("should re-export the public Result and ResultConfig types", () => {
+    expectTypeOf<Result["config"]>().toEqualTypeOf<ResultConfig | undefined>();
+    expectTypeOf<ResultConfig>().toHaveProperty("filePath");
+    expectTypeOf<ResultConfig["filePath"]>().toEqualTypeOf<string | undefined>();
   });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,5 +2,7 @@ import { webfont } from "./standalone";
 
 export { diagnoseGlyphsData, diagnoseSvgContents } from "./lib/svgDiagnostics/diagnoseSvgContents";
 export { webfont } from "./standalone";
+export type { Result } from "./types/Result";
+export type { ResultConfig } from "./types/ResultConfig";
 export type { SvgDiagnosticCode, SvgGlyphDiagnostic, SvgToolsOptions } from "./types/SvgToolsOptions";
 export default webfont;


### PR DESCRIPTION
## Summary

### Proposed changes

Exposes the public result types on the package API so TypeScript consumers can annotate `webfont()` output directly.

- **`src/index.ts`:** re-export `Result` (from `./types/Result`) and `ResultConfig` (from `./types/ResultConfig`) from the package entry. They were already defined and exported internally but not surfaced on the public entry point, so consumers had to fall back to `ReturnType`/`Awaited` inference.
- **`README.md`:** add a **TypeScript** example under the existing **Result** section showing `import { webfont, type Result, type ResultConfig } from "webfont"` and typed access to `result.config.filePath`.
- **`src/index.test.ts`:** add a type-level test (`expectTypeOf`) that fails `npm run typecheck` if the exports are removed or their shape changes, plus a test asserting the default and named `webfont` exports are the same reference.

No runtime behavior changes — this is a public type-surface addition plus docs.

### Related issue

Refs #758 (kept open until the fix ships on npm, per the release workflow).

### Dependencies added/removed (if applicable)

N/A — no `package.json` changes.

---

### Testing

- [x] I have added or updated tests that prove my fix is effective or that my feature works (if applicable)
  - [x] Unit test — type-level assertions in `src/index.test.ts` (validated by `tsc`), plus default/named export identity.

#### How to test

1. `npm run lint` — Biome clean.
2. `npm run typecheck` — passes; removing either export or changing `ResultConfig`/`Result` shape makes it fail.
3. `npm test` — 418 tests pass.
4. `npm run test:package` — publint clean, `attw` green for node10 / node16 (CJS & ESM) / bundler, and ESM+CJS pack-smoke consumers OK, confirming the types resolve from the published tarball.
5. In a consumer: `import { webfont, type Result, type ResultConfig } from "webfont"` type-checks.

#### Test configuration

- N/A

---

## Checklist

- [ ] I have added corresponding labels to this PR (like bug, enhancement...);
- [x] My commits follow the [Conventional Commits 1.0 Guidelines](https://www.conventionalcommits.org/en/v1.0.0/);
- [x] My code follows the style guidelines of this project;
- [x] I have performed a self-review of my own code;
- [x] I have made changes to the documentation (if applicable);
- [x] My changes generate no new warnings or errors;

Made with [Cursor](https://cursor.com)