### PR TITLE
feat: add TTF to SVG font encoder

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -35,12 +35,13 @@ Canonical list of product capabilities. **Update this file in the same PR** when
 ### TTF to webfont encoding
 
 - **Stability**: in-progress
-- **Description**: Encode one or more `.ttf` TrueType files to `eot`, `woff`, and/or `woff2` (and optional TTF pass-through). Auto-detected from input extension — no separate flag (see [#13](https://github.com/itgalaxy/webfont/issues/13)).
+- **Description**: Encode one or more `.ttf` TrueType files to `svg`, `eot`, `woff`, and/or `woff2` (and optional TTF pass-through). Auto-detected from input extension — no separate flag (see [#13](https://github.com/itgalaxy/webfont/issues/13)).
 - **Properties**:
   - Input: one or more local `.ttf` paths or globs per run.
-  - Output: `ttf` (copy), `eot`, `woff`, and/or `woff2` per input via existing encoders (`ttf2eot`, `ttf2woff`, `wawoff2`).
-  - Batch results on `result.transcodedFonts` (`{ source, ttf?, eot?, woff?, woff2? }[]`). Single input mirrors buffers on `result` top level.
-  - Default `formats` when SVG-pipeline defaults are still configured: `['woff', 'woff2']`.
+  - Output: `ttf` (copy), `svg` (SVG font), `eot`, `woff`, and/or `woff2` per input via existing encoders (`fonteditor-core`, `ttf2eot`, `ttf2woff`, `wawoff2`).
+  - `svg` produces a legacy **SVG font** (glyph outlines + metrics as XML) via [`fonteditor-core`](https://github.com/kekee000/fonteditor-core) — pure JS, no Java/FontForge ([#764](https://github.com/itgalaxy/webfont/issues/764)). Opt-in only; not part of the default output set.
+  - Batch results on `result.transcodedFonts` (`{ source, svg?, ttf?, eot?, woff?, woff2? }[]`). Single input mirrors buffers on `result` top level (`result.svg` is a string).
+  - Default `formats` when SVG-pipeline defaults are still configured: `['woff', 'woff2']` (SVG font stays opt-in).
   - Does **not** accept `.otf` input (TrueType only). Does **not** merge multiple weights into one file.
   - `template` and `glyphTransformFn` are not supported in this mode.
   - `glyphContentTransformFn` is not supported in this mode.
@@ -48,11 +49,12 @@ Canonical list of product capabilities. **Update this file in the same PR** when
   - **Architecture:** see [ADR 0009](docs/adr/0009-ttf-webfont-encoding-pipeline.md).
 - **Test Criteria**:
   - [x] `.ttf` input with `formats: ['woff', 'woff2']` yields valid WOFF and WOFF2
-  - [x] Default formats produce `woff` + `woff2` when SVG defaults are configured
-  - [x] Multiple TTF files encode in one run (`transcodedFonts`)
+  - [x] `.ttf` input with `formats: ['svg']` yields a valid SVG font ([#764](https://github.com/itgalaxy/webfont/issues/764))
+  - [x] Default formats produce `woff` + `woff2` when SVG defaults are configured (no SVG font)
+  - [x] Multiple TTF files encode in one run (`transcodedFonts`), including `svg`
   - [x] Mixed `.svg` + `.ttf` or `.ttf` + `.woff2` inputs reject
   - [x] Template option in TTF mode rejects
-  - [x] CLI writes encoded outputs for a single TTF input
+  - [x] CLI writes encoded outputs (incl. `svg`) for a single TTF input
 
 ### WOFF / WOFF2 container decompression
 
@@ -221,7 +223,7 @@ Canonical list of product capabilities. **Update this file in the same PR** when
 - **Stability**: planned
 - **Description**: Convert between outline/container formats beyond the current three pipelines (e.g. TTF ↔ OTF transcoding, OTF input encoding).
 - **Properties**:
-  - **Partially supported:** TTF → `eot` / `woff` / `woff2` (see TTF to webfont encoding). WOFF/WOFF2 → TTF/OTF decompression.
+  - **Partially supported:** TTF → `svg` (SVG font) / `eot` / `woff` / `woff2` (see TTF to webfont encoding). WOFF/WOFF2 → TTF/OTF decompression.
   - **Out of scope today:** OTF input encoding, TTF ↔ OTF outline conversion.
   - External tools (FontForge, fontTools, etc.) are required for TTF → OTF today.
 - **Test Criteria**:

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ See **[FEATURES.md](./FEATURES.md)** for the canonical capability list (what is 
 ## Features
 
 - **SVG icon pipeline** (default): `.svg` icons → `svg`, `ttf`, `eot`, `woff`, `woff2` (not `otf`);
-- **TTF encoding**: one or more `.ttf` files → `ttf` (pass-through), `eot`, `woff`, and/or `woff2` (auto-detected — no extra flag);
+- **TTF encoding**: one or more `.ttf` files → `ttf` (pass-through), `svg` (SVG font), `eot`, `woff`, and/or `woff2` (auto-detected — no extra flag);
 - **Webfont decompression**: one `.woff` or `.woff2` file → `ttf` and/or `otf` matching the **embedded SFNT flavor** (decompress only — not TTF ↔ OTF transcoding);
 - Config files: `JavaScript`, `JSON`, or `YAML` via [cosmiconfig](https://github.com/cosmiconfig/cosmiconfig);
 - Built-in and custom CSS templates (`css`, `scss`, [`styl`](https://github.com/itgalaxy/webfont/pull/164/));
@@ -30,7 +30,7 @@ webfont runs one of three pipelines depending on matched input files. They canno
 | Mode | Input | Outputs | Notes |
 |------|--------|---------|--------|
 | **SVG icons** | One or more `.svg` files | `svg`, `ttf`, `eot`, `woff`, `woff2` | Default. Builds TrueType via `svg2ttf`. **`otf` is rejected** — use `ttf`. |
-| **TTF encoding** | One or more `.ttf` files | `ttf`, `eot`, `woff`, and/or `woff2` per input | Auto-detected. Default when SVG-pipeline `formats` are still configured: `woff` + `woff2`. No templates. |
+| **TTF encoding** | One or more `.ttf` files | `ttf`, `svg` (SVG font), `eot`, `woff`, and/or `woff2` per input | Auto-detected. Default when SVG-pipeline `formats` are still configured: `woff` + `woff2` (`svg` is opt-in). No templates. |
 | **Webfont decompress** | One or more `.woff` / `.woff2` paths, globs, or `http(s)` URLs | `ttf` and/or `otf` per input | One output file per source (basename from filename; collisions get `-woff`/`-woff2`). Not a single merged font. |
 
 **Not supported today**
@@ -156,6 +156,13 @@ const subset = await webfont({
   files: "path/to/font.ttf",
   formats: ["woff2"],
 });
+
+// TTF → SVG font (legacy format; opt-in, pure JS via fonteditor-core)
+const svgFont = await webfont({
+  files: "path/to/font.ttf",
+  formats: ["svg"],
+});
+// svgFont.svg → SVG font as a string
 
 // Batch: multiple TTF files in one run
 const batch = await webfont({
@@ -292,7 +299,7 @@ Notes:
 - Possible values: `svg`, `ttf`, `otf`, `eot`, `woff`, `woff2`
 - Description: Font file types to generate.
   - **SVG input**: `svg`, `ttf`, `eot`, `woff`, `woff2` only. **`otf` is not supported** (pipeline uses TrueType outlines).
-  - **TTF input**: `ttf`, `eot`, `woff`, and/or `woff2` only. **`svg` and `otf` are not produced** in this mode.
+  - **TTF input**: `svg` (SVG font), `ttf`, `eot`, `woff`, and/or `woff2`. `svg` is **opt-in** (not in the default `woff` + `woff2` set); **`otf` is not produced** in this mode.
   - **WOFF/WOFF2 input**: `ttf` and/or `otf` only — must match the decompressed SFNT flavor inside the file (not arbitrary transcoding). `eot`, `woff`, `woff2`, and `svg` are not produced in this mode.
 - CLI: pass `-f` / `--formats` as a JSON array (for example `'["woff2"]'`) or as a comma-separated list (for example `woff2` or `svg, ttf, woff2`). Invalid format names throw an error.
 - API and config files: `formats` must be an array of the values above; unknown names (for example `icon`) throw before the pipeline runs.

--- a/docs/migration/issue-0764-ttf-svg-font.md
+++ b/docs/migration/issue-0764-ttf-svg-font.md
@@ -1,0 +1,65 @@
+# TTF to SVG font encoding ([#764](https://github.com/itgalaxy/webfont/issues/764))
+
+**Minimum version:** *pending*
+
+## What changed
+
+In **TTF encoding mode**, `svg` is now a valid **output format**: a `.ttf` file can be
+converted to a legacy **SVG font** (glyph outlines + metrics as XML). It is produced in
+pure JavaScript via [`fonteditor-core`](https://github.com/kekee000/fonteditor-core) — no
+Java or FontForge.
+
+`svg` is **opt-in**: the default TTF output stays `woff` + `woff2` when SVG-pipeline
+`formats` are still configured.
+
+## Before
+
+TTF input rejected `formats: ["svg"]`:
+
+```
+formats must include at least one of "ttf", "eot", "woff", or "woff2" when converting TTF input
+```
+
+To get an SVG font from a TTF you needed an external tool (FontForge, `uipoet/webfonts`, etc.).
+
+## After
+
+```shell
+webfont path/to/font.ttf -d dist/fonts -f svg
+```
+
+Programmatic:
+
+```js
+const result = await webfont({
+  files: "fonts/MyFont.ttf",
+  formats: ["svg"],
+});
+// result.svg → SVG font as a string
+```
+
+Batch runs expose the SVG font per input on `result.transcodedFonts`
+(`{ source, svg?, ttf?, eot?, woff?, woff2? }[]`). The CLI writes `<name>.svg`.
+
+A run whose `formats` contains **no** encoder output (for example `["otf"]`) still rejects,
+now with `svg` listed:
+
+```
+formats must include at least one of "svg", "ttf", "eot", "woff", or "woff2" when converting TTF input
+```
+
+## Workaround on older versions
+
+Use an external converter until upgrade (both require a Java/native toolchain):
+
+```shell
+# FontForge
+fontforge -lang=ff -c 'Open($1); Generate($2)' font.ttf font.svg
+```
+
+## After upgrading
+
+```shell
+npm install webfont@<version>
+webfont "fonts/*.ttf" -d dist/webfonts -f svg --dest-create
+```

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "cosmiconfig": "9.0.2",
         "deepmerge": "^4.2.2",
+        "fonteditor-core": "2.6.3",
         "fontverter": "2.0.0",
         "globby": "16.2.0",
         "meow": "14.1.0",
@@ -2521,6 +2522,23 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/fonteditor-core": {
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/fonteditor-core/-/fonteditor-core-2.6.3.tgz",
+      "integrity": "sha512-YUryIKjkenjZ41E7JvM3V+02Ak4mTHDDTwBWgs9KBzypzHqLZHuua1UDRevZNTKawmnq1dbBAa70Jddl2+F4FQ==",
+      "dependencies": {
+        "@xmldom/xmldom": "^0.8.3"
+      }
+    },
+    "node_modules/fonteditor-core/node_modules/@xmldom/xmldom": {
+      "version": "0.8.13",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.13.tgz",
+      "integrity": "sha512-KRYzxepc14G/CEpEGc3Yn+JKaAeT63smlDr+vjB8jRfgTBBI9wRj/nkQEO+ucV8p8I9bfKLWp37uHgFrbntPvw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
       }
     },
     "node_modules/fontverter": {
@@ -6808,6 +6826,21 @@
       "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
       "requires": {
         "to-regex-range": "^5.0.1"
+      }
+    },
+    "fonteditor-core": {
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/fonteditor-core/-/fonteditor-core-2.6.3.tgz",
+      "integrity": "sha512-YUryIKjkenjZ41E7JvM3V+02Ak4mTHDDTwBWgs9KBzypzHqLZHuua1UDRevZNTKawmnq1dbBAa70Jddl2+F4FQ==",
+      "requires": {
+        "@xmldom/xmldom": "^0.8.3"
+      },
+      "dependencies": {
+        "@xmldom/xmldom": {
+          "version": "0.8.13",
+          "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.13.tgz",
+          "integrity": "sha512-KRYzxepc14G/CEpEGc3Yn+JKaAeT63smlDr+vjB8jRfgTBBI9wRj/nkQEO+ucV8p8I9bfKLWp37uHgFrbntPvw=="
+        }
       }
     },
     "fontverter": {

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
   "dependencies": {
     "cosmiconfig": "9.0.2",
     "deepmerge": "^4.2.2",
+    "fonteditor-core": "2.6.3",
     "fontverter": "2.0.0",
     "globby": "16.2.0",
     "meow": "14.1.0",

--- a/src/cli/index.test.ts
+++ b/src/cli/index.test.ts
@@ -542,6 +542,18 @@ describe("cli", () => {
     expect(output.files).toEqual(["webfont.hash", "webfont.woff2"]);
   });
 
+  it("should convert a ttf font to an svg font via the CLI (#764)", async () => {
+    const output = await execCLI(`${fixturesGlob}/fonts/iconfont.ttf -d ${destination} -f svg`);
+
+    expect(output.code).toBe(0);
+    expect(output.stderr).toBe("");
+    expect(output.files).toContain("webfont.svg");
+
+    const svg = await fsPromise.readFile(`${destination}/webfont.svg`, { encoding: "utf-8" });
+    expect(svg).toContain("<font");
+    expect(svg).toContain("<glyph");
+  });
+
   it("should create dest directory if it does not exist and --dest-create flag is provided", async () => {
     const nonExistentDestination = `${destination}/that/does/not/exist`;
     const output = await execCLI(`${source} -d ${nonExistentDestination} --dest-create`);

--- a/src/cli/program.test.ts
+++ b/src/cli/program.test.ts
@@ -17,6 +17,7 @@ import {
   startCli,
   writeDecompressedFontFiles,
   writeResultFiles,
+  writeTranscodedFontFiles,
 } from "./program";
 
 vi.mock("../standalone", async (importOriginal) => {
@@ -355,6 +356,28 @@ describe("cli program", () => {
 
       expect(await fsPromise.readFile(path.join(destination, "iconfont-woff.ttf"), "utf8")).toBe("woff-ttf");
       expect(await fsPromise.readFile(path.join(destination, "iconfont-woff2.ttf"), "utf8")).toBe("woff2-ttf");
+    });
+  });
+
+  describe("writeTranscodedFontFiles", () => {
+    it("should write an svg font per transcoded font", async () => {
+      const destination = "temp/cli-program-transcoded-svg";
+      await fsPromise.mkdir(destination, { recursive: true });
+
+      await writeTranscodedFontFiles(
+        [
+          { source: "src/fixtures/fonts/a.ttf", svg: "<svg>a</svg>", woff2: Buffer.from("a2") },
+          { source: "src/fixtures/fonts/b.ttf", svg: "<svg>b</svg>", woff2: Buffer.from("b2") },
+        ],
+        {
+          dest: destination,
+          fontName: "webfont",
+        } as never,
+        destination,
+      );
+
+      expect(await fsPromise.readFile(path.join(destination, "a.svg"), "utf8")).toBe("<svg>a</svg>");
+      expect(await fsPromise.readFile(path.join(destination, "b.svg"), "utf8")).toBe("<svg>b</svg>");
     });
   });
 

--- a/src/cli/program.ts
+++ b/src/cli/program.ts
@@ -381,6 +381,10 @@ export const writeTranscodedFontFiles = async (
       const basename = getTranscodedFontOutputBasename(fonts, font, config);
       const writes: Promise<void>[] = [];
 
+      if (font.svg) {
+        writes.push(fs.promises.writeFile(path.resolve(path.join(dest, `${basename}.svg`)), font.svg));
+      }
+
       if (font.ttf) {
         writes.push(fs.promises.writeFile(path.resolve(path.join(dest, `${basename}.ttf`)), font.ttf));
       }

--- a/src/lib/ttfEncode.test.ts
+++ b/src/lib/ttfEncode.test.ts
@@ -87,7 +87,11 @@ describe("ttfEncode", () => {
       const ttf = await fsPromise.readFile(fixtureTtf);
       const svg = encodeTtfToSvg(ttf);
 
-      expect(svg).toContain("<metadata></metadata>");
+      // Assert the intent ("no non-empty metadata") rather than fonteditor-core's
+      // exact empty-element serialization, which may vary across releases
+      // (`<metadata></metadata>`, `<metadata/>`, or omitted) without changing behavior.
+      expect(isSvg(svg)).toBe(true);
+      expect(svg).not.toMatch(/<metadata>[^<]+<\/metadata>/u);
     });
   });
 });

--- a/src/lib/ttfEncode.test.ts
+++ b/src/lib/ttfEncode.test.ts
@@ -2,11 +2,12 @@ import crypto from "crypto";
 import fontverter from "fontverter";
 import * as fsPromise from "fs/promises";
 import isEot from "is-eot";
+import isSvg from "is-svg";
 import isTtf from "is-ttf";
 import isWoff from "is-woff";
 import isWoff2 from "is-woff2";
 import wawoff2 from "wawoff2";
-import { encodeTtfToEot, encodeTtfToWoff, encodeTtfToWoff2 } from "./ttfEncode";
+import { encodeTtfToEot, encodeTtfToSvg, encodeTtfToWoff, encodeTtfToWoff2 } from "./ttfEncode";
 
 const fixtureTtf = "src/fixtures/fonts/iconfont.ttf";
 
@@ -60,6 +61,33 @@ describe("ttfEncode", () => {
       const eot = encodeTtfToEot(ttf);
 
       expect(isEot(eot)).toBe(true);
+    });
+  });
+
+  describe("encodeTtfToSvg (fonteditor-core)", () => {
+    it("should encode a ttf buffer to a valid svg font string", async () => {
+      const ttf = await fsPromise.readFile(fixtureTtf);
+      const svg = encodeTtfToSvg(ttf);
+
+      expect(typeof svg).toBe("string");
+      expect(isSvg(svg)).toBe(true);
+      expect(svg).toContain("<font");
+      expect(svg).toContain("<font-face");
+      expect(svg).toContain("<glyph");
+    });
+
+    it("should embed provided metadata in the svg output", async () => {
+      const ttf = await fsPromise.readFile(fixtureTtf);
+      const svg = encodeTtfToSvg(ttf, { metadata: "webfont-metadata-marker" });
+
+      expect(svg).toContain("<metadata>webfont-metadata-marker</metadata>");
+    });
+
+    it("should not embed metadata when none is provided", async () => {
+      const ttf = await fsPromise.readFile(fixtureTtf);
+      const svg = encodeTtfToSvg(ttf);
+
+      expect(svg).toContain("<metadata></metadata>");
     });
   });
 });

--- a/src/lib/ttfEncode.ts
+++ b/src/lib/ttfEncode.ts
@@ -1,8 +1,12 @@
+import { createFont } from "fonteditor-core";
 import ttf2woff from "ttf2woff";
 import wawoff2 from "wawoff2";
 import convertTtfToEot from "./ttf2eot";
 
 export const encodeTtfToEot = (buffer: Buffer): Buffer => convertTtfToEot(buffer);
+
+export const encodeTtfToSvg = (buffer: Buffer, options: { metadata?: string } = {}): string =>
+  createFont(buffer, { type: "ttf" }).write({ type: "svg", metadata: options.metadata });
 
 export const encodeTtfToWoff = (buffer: Buffer, options: { metadata?: string } = {}): Buffer =>
   Buffer.from(ttf2woff(buffer, options).buffer);

--- a/src/standalone/convertTtfInput.test.ts
+++ b/src/standalone/convertTtfInput.test.ts
@@ -1,4 +1,5 @@
 import * as fsPromise from "fs/promises";
+import isSvg from "is-svg";
 import isTtf from "is-ttf";
 import isWoff2 from "is-woff2";
 import { vi } from "vitest";
@@ -102,6 +103,38 @@ describe("convertTtfInput", () => {
     expect(isTtf(result.ttf)).toBe(true);
     expect(isWoff2(result.woff2)).toBe(true);
     expect(result.transcodedFonts).toHaveLength(1);
+  });
+
+  it("should encode ttf input to a valid svg font when requested", async () => {
+    const result = await convertTtfInput([fixtureTtf], {
+      files: fixtureTtf,
+      formats: ["svg"],
+    } as WebfontOptions);
+
+    expect(typeof result.svg).toBe("string");
+    expect(isSvg(result.svg as string)).toBe(true);
+    expect(result.transcodedFonts?.[0]?.svg).toBe(result.svg);
+  });
+
+  it("should not emit svg unless it is requested", async () => {
+    const result = await convertTtfInput([fixtureTtf], {
+      files: fixtureTtf,
+      formats: ["woff2"],
+    } as WebfontOptions);
+
+    expect(result.svg).toBeUndefined();
+    expect(result.transcodedFonts?.[0]?.svg).toBeUndefined();
+  });
+
+  it("should encode svg for every input in a batch run", async () => {
+    const result = await convertTtfInput([fixtureTtf, fixtureTtf], {
+      files: [fixtureTtf, fixtureTtf],
+      formats: ["svg"],
+    } as WebfontOptions);
+
+    expect(result.svg).toBeUndefined();
+    expect(result.transcodedFonts).toHaveLength(2);
+    expect(result.transcodedFonts?.every((font) => isSvg(font.svg as string))).toBe(true);
   });
 
   it("should not mirror top-level outputs for batch runs", async () => {

--- a/src/standalone/convertTtfInput.ts
+++ b/src/standalone/convertTtfInput.ts
@@ -1,7 +1,7 @@
 import * as fsPromise from "fs/promises";
 import { isHttpUrl } from "../lib/inputSourceUtils";
 import { getSfntFlavor } from "../lib/sfnt/flavor";
-import { encodeTtfToEot, encodeTtfToWoff, encodeTtfToWoff2 } from "../lib/ttfEncode";
+import { encodeTtfToEot, encodeTtfToSvg, encodeTtfToWoff, encodeTtfToWoff2 } from "../lib/ttfEncode";
 import type { Result } from "../types/Result";
 import type { TranscodedFont } from "../types/TranscodedFont";
 import type { WebfontOptions } from "../types/WebfontOptions";
@@ -41,6 +41,14 @@ const assertValidTtfInput = (buffer: Buffer, source: string): void => {
   }
 };
 
+const resolveMetadata = (options: WebfontOptions): string | undefined => {
+  if (typeof options.metadata === "string") {
+    return options.metadata;
+  }
+
+  return undefined;
+};
+
 const assignTtfOutput = async (
   transcoded: TranscodedFont,
   buffer: Buffer,
@@ -52,19 +60,18 @@ const assignTtfOutput = async (
     return;
   }
 
+  if (format === "svg") {
+    transcoded.svg = encodeTtfToSvg(buffer, { metadata: resolveMetadata(options) });
+    return;
+  }
+
   if (format === "eot") {
     transcoded.eot = encodeTtfToEot(buffer);
     return;
   }
 
   if (format === "woff") {
-    let metadata: string | undefined;
-
-    if (typeof options.metadata === "string") {
-      metadata = options.metadata;
-    }
-
-    transcoded.woff = encodeTtfToWoff(buffer, { metadata });
+    transcoded.woff = encodeTtfToWoff(buffer, { metadata: resolveMetadata(options) });
     return;
   }
 
@@ -114,6 +121,7 @@ export const convertTtfInput = async (fontFiles: readonly string[], options: Web
   if (transcodedFonts.length === 1) {
     const [single] = transcodedFonts;
 
+    result.svg = single.svg;
     result.ttf = single.ttf;
     result.eot = single.eot;
     result.woff = single.woff;

--- a/src/standalone/inputMode.test.ts
+++ b/src/standalone/inputMode.test.ts
@@ -137,13 +137,21 @@ describe("resolveTtfConversionFormats", () => {
     expect(resolveTtfConversionFormats(["ttf", "woff2"])).toEqual(["ttf", "woff2"]);
   });
 
+  it("should keep an explicit svg output request", () => {
+    expect(resolveTtfConversionFormats(["svg"])).toEqual(["svg"]);
+  });
+
+  it("should keep svg alongside webfont output requests", () => {
+    expect(resolveTtfConversionFormats(["svg", "woff2"])).toEqual(["svg", "woff2"]);
+  });
+
   it("should deduplicate explicit encode formats", () => {
     expect(resolveTtfConversionFormats(["woff2", "woff2", "woff"])).toEqual(["woff2", "woff"]);
   });
 
-  it("should reject ttf runs without webfont output formats", () => {
-    expect(() => resolveTtfConversionFormats(["svg"])).toThrow(
-      'formats must include at least one of "ttf", "eot", "woff", or "woff2" when converting TTF input',
+  it("should reject ttf runs without any encoder output format", () => {
+    expect(() => resolveTtfConversionFormats(["otf"])).toThrow(
+      'formats must include at least one of "svg", "ttf", "eot", "woff", or "woff2" when converting TTF input',
     );
   });
 });

--- a/src/standalone/inputMode.ts
+++ b/src/standalone/inputMode.ts
@@ -75,9 +75,9 @@ export const filterInputFilesByMode = (filePaths: readonly string[], mode: Input
 
 export type ConversionFormat = "otf" | "ttf";
 
-export type TtfEncodeFormat = "eot" | "ttf" | "woff" | "woff2";
+export type TtfEncodeFormat = "eot" | "svg" | "ttf" | "woff" | "woff2";
 
-const TTF_ENCODE_FORMATS = new Set<Format>(["ttf", "eot", "woff", "woff2"]);
+const TTF_ENCODE_FORMATS = new Set<Format>(["ttf", "svg", "eot", "woff", "woff2"]);
 
 export const resolveTtfConversionFormats = (formats: readonly Format[]): TtfEncodeFormat[] => {
   const encodeFormats = formats.filter((format): format is TtfEncodeFormat => TTF_ENCODE_FORMATS.has(format));
@@ -91,7 +91,7 @@ export const resolveTtfConversionFormats = (formats: readonly Format[]): TtfEnco
 
   if (encodeFormats.length === 0) {
     throw new Error(
-      'formats must include at least one of "ttf", "eot", "woff", or "woff2" when converting TTF input',
+      'formats must include at least one of "svg", "ttf", "eot", "woff", or "woff2" when converting TTF input',
     );
   }
 

--- a/src/standalone/ttfConversion.integration.test.ts
+++ b/src/standalone/ttfConversion.integration.test.ts
@@ -1,5 +1,6 @@
 import * as fsPromise from "fs/promises";
 import isEot from "is-eot";
+import isSvg from "is-svg";
 import isTtf from "is-ttf";
 import isWoff from "is-woff";
 import isWoff2 from "is-woff2";
@@ -86,14 +87,26 @@ describe("TTF to webfont conversion", () => {
     ).rejects.toThrow("Templates are not supported when converting TTF input");
   });
 
-  it("should reject formats without webfont outputs for ttf input", async () => {
+  it("should encode ttf input to a valid svg font when requested", async () => {
+    const result = await standalone({
+      files: fixtureTtf,
+      formats: ["svg"],
+    });
+
+    expect(typeof result.svg).toBe("string");
+    expect(isSvg(result.svg as string)).toBe(true);
+    expect(result.woff).toBeUndefined();
+    expect(result.glyphsData).toBeUndefined();
+  });
+
+  it("should reject formats without any ttf encoder output", async () => {
     await expect(
       standalone({
         files: fixtureTtf,
-        formats: ["svg"],
+        formats: ["otf"],
       }),
     ).rejects.toThrow(
-      'formats must include at least one of "ttf", "eot", "woff", or "woff2" when converting TTF input',
+      'formats must include at least one of "svg", "ttf", "eot", "woff", or "woff2" when converting TTF input',
     );
   });
 

--- a/src/types/TranscodedFont.ts
+++ b/src/types/TranscodedFont.ts
@@ -1,6 +1,7 @@
 export type TranscodedFont = {
   source: string;
   eot?: Buffer;
+  svg?: string;
   ttf?: Buffer;
   woff?: Buffer;
   woff2?: Buffer;

--- a/types/fonteditor-core.d.ts
+++ b/types/fonteditor-core.d.ts
@@ -1,0 +1,8 @@
+// fonteditor-core's bundled type declarations list the DOM `Document` global as
+// an accepted parse input (FontInput = ArrayBuffer | Buffer | string | Document)
+// for reading SVG fonts from a parsed document. webfont only uses the
+// Buffer-based TTF -> SVG path in Node and deliberately keeps the DOM lib out of
+// tsconfig (Node-only runtime plus a browser stub). This minimal ambient shim
+// satisfies the reference without pulling in the full DOM lib or flipping
+// skipLibCheck, and merges harmlessly if the DOM lib is ever added.
+declare type Document = unknown;


### PR DESCRIPTION
## Summary

### Proposed changes

This PR brings the following changes:

- Add `svg` as an **opt-in output format** of the TTF encoding mode: a `.ttf` file can now be converted to a legacy **SVG font** (glyph outlines + metrics as XML);
- Convert in **pure JavaScript** via [`fonteditor-core`](https://github.com/kekee000/fonteditor-core) — no Java/FontForge — closing the last gap versus legacy converters like `uipoet/webfonts`;
- New `encodeTtfToSvg` wrapper (mirrors the existing `encodeTtfTo*` encoders); `svg` accepted by `resolveTtfConversionFormats`;
- `TranscodedFont.svg` / `result.svg` populated for single and batch TTF runs; the CLI writes `<name>.svg`;
- Default TTF output stays `woff` + `woff2` (SVG font is **opt-in**);
- `formats: ["svg"]` on TTF input previously **rejected**; it now produces an SVG font (a run with no encoder output, e.g. `["otf"]`, still rejects, now listing `svg`).

### Related issue

- Closes-when-published: #764 (kept open until the fix ships on npm, per repo workflow).

### Dependencies added/removed (if applicable)

- Add: `fonteditor-core@2.6.3` (production; pure JS, ships TypeScript types).
- A minimal ambient shim (`types/fonteditor-core.d.ts`) declares the DOM `Document` type the package's `.d.ts` references, without pulling in the DOM lib or flipping `skipLibCheck`.

---

### Testing

- [x] I have added or updated tests that prove my feature works
  - [x] Unit test — `encodeTtfToSvg` (`ttfEncode.test.ts`), `resolveTtfConversionFormats` (`inputMode.test.ts`), `writeTranscodedFontFiles` svg write (`program.test.ts`)
  - [x] Integration test — `webfont()` TTF→SVG (`convertTtfInput.test.ts`, `ttfConversion.integration.test.ts`) and end-to-end CLI (`cli/index.test.ts`)

#### How to test

1. `npm test` — full build + 429 tests pass.
2. CLI: `node dist/cli.mjs src/fixtures/fonts/iconfont.ttf -d temp/out -f svg` → writes `temp/out/webfont.svg` (valid SVG font with `<font>`/`<glyph>`).
3. Programmatic: `webfont({ files: "font.ttf", formats: ["svg"] })` → `result.svg` is an SVG font string.
4. `npm run lint`, `npm run typecheck`, `npm run depcheck` — all clean.

#### Test configuration

- Node.js version: N/A (repo `engines`: `>=24.14.0`)

---

## Checklist

- [x] I have added corresponding labels to this PR (like bug, enhancement...);
- [x] My commits follow the [Conventional Commits 1.0 Guidelines](https://www.conventionalcommits.org/en/v1.0.0/);
- [x] My code follows the style guidelines of this project;
- [x] I have performed a self-review of my own code;
- [x] I have made changes to the documentation (README, FEATURES, migration doc);
- [x] My changes generate no new warnings or errors.

Made with [Cursor](https://cursor.com)