### PR TITLE
docs: document brew install webfont from homebrew-core

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Requires **Node.js** >= 24.14.0. Install as a dev dependency and run at **build 
 npm install --save-dev webfont
 ```
 
-On macOS or Linux you can also install the CLI with [Homebrew](https://brew.sh) (`brew tap itgalaxy/webfont https://github.com/itgalaxy/webfont` then `brew install itgalaxy/webfont/webfont`). See [install guide](./packages/webfont/install.md#homebrew-macos--linux-cli).
+On macOS or Linux you can also install the CLI with [Homebrew](https://brew.sh): `brew install webfont` ([homebrew-core](https://github.com/Homebrew/homebrew-core/pull/291610)). See [install guide](./packages/webfont/install.md#homebrew-macos--linux-cli).
 
 ```js
 import { webfont } from "webfont";
@@ -72,7 +72,7 @@ Node.js only — do not import from client-side app code ([#198](https://github.
 
 This is an **npm workspaces** monorepo. The published package lives in **`packages/webfont`** (`name: "webfont"` on npm). User-facing markdown for the docs site stays at the repo root; package-specific guides ship inside the tarball (`install.md`, `docs/configuration.md`, `docs/cli.md`, `NOTICE.md`, `LICENSE`).
 
-**Homebrew:** `HomebrewFormula/webfont.rb` and `Aliases/webfonts` at the repo root serve the monorepo tap ([#769](https://github.com/itgalaxy/webfont/issues/769)). Bump the formula on release with `node scripts/sync-homebrew-formula.mjs`.
+**Homebrew:** `brew install webfont` from [homebrew-core](https://github.com/Homebrew/homebrew-core/pull/291610). The monorepo tap (`HomebrewFormula/webfont.rb`, `Aliases/webfonts`) remains for early formula updates and the `webfonts` alias ([#769](https://github.com/itgalaxy/webfont/issues/769)). Bump both on release with `node scripts/sync-homebrew-formula.mjs`.
 
 ## Contributing
 

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -449,6 +449,67 @@ See [#558](https://github.com/itgalaxy/webfont/issues/558), [MaterialDesign#6519
 
 ---
 
+## Homebrew: formula not found or wrong source
+
+### What error appeared
+
+`brew install webfont` fails with:
+
+```text
+Warning: No available formula with the name "webfont". Did you mean webfs?
+```
+
+Or `brew info webfont` shows `Tap: itgalaxy/webfont` when you expected homebrew-core.
+
+### Why it usually happens
+
+- **Stale Homebrew index** — especially right after a new formula lands in homebrew-core. Run `brew update` before installing.
+- **Monorepo tap still tapped** — if you ran `brew tap itgalaxy/webfont`, Homebrew installs from the tap first. That still works, but it is not the same as the core formula.
+- **Tap removed but index not refreshed** — after `brew untap itgalaxy/webfont`, some setups need `brew update` before `brew install webfont` resolves homebrew-core.
+
+### Steps to try to resolve
+
+1. **Refresh and install from core:**
+
+   ```shell
+   brew update
+   brew install webfont
+   ```
+
+2. **Confirm which formula is installed:**
+
+   ```shell
+   brew info webfont
+   webfont --version
+   ```
+
+   Core shows `From: https://github.com/Homebrew/homebrew-core/...`. The tap shows `Tap: itgalaxy/webfont`.
+
+3. **Switch from tap to core:**
+
+   ```shell
+   brew uninstall webfont
+   brew untap itgalaxy/webfont
+   brew update
+   brew install webfont
+   ```
+
+4. **Smoke-test the CLI** (same as the Homebrew formula test):
+
+   ```shell
+   webfont path/to/icon.svg -d /tmp/webfont-test -f woff2 --dest-create
+   ls /tmp/webfont-test/webfont.woff2
+   ```
+
+5. **Optional tap** — for the `webfonts` alias or pre-core formula bumps, see [Install — Homebrew](./packages/webfont/install.md#homebrew-macos--linux-cli).
+
+### Related
+
+- [homebrew-core PR #291610](https://github.com/Homebrew/homebrew-core/pull/291610) — merged formula
+- [#785](https://github.com/itgalaxy/webfont/issues/785) — tracking issue
+
+---
+
 ## Can't resolve `fs` (webpack / React / Vite client bundle)
 
 ### What error appeared

--- a/packages/webfont/install.md
+++ b/packages/webfont/install.md
@@ -25,33 +25,61 @@ npm install --save-dev webfont
 
 ### Homebrew (macOS / Linux CLI)
 
-**Today** — monorepo tap (requires the URL once):
+**Recommended** — [homebrew-core](https://github.com/Homebrew/homebrew-core) (no tap):
+
+```shell
+brew install webfont
+```
+
+If Homebrew reports that no formula named `webfont` exists, refresh the index first:
+
+```shell
+brew update
+brew install webfont
+```
+
+Homebrew installs the published npm tarball and requires the `node` formula. Verify the CLI:
+
+```shell
+webfont --version
+```
+
+**Monorepo tap (optional)** — use when you want the `webfonts` alias or a formula change before it lands in core ([#769](https://github.com/itgalaxy/webfont/issues/769)):
 
 ```shell
 brew tap itgalaxy/webfont https://github.com/itgalaxy/webfont
 brew install webfont
 ```
 
-The alias `webfonts` also works inside the tap:
+The alias `webfonts` works only in the tap:
 
 ```shell
 brew install webfonts
 ```
 
-**Planned** — after [homebrew-core acceptance](https://github.com/itgalaxy/webfont/issues/785), plain install with no tap:
+**Switching from tap to core** — if you already installed from `itgalaxy/webfont` and want the core formula:
 
 ```shell
+brew uninstall webfont
+brew untap itgalaxy/webfont
+brew update
 brew install webfont
 ```
 
-Homebrew installs the published npm tarball and requires the `node` formula. For library use inside a Node project, prefer the npm dev dependency above.
+For library use inside a Node project, prefer the npm dev dependency above.
 
 ## Verify
 
-**CLI**
+**CLI (npm project)**
 
 ```shell
 npx webfont --version
+```
+
+**CLI (Homebrew)**
+
+```shell
+webfont --version
 ```
 
 **Programmatic API** — prefer the named export:

--- a/scripts/render-homebrew-core-formula.mjs
+++ b/scripts/render-homebrew-core-formula.mjs
@@ -15,10 +15,7 @@ const TAP_FORMULA = join(REPO_ROOT, "HomebrewFormula/webfont.rb");
 
 /** @param {{ url: string; sha256: string }} fields */
 export function renderHomebrewCoreFormula({ url, sha256 }) {
-  return `# typed: strict
-# frozen_string_literal: true
-
-class Webfont < Formula
+  return `class Webfont < Formula
   desc "Generator of fonts from SVG icons, with TTF encoding and WOFF/WOFF2 decoding"
   homepage "https://webfont.js.org/"
   url "${url}"


### PR DESCRIPTION
## Summary

### Proposed changes

- Make `brew install webfont` (homebrew-core) the primary Homebrew install path in `packages/webfont/install.md` and `README.md`.
- Document optional monorepo tap, `webfonts` alias, and switching from tap to core.
- Add **Homebrew: formula not found or wrong source** to `TROUBLESHOOTING.md` (stale index, tap vs core).
- Align `scripts/render-homebrew-core-formula.mjs` with homebrew-core style (no `typed: strict` header).

### Related issue

https://github.com/itgalaxy/webfont/issues/785

### Dependencies added/removed (if applicable)

N/A

---

### Testing

- [x] I have added or updated tests that prove my fix is effective or that my feature works (if applicable)
  - [x] Manual test

#### How to test

1. On macOS/Linux with Homebrew: `brew update && brew install webfont` (or reinstall after untapping `itgalaxy/webfont`).
2. Run `webfont --version` and convert one SVG to WOFF2 with `--dest-create`.
3. Review `install.md` and `TROUBLESHOOTING.md` on the docs site preview.

#### Test configuration

N/A

---

## Checklist

- [x] I have added corresponding labels to this PR (like bug, enhancement...);
- [x] My commits follow the [Conventional Commits 1.0 Guidelines](https://www.conventionalcommits.org/en/v1.0.0/);
- [x] My code follows the style guidelines of this project;
- [x] I have performed a self-review of my own code;
- [x] I have mapped technical debts found on my changes;
- [x] I have made changes to the documentation (if applicable);
- [x] My changes generate no new warnings or errors;

Made with [Cursor](https://cursor.com)