### PR TITLE
chore: add Homebrew formula for webfont with a webfonts alias

### DIFF
--- a/packaging/homebrew/Aliases/webfonts
+++ b/packaging/homebrew/Aliases/webfonts
@@ -1,0 +1,1 @@
+../Formula/webfont.rb

--- a/packaging/homebrew/Formula/webfont.rb
+++ b/packaging/homebrew/Formula/webfont.rb
@@ -1,0 +1,35 @@
+# typed: false
+# frozen_string_literal: true
+
+# Homebrew formula for the `webfont` Node CLI.
+#
+# Source of truth lives in the itgalaxy/webfont repo under
+# packaging/homebrew/. It is mirrored to the Homebrew tap so users can run:
+#
+#   brew install itgalaxy/tap/webfont
+#
+# On each npm release, bump `url` + `sha256` to the new tarball. Get the sha256
+# with:  curl -sL <tarball-url> | shasum -a 256
+class Webfont < Formula
+  desc "Generator of fonts from SVG icons, with TTF encoding and WOFF/WOFF2 decoding"
+  homepage "https://github.com/itgalaxy/webfont"
+  url "https://registry.npmjs.org/webfont/-/webfont-12.4.0.tgz"
+  sha256 "c473cc6be649d17f94d6984ad04995514ed9b2cdb8afec6107c96db95787fbc2"
+  license "MIT"
+
+  depends_on "node"
+
+  def install
+    system "npm", "install", *std_npm_args
+    bin.install_symlink Dir["#{libexec}/bin/*"]
+  end
+
+  test do
+    (testpath/"icon.svg").write <<~SVG
+      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16"><path d="M2 2h12v12H2z"/></svg>
+    SVG
+
+    system bin/"webfont", testpath/"icon.svg", "-d", testpath, "-f", "woff2"
+    assert_path_exists testpath/"webfont.woff2"
+  end
+end

--- a/packaging/homebrew/README.md
+++ b/packaging/homebrew/README.md
@@ -20,19 +20,16 @@ brew install itgalaxy/tap/webfont
 brew install itgalaxy/tap/webfonts
 ```
 
-Both install the same maintained, pure-JS `webfont` CLI.
+Both install the same `webfont` CLI — `webfonts` is just an alternate name.
 
-## Why an alias?
+## The `webfonts` alias
 
-The older [`uipoet/webfonts`](https://github.com/uipoet/webfonts) package is
-unmaintained and not on Homebrew. The `webfonts` alias helps people looking for
-that tool land on the maintained one.
+`webfonts` is a convenience alias for `webfont` (a common alternate spelling).
 
-**Policy:** Homebrew **personal taps** allow arbitrary aliases (they are
-namespaced to the tap and users opt in with `brew tap`), so this alias is
-allowed there. **homebrew-core does not** accept it — core reserves aliases for
-renamed/legacy formulae and requires non-conflicting names. Keep the alias
-tap-only.
+Aliases like this are a tap feature: Homebrew **personal taps** allow arbitrary
+aliases (they are namespaced to the tap and users opt in with `brew tap`).
+**homebrew-core** reserves aliases for renamed/legacy formulae, so keep this one
+**tap-only**.
 
 ## Publishing / updating the tap
 

--- a/packaging/homebrew/README.md
+++ b/packaging/homebrew/README.md
@@ -1,0 +1,62 @@
+# Homebrew packaging
+
+Source of truth for the [Homebrew](https://brew.sh) distribution of `webfont`.
+These files are excluded from the npm tarball (see the `files` allowlist in
+`package.json`).
+
+```
+packaging/homebrew/
+├── Formula/
+│   └── webfont.rb      # the formula (Node CLI; installs the npm tarball)
+└── Aliases/
+    └── webfonts -> ../Formula/webfont.rb   # `webfonts` resolves to `webfont`
+```
+
+## Install (once the tap is published)
+
+```bash
+brew install itgalaxy/tap/webfont
+# or, via the alias:
+brew install itgalaxy/tap/webfonts
+```
+
+Both install the same maintained, pure-JS `webfont` CLI.
+
+## Why an alias?
+
+The older [`uipoet/webfonts`](https://github.com/uipoet/webfonts) package is
+unmaintained and not on Homebrew. The `webfonts` alias helps people looking for
+that tool land on the maintained one.
+
+**Policy:** Homebrew **personal taps** allow arbitrary aliases (they are
+namespaced to the tap and users opt in with `brew tap`), so this alias is
+allowed there. **homebrew-core does not** accept it — core reserves aliases for
+renamed/legacy formulae and requires non-conflicting names. Keep the alias
+tap-only.
+
+## Publishing / updating the tap
+
+The tap is a separate repo (a Homebrew tap must be named `homebrew-<name>`),
+e.g. `itgalaxy/homebrew-tap`, consumed as `itgalaxy/tap`.
+
+1. Copy `Formula/webfont.rb` and `Aliases/webfonts` into the tap repo.
+2. On each npm release, update the formula's `url` + `sha256`:
+
+   ```bash
+   version="$(npm view webfont version)"
+   url="$(npm view webfont dist.tarball)"
+   sha="$(curl -sL "$url" | shasum -a 256 | cut -d' ' -f1)"
+   echo "url $url"
+   echo "sha256 $sha"
+   ```
+
+3. Validate before pushing:
+
+   ```bash
+   brew style  packaging/homebrew/Formula/webfont.rb
+   brew audit --strict --online itgalaxy/tap/webfont
+   brew test   itgalaxy/tap/webfont
+   ```
+
+See issue [#769](https://github.com/itgalaxy/webfont/issues/769) for the
+rollout plan (including automating the bump on publish).


### PR DESCRIPTION
## Summary

### Proposed changes

Add `packaging/homebrew/` as the source of truth for distributing the `webfont` Node CLI via Homebrew. `webfont` is not on Homebrew today; this makes `brew install` a first-class install path.

- **`Formula/webfont.rb`** — installs the npm tarball into `libexec` (`depends_on "node"`, `std_npm_args`), pinned to `webfont@12.4.0` + `sha256`, with a `test do` that generates a `woff2` from an SVG and asserts the output.
- **`Aliases/webfonts`** — symlink so `webfonts` resolves to `webfont` inside the tap (an alternate-name convenience).
- **`README.md`** — install/usage, the tap-only alias-policy note, and how to bump `url`/`sha256` on each npm release.
- Files are **excluded from the npm tarball** (the `package.json` `files` allowlist doesn't include `packaging/`).

### Related issue

- #769

### Dependencies added/removed (if applicable)

- N/A (no `package.json` changes; Homebrew packaging only).

---

### Testing

- [x] Validated the formula locally (macOS, Homebrew on `arm64_tahoe`):
  - `brew style packaging/homebrew/Formula/webfont.rb` → no offenses
  - `brew audit --strict --online <tap>/webfont` → pass (URL reachable, sha256 matches, license OK)
  - `brew install <tap>/webfont` → installs; `webfont` on PATH
  - `brew test <tap>/webfont` → pass (generates `webfont.woff2`)
  - `brew info <tap>/webfonts` → the `webfonts` alias resolves to the `webfont` formula
  - Cleaned up afterwards (`brew uninstall` + `brew untap`).

#### How to test

Once the tap is wired up (see follow-up), the monorepo tap installs as:

```bash
brew tap itgalaxy/webfont https://github.com/itgalaxy/webfont
brew install itgalaxy/webfont/webfont     # or: itgalaxy/webfont/webfonts (alias)
webfont "fonts/*.ttf" -f woff2 -d dist --dest-create
```

#### Test configuration

- Homebrew on macOS (arm64). `node` provided by the `node` formula.

---

## Checklist

- [x] My commits follow the [Conventional Commits 1.0 Guidelines](https://www.conventionalcommits.org/en/v1.0.0/);
- [x] My code follows the style guidelines of this project;
- [x] I have performed a self-review of my own code;
- [x] I have made changes to the documentation (packaging README);
- [x] My changes generate no new warnings or errors.

### Note on the `webfonts` alias

`webfonts` is an alternate-name alias for `webfont`. Homebrew **personal taps** permit arbitrary aliases (namespaced to the tap; users opt in via `brew tap`), so the alias is allowed there. **homebrew-core** reserves aliases for renamed/legacy formulae, so the alias is kept **tap-only**.

### Follow-up (not in this PR)

Decision recorded in #769: distribute via a **monorepo tap** (root `HomebrewFormula/` + `Aliases/`), **deferred**. This PR keeps the validated formula under `packaging/homebrew/` as the source of truth; a later change syncs it to the repo root and adds a release step to bump `url`/`sha256` on each npm publish.