### PR TITLE
ci: publish GitHub Packages by workspace path after rename

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -153,7 +153,9 @@ jobs:
       # for a PAT secret with `write:packages` if you prefer a personal token.
       - name: Write ~/.npmrc for GitHub Packages
         run: printf '%s\n' '@itgalaxy:registry=https://npm.pkg.github.com/' '//npm.pkg.github.com/:_authToken=${NODE_AUTH_TOKEN}' > "$HOME/.npmrc"
-      - run: npm publish --ignore-scripts -w webfont
+      # Publish by workspace path: `npm pkg set name=…` above renames the package to
+      # `@itgalaxy/webfont`, so `-w webfont` no longer resolves.
+      - run: npm publish --ignore-scripts -w packages/webfont
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
## Summary

### Proposed changes

This PR brings the following changes:

- Fix `publish-github-packages` in `npm-publish.yml`: use `-w packages/webfont` instead of `-w webfont` after the checkout-only rename to `@itgalaxy/webfont`.

### Related issue

N/A — regression from monorepo publish workflow (v12.5.0 GitHub Packages job failed; npmjs job succeeded).

### Dependencies added/removed (if applicable)

N/A

---

### Testing

- [ ] I have added or updated tests that prove my fix is effective or that my feature works (if applicable)

No runtime tests; CI-only workflow fix. Reproduced locally: after `npm pkg set name=@itgalaxy/webfont -w webfont`, `npm publish -w webfont` fails with “No workspaces found”; `-w packages/webfont` succeeds.

#### How to test

1. Merge and re-run **Actions → npm publish** with tag `v12.5.0` (note: `publish-npm` may fail because 12.5.0 is already on npmjs — only `publish-github-packages` was missing).

#### Test configuration

N/A

---

## Checklist

- [ ] I have added corresponding labels to this PR (like bug, enhancement...);
- [x] My commits follow the [Conventional Commits 1.0 Guidelines](https://www.conventionalcommits.org/en/v1.0.0/);
- [x] My code follows the style guidelines of this project;
- [x] I have performed a self-review of my own code;
- [ ] I have mapped technical debts found on my changes;
- [ ] I have made changes to the documentation (if applicable);
- [x] My changes generate no new warnings or errors;

Made with [Cursor](https://cursor.com)