### PR TITLE
ci(release-please): fix publish dispatch (pass --repo, resolve tag via API)

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -40,7 +40,20 @@ jobs:
         run: |
           # This job does not check out the repo, so pass --repo explicitly
           # (gh otherwise looks for a local git remote and fails). release-please
-          # just cut the release, so it is the most recent one.
-          tag="$(gh release list --repo "$REPO" --limit 1 --json tagName --jq '.[0].tagName')"
+          # just cut the release, so it is the most recent one. Retry a few times
+          # to absorb GitHub API propagation lag right after the release is made.
+          tag=""
+          for attempt in 1 2 3 4 5; do
+            tag="$(gh release list --repo "$REPO" --limit 1 --json tagName --jq '.[0].tagName')"
+            if [ -n "$tag" ]; then
+              break
+            fi
+            echo "No release visible yet (attempt $attempt/5); retrying in 5s..."
+            sleep 5
+          done
+          if [ -z "$tag" ]; then
+            echo "::error::release-please reported a release but no tag could be resolved; not dispatching npm-publish."
+            exit 1
+          fi
           echo "Release created; dispatching npm-publish.yml for tag: $tag"
           gh workflow run npm-publish.yml --repo "$REPO" --ref master --field tag="$tag"

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -36,10 +36,11 @@ jobs:
         if: ${{ steps.release.outputs.releases_created == 'true' }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TAG: ${{ steps.release.outputs['.--tag_name'] }}
+          REPO: ${{ github.repository }}
         run: |
-          if [ -z "$TAG" ]; then
-            TAG="$(gh release list --limit 1 --json tagName --jq '.[0].tagName')"
-          fi
-          echo "Release created; dispatching npm-publish.yml for tag: $TAG"
-          gh workflow run npm-publish.yml --ref master --field tag="$TAG"
+          # This job does not check out the repo, so pass --repo explicitly
+          # (gh otherwise looks for a local git remote and fails). release-please
+          # just cut the release, so it is the most recent one.
+          tag="$(gh release list --repo "$REPO" --limit 1 --json tagName --jq '.[0].tagName')"
+          echo "Release created; dispatching npm-publish.yml for tag: $tag"
+          gh workflow run npm-publish.yml --repo "$REPO" --ref master --field tag="$tag"


### PR DESCRIPTION
## Summary

### Proposed changes

Follow-up fix to #761. On the first real run (release `v12.3.0`), the dispatch step **created the release but failed to trigger** `npm-publish`:

- The `release-please` job does **not** check out the repo, so `gh` could not determine the repository — `failed to run git: fatal: not a git repository`.
- The `steps.release.outputs['.--tag_name']` expression resolved **empty**.

**Fix:**
- Pass `--repo "$GITHUB_REPOSITORY"` to both `gh release list` and `gh workflow run` so they work without a checkout.
- Resolve the freshly-cut tag from `gh release list` (release-please serializes releases via its concurrency group, so the latest release is the one just created), dropping the fragile path-prefixed output.

`v12.3.0` was published by dispatching `npm-publish` manually; this makes the automatic dispatch work for the next release.

### Related issue

Follow-up to #761 (publish pipeline). N/A issue.

### Dependencies added/removed (if applicable)

N/A.

---

### Testing

- [x] Workflow-only change. YAML validated locally; `lint:suppressions` clean. Verified against the failed run `28691563389` (root cause: missing `--repo` + empty tag output).

#### How to test

1. Merge to `master`.
2. On the next merged Release PR, the `Release Please` run should create the release **and** dispatch `npm-publish.yml` for the new tag (check **Actions**).

#### Test configuration

- N/A

---

## Checklist

- [x] I have added corresponding labels to this PR (like bug, enhancement...);
- [x] My commits follow the [Conventional Commits 1.0 Guidelines](https://www.conventionalcommits.org/en/v1.0.0/);
- [x] My code follows the style guidelines of this project;
- [x] I have performed a self-review of my own code;
- [x] I have made changes to the documentation (if applicable);
- [x] My changes generate no new warnings or errors;

Made with [Cursor](https://cursor.com)