### PR TITLE
ci(release-please): dispatch npm-publish after cutting a release

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -8,6 +8,7 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  actions: write
 
 concurrency:
   group: release-please-${{ github.repository }}
@@ -24,3 +25,21 @@ jobs:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
           include-component-in-tag: false
+
+      # A GitHub Release created by this workflow uses the built-in GITHUB_TOKEN,
+      # and events triggered by GITHUB_TOKEN do not start other workflows. So the
+      # `release: published` event does NOT trigger npm-publish.yml on its own.
+      # workflow_dispatch is the documented exception: dispatching it with the
+      # GITHUB_TOKEN DOES start the run. Trigger the publish here when (and only
+      # when) release-please actually cut a release.
+      - name: Trigger the npm publish workflow for the new release
+        if: ${{ steps.release.outputs.releases_created == 'true' }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ steps.release.outputs['.--tag_name'] }}
+        run: |
+          if [ -z "$TAG" ]; then
+            TAG="$(gh release list --limit 1 --json tagName --jq '.[0].tagName')"
+          fi
+          echo "Release created; dispatching npm-publish.yml for tag: $TAG"
+          gh workflow run npm-publish.yml --ref master --field tag="$TAG"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -200,7 +200,7 @@ Versioning is automated with [Release Please](https://github.com/googleapis/rele
 1. Merge changes to `master` using [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `docs:`, `ci:`, etc.).
 2. Release Please opens or updates a **Release PR** with the next version, `CHANGELOG.md`, and `package.json` updates.
 3. Review and merge the Release PR to create the git tag and GitHub Release on GitHub.
-4. Publish to npm (see **npm publishing** below). The [`npm-publish`](.github/workflows/npm-publish.yml) workflow listens for `release: published`, but releases created with the default `GITHUB_TOKEN` usually **do not** trigger downstream workflows — use manual publish or re-run the workflow from the Actions tab if needed.
+4. Merging the Release PR is enough to publish (see **npm publishing** below): the [Release Please](.github/workflows/release-please.yml) workflow cuts the GitHub Release and then **dispatches** [`npm-publish`](.github/workflows/npm-publish.yml) for the new tag. A `release: published` event created with the default `GITHUB_TOKEN` does not start downstream workflows, so the publish is triggered explicitly via `workflow_dispatch` (the documented exception to that rule).
 
 **Git tags** created by Release Please follow **`v{semver}`** (for example `v12.0.0`). The config sets `include-component-in-tag: false` so tags are not prefixed with the package name (`webfont-v12.0.0`). See [ADR 0004](docs/adr/0004-release-please-instead-of-standard-version.md).
 
@@ -220,7 +220,7 @@ Publishing from GitHub Actions deploys the same validated build to **two environ
 1. Create an npm **Automation** or **Granular** access token for the `webfont` package (npmjs.com → **Access Tokens**) with publish permission (OTP/2FA-for-writes disabled for automation, or use a token type that bypasses it).
 2. Add it as a GitHub repository secret named **`NODE_AUTH_TOKEN`** ([Settings → Secrets and variables → Actions](https://github.com/itgalaxy/webfont/settings/secrets/actions)). GitHub Packages needs no secret — it uses `GITHUB_TOKEN`.
 
-**After merging a Release PR:** the [`npm-publish`](.github/workflows/npm-publish.yml) workflow listens for `release: published`, but releases created with the default `GITHUB_TOKEN` usually **do not** trigger downstream workflows — use **Actions → npm publish → Run workflow** with the release tag (e.g. `v12.1.0`) if publish does not start automatically.
+**After merging a Release PR:** the [Release Please](.github/workflows/release-please.yml) workflow cuts the GitHub Release and then dispatches [`npm-publish`](.github/workflows/npm-publish.yml) with the new tag automatically. (A `release: published` event from the default `GITHUB_TOKEN` does not start downstream workflows, so the dispatch is done explicitly — `workflow_dispatch` and `repository_dispatch` are the exceptions to that rule.) If publish does not start, run it manually: **Actions → npm publish → Run workflow** with the release tag (e.g. `v12.1.0`).
 
 **Future:** [npm Trusted Publishing](https://docs.npmjs.com/trusted-publishers) (OIDC) can replace the `NODE_AUTH_TOKEN` secret when a maintainer configures it on npmjs.com for workflow `npm-publish.yml`.
 


### PR DESCRIPTION
## Summary

### Proposed changes

Fixes the release pipeline so that **merging a Release PR actually publishes**.

- A GitHub Release created by the `release-please` workflow uses the built-in `GITHUB_TOKEN`. Events triggered by `GITHUB_TOKEN` **do not start other workflow runs**, so the `release: published` event never triggers [`npm-publish.yml`](.github/workflows/npm-publish.yml).
- **Evidence:** `v12.0.1`, `v12.1.0`, `v12.1.1` and `v12.2.0` (all cut by release-please) never auto-ran `npm-publish`; only the manually-created `v12.0.0` did (via a `release` event). Every CI publish so far was a manual `workflow_dispatch`.
- **Fix:** after `release-please` cuts a release, dispatch `npm-publish.yml` via `workflow_dispatch` — the documented exception to the `GITHUB_TOKEN` rule (dispatching with `GITHUB_TOKEN` *does* start the run). Gated on `releases_created == 'true'`, passing the new tag (with a fallback that resolves it from the latest release).
- Adds `actions: write` permission so the token can dispatch, and updates `CONTRIBUTING.md`.

### Related issue

Follow-up to the publish pipeline work in #742 / #756. N/A issue.

### Dependencies added/removed (if applicable)

N/A — no `package.json` changes.

---

### Testing

- [x] No runtime code; workflow + docs only. YAML validated locally (`yaml` parser); `lint:suppressions` clean on pre-commit.

#### How to test

1. Merge this PR to `master` **before** merging the next Release PR.
2. Merge the Release PR → the `Release Please` run creates the Release and then dispatches `npm-publish.yml` for the new tag (visible under **Actions**).
3. Fallback still available: **Actions → npm publish → Run workflow** with the tag.

#### Test configuration

- N/A

---

## Checklist

- [x] I have added corresponding labels to this PR (like bug, enhancement...);
- [x] My commits follow the [Conventional Commits 1.0 Guidelines](https://www.conventionalcommits.org/en/v1.0.0/);
- [x] My code follows the style guidelines of this project;
- [x] I have performed a self-review of my own code;
- [x] I have made changes to the documentation (if applicable);
- [x] My changes generate no new warnings or errors;

Made with [Cursor](https://cursor.com)