### PR TITLE
docs: add GitHub Pages site and Actions deploy workflow

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,53 @@
+name: Deploy docs to GitHub Pages
+
+# Publishes the docs/ folder from master to GitHub Pages.
+#
+# Uses the GitHub Actions publishing source (not a gh-pages branch). The
+# `enablement: true` below lets the workflow turn Pages on via the automation
+# token, so no manual Settings change is required to go live at
+# https://itgalaxy.github.io/webfont.
+#
+# Custom domain (webfont.js.org) is a separate step: the CNAME file is NOT
+# honored for workflow deploys, so the domain must be set once via the Pages
+# settings/API by a repo admin, and the js.org subdomain PR must be merged.
+
+on:
+  push:
+    branches: [master]
+    paths:
+      - "docs/**"
+      - ".github/workflows/pages.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Configure Pages
+        uses: actions/configure-pages@v5
+        with:
+          enablement: true
+
+      - name: Upload docs artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: docs
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,46 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>webfont</title>
+    <meta name="description" content="Generate fonts from SVG icons." />
+    <style>
+      :root {
+        color-scheme: light dark;
+      }
+      body {
+        margin: 0;
+        min-height: 100vh;
+        display: grid;
+        place-items: center;
+        font-family: system-ui, -apple-system, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+        background: #0b0b0c;
+        color: #fafafa;
+      }
+      main {
+        text-align: center;
+        padding: 2rem;
+      }
+      h1 {
+        margin: 0;
+        font-size: clamp(2.5rem, 12vw, 7rem);
+        letter-spacing: -0.04em;
+      }
+      p {
+        margin: 0.75rem 0 0;
+        opacity: 0.65;
+      }
+      a {
+        color: inherit;
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      <h1>webfont</h1>
+      <p>Generate fonts from SVG icons.</p>
+      <p><a href="https://github.com/itgalaxy/webfont">github.com/itgalaxy/webfont</a></p>
+    </main>
+  </body>
+</html>


### PR DESCRIPTION
## Summary

### Proposed changes

- Add a minimal **`docs/index.html`** landing page (package name + tagline + repo link) — a first iteration to validate the Pages pipeline.
- Add **`.github/workflows/pages.yml`** that deploys the `docs/` folder from `master` to **GitHub Pages** via GitHub Actions. **No `gh-pages` branch.**
- `actions/configure-pages@v5` runs with **`enablement: true`** so the workflow can turn Pages on through the automation token — the site can go live at `https://itgalaxy.github.io/webfont` **without** a manual Settings change (contributor has no repo Settings access).

### Related issue

- #773

### Dependencies added/removed (if applicable)

- N/A (docs + CI only; no `package.json` changes).

---

### Testing

- Docs/CI-only change; no runtime tests. YAML follows the official GitHub Pages Actions template; GitHub validates the workflow on push. After merge, verify the `Deploy docs to GitHub Pages` run succeeds and the site loads.

#### How to test

1. Merge to `master` (or run the workflow via **workflow_dispatch**).
2. Confirm the `Deploy docs to GitHub Pages` workflow succeeds and open `https://itgalaxy.github.io/webfont`.

---

## Checklist

- [x] My commits follow the [Conventional Commits 1.0 Guidelines](https://www.conventionalcommits.org/en/v1.0.0/);
- [x] I have made changes to the documentation;
- [x] My changes generate no new warnings or errors.

### Follow-up / dependencies (not in this PR)

- **Custom domain `webfont.js.org`:** the CNAME file is **not** honored for workflow (Actions) deploys, so a repo **admin** must set the domain once via Pages settings or the API (`PUT /repos/itgalaxy/webfont/pages` → `{"cname":"webfont.js.org"}`).
- **js.org:** a **draft/WIP** PR to `js-org/js.org` adds `"webfont": "itgalaxy.github.io"` to `cnames_active.js`; flip to ready + merge only after the site is live with real content.
- If org policy blocks Actions from enabling Pages, a one-time admin toggle (Settings → Pages → Source: GitHub Actions) is the fallback.
- Replace the placeholder landing page with real content before requesting the js.org merge.

Made with [Cursor](https://cursor.com)