### PR TITLE
ci: add Vercel deploy workflow

### DIFF
--- a/.github/workflows/vercel-deploy.yml
+++ b/.github/workflows/vercel-deploy.yml
@@ -16,12 +16,16 @@ permissions:
 env:
   VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
   VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+  # Pin the CLI for deterministic deploys; override via repo variable when bumping.
+  VERCEL_CLI_VERSION: ${{ vars.VERCEL_CLI_VERSION || '54.20.1' }}
 
 jobs:
   deploy:
     runs-on: ubuntu-latest
     # Skip on forks: secrets are not available and the deploy would fail.
     if: github.repository == 'itgalaxy/webfont'
+    env:
+      VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
     steps:
       - uses: actions/checkout@v7
       - name: Use Node.js
@@ -30,10 +34,10 @@ jobs:
           node-version: 24.x
           cache: npm
       - name: Install Vercel CLI
-        run: npm install --global vercel@latest
+        run: npm install --global "vercel@${VERCEL_CLI_VERSION}"
       - name: Pull Vercel project settings
-        run: vercel pull --yes --environment=production --token=${{ secrets.VERCEL_TOKEN }}
+        run: vercel pull --yes --environment=production
       - name: Build with Vercel (runs npm run docs:build)
-        run: vercel build --prod --token=${{ secrets.VERCEL_TOKEN }}
+        run: vercel build --prod
       - name: Deploy prebuilt output to Vercel
-        run: vercel deploy --prebuilt --prod --token=${{ secrets.VERCEL_TOKEN }}
+        run: vercel deploy --prebuilt --prod

--- a/.github/workflows/vercel-deploy.yml
+++ b/.github/workflows/vercel-deploy.yml
@@ -1,0 +1,39 @@
+name: Deploy docs to Vercel
+
+on:
+  push:
+    branches: [master]
+  workflow_dispatch:
+
+# Never run two production deploys at once; a newer push cancels an in-flight one.
+concurrency:
+  group: vercel-production
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+env:
+  VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+  VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    # Skip on forks: secrets are not available and the deploy would fail.
+    if: github.repository == 'itgalaxy/webfont'
+    steps:
+      - uses: actions/checkout@v7
+      - name: Use Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24.x
+          cache: npm
+      - name: Install Vercel CLI
+        run: npm install --global vercel@latest
+      - name: Pull Vercel project settings
+        run: vercel pull --yes --environment=production --token=${{ secrets.VERCEL_TOKEN }}
+      - name: Build with Vercel (runs npm run docs:build)
+        run: vercel build --prod --token=${{ secrets.VERCEL_TOKEN }}
+      - name: Deploy prebuilt output to Vercel
+        run: vercel deploy --prebuilt --prod --token=${{ secrets.VERCEL_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -79,3 +79,7 @@ src/**/*.d.ts
 
 # Generated font demo for the docs site (built by `npm run docs:demo`)
 public/font-demo
+
+# Vercel CLI local state (project link + pulled env)
+.vercel
+.env*.local

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -161,6 +161,13 @@ See also [CONTRIBUTING.md](./CONTRIBUTING.md) — “User-facing changes and doc
 - **Never push to `master`.** Use a branch and open a PR (see [Pull requests](#pull-requests) below).
 - **Push without asking.** After commits on a feature or PR branch, run `git push` as part of finishing the work. Do not end responses with “want me to push?” or similar — push, then report what was pushed and the PR URL if applicable.
 
+### CI workflows
+
+When adding or editing `.github/workflows/*.yml`, follow [CONTRIBUTING.md](./CONTRIBUTING.md#ci-changes) — especially:
+
+- **Pin third-party CLI versions** on deploy/release paths; do not use `@latest`. Prefer a repository **variable** with a safe default in the workflow expression (e.g. `vars.VERCEL_CLI_VERSION || '54.20.1'`).
+- **Bind secrets once** at the job or step `env` block; reference the env var in `run` commands instead of repeating `${{ secrets.* }}` inline across steps. Match existing patterns in `npm-publish.yml` (`NODE_AUTH_TOKEN`) and `vercel-deploy.yml` (`VERCEL_TOKEN`).
+
 ### Lint and type hygiene
 
 - **No `eslint-disable*` comments.** ESLint is not used; Biome is the linter ([ADR 0001](docs/adr/0001-eslint-vs-biome-linting.md)). Delete stale ESLint suppressions; use `biome-ignore` only when a rule cannot be satisfied by a small code change.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -191,6 +191,9 @@ Pull requests that change CI configuration (for example, GitHub Actions workflow
 
 Do not use `chore:` or `chore(ci):` for CI-only changes.
 
+- **Pin tool versions.** Do not install CLIs with `@latest` (or other floating tags) on deploy or release paths — pin a semver in the workflow and optionally allow override via a repository **variable** with a safe default (for example `VERCEL_CLI_VERSION` defaulting to `54.20.1` in [`.github/workflows/vercel-deploy.yml`](.github/workflows/vercel-deploy.yml)). Bump pins in focused `ci(deps):` pull requests.
+- **Bind secrets once.** Map repository secrets to `env` at the job or step level and let the tool read them from the environment. Do not repeat `${{ secrets.* }}` inline across multiple `run` commands — it is error-prone and harder to audit. See [`npm-publish.yml`](.github/workflows/npm-publish.yml) (`NODE_AUTH_TOKEN`) and [`vercel-deploy.yml`](.github/workflows/vercel-deploy.yml) (`VERCEL_TOKEN`) for the pattern.
+
 **AppVeyor:** a legacy project may still receive GitHub webhooks. Root `appveyor.yml` disables builds via a non-matching branch filter (`appveyor-disabled`) because maintainers may lack AppVeyor dashboard access. Do not delete it until the AppVeyor project is removed upstream.
 
 ### Releases


### PR DESCRIPTION
## Summary

### Proposed changes

- Add `.github/workflows/vercel-deploy.yml` that deploys the VitePress docs to **Vercel from GitHub Actions** using the official Vercel CLI flow (`vercel pull` → `vercel build --prod` → `vercel deploy --prebuilt --prod`).
- Triggers on **push to `master`** and **manual `workflow_dispatch`**.
- `concurrency` guard cancels an in-flight production deploy when a newer push arrives.
- Skips on forks (`github.repository == 'itgalaxy/webfont'`) since secrets are unavailable there.
- Reuses the repo action versions (`actions/checkout@v7`, `actions/setup-node@v6`, Node 24.x) and the existing `vercel.json` (`framework: vitepress`, build `npm run docs:build`, output `.vitepress/dist`).

This is an **alternative to Vercel's native Git integration**. Use one or the other — if this workflow is enabled, do **not** also connect Vercel's Git auto-deploy, or every push would deploy twice.

### Required repository secrets

The deploy needs three secrets (Settings → Secrets and variables → Actions):

- `VERCEL_TOKEN` — Vercel account token (Vercel → Account Settings → Tokens).
- `VERCEL_ORG_ID` — from `.vercel/project.json` after `vercel link`.
- `VERCEL_PROJECT_ID` — from `.vercel/project.json` after `vercel link`.

To generate the IDs: run `vercel login` then `vercel link` locally once; copy `orgId`/`projectId` from the generated `.vercel/project.json` into the secrets above.

### Related issue

Advances #773 (docs site on Vercel) — provides the Actions-based deploy path.

### Dependencies added/removed (if applicable)

- N/A (the workflow installs `vercel` CLI at runtime; no `package.json` change).

---

### Testing

- [x] Manual — workflow YAML reviewed; mirrors the documented Vercel CLI CI recipe. No runtime code changed, so no unit tests apply.

#### How to test

1. Add `VERCEL_TOKEN`, `VERCEL_ORG_ID`, `VERCEL_PROJECT_ID` repository secrets.
2. Merge, then push to `master` (or run the workflow via **Run workflow**).
3. Check the Actions run and the resulting Vercel production deployment URL.

#### Test configuration

- Node.js version (if applicable): 24.x (runner)
- NPM version (if applicable): N/A

---

## Checklist

- [ ] I have added corresponding labels to this PR (like bug, enhancement...);
- [x] My commits follow the Conventional Commits 1.0 Guidelines;
- [x] My code follows the style guidelines of this project;
- [x] I have performed a self-review of my own code;
- [x] I have made changes to the documentation (if applicable);
- [x] My changes generate no new warnings or errors;

Made with [Cursor](https://cursor.com)