### PR TITLE
chore(deps): bump grunt and enforce npm audit in CI

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -46,7 +46,7 @@ jobs:
           node-version: 26.x
           cache: npm
       - run: npm ci
-      - run: npm audit --audit-level=info
+      - run: npm run audit
       - run: npm test
       - name: Validate published package surface (publint + attw + pack-smoke)
         run: npm run test:package

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -46,6 +46,7 @@ jobs:
           node-version: 26.x
           cache: npm
       - run: npm ci
+      - run: npm audit --audit-level=moderate
       - run: npm test
       - name: Validate published package surface (publint + attw + pack-smoke)
         run: npm run test:package

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -46,7 +46,7 @@ jobs:
           node-version: 26.x
           cache: npm
       - run: npm ci
-      - run: npm audit --audit-level=moderate
+      - run: npm audit --audit-level=info
       - run: npm test
       - name: Validate published package surface (publint + attw + pack-smoke)
         run: npm run test:package

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -21,7 +21,7 @@ jobs:
         node-version: ${{ matrix.node-version }}
         cache: npm
     - run: npm ci
-    - run: npm audit --audit-level=info
+    - run: npm run audit
     - run: npm run lint:suppressions
     - run: npm run typecheck
     - run: npm run depcheck

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -21,7 +21,7 @@ jobs:
         node-version: ${{ matrix.node-version }}
         cache: npm
     - run: npm ci
-    - run: npm audit --audit-level=moderate
+    - run: npm audit --audit-level=info
     - run: npm run lint:suppressions
     - run: npm run typecheck
     - run: npm run depcheck

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -21,6 +21,7 @@ jobs:
         node-version: ${{ matrix.node-version }}
         cache: npm
     - run: npm ci
+    - run: npm audit --audit-level=moderate
     - run: npm run lint:suppressions
     - run: npm run typecheck
     - run: npm run depcheck

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -14,7 +14,7 @@ pre-push:
         jobs:
           - run: npm run typecheck
           - run: npm run depcheck
-          - run: npm audit --audit-level=moderate
+          - run: npm audit --audit-level=info
     - group:
         piped: true
         jobs:

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -14,6 +14,7 @@ pre-push:
         jobs:
           - run: npm run typecheck
           - run: npm run depcheck
+          - run: npm audit --audit-level=moderate
     - group:
         piped: true
         jobs:

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -14,7 +14,7 @@ pre-push:
         jobs:
           - run: npm run typecheck
           - run: npm run depcheck
-          - run: npm audit --audit-level=info
+          - run: npm run audit
     - group:
         piped: true
         jobs:

--- a/package-lock.json
+++ b/package-lock.json
@@ -3524,9 +3524,9 @@
       "license": "ISC"
     },
     "node_modules/grunt": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/grunt/-/grunt-1.6.1.tgz",
-      "integrity": "sha512-/ABUy3gYWu5iBmrUSRBP97JLpQUm0GgVveDCp6t3yRNIoltIYw7rEj3g5y1o2PGPR2vfTRGa7WC/LZHLTXnEzA==",
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/grunt/-/grunt-1.6.2.tgz",
+      "integrity": "sha512-bUzh5nA/P5L66ihXTDP6J5BGnMB/8lXJXejYWSbH4Y4TvWM9t2S39sggQDYYQlx06cYcCsmu63HMYHGCIzUVfg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3535,14 +3535,14 @@
         "exit": "~0.1.2",
         "findup-sync": "~5.0.0",
         "glob": "~7.1.6",
-        "grunt-cli": "~1.4.3",
+        "grunt-cli": "^1.4.3",
         "grunt-known-options": "~2.0.0",
         "grunt-legacy-log": "~3.0.0",
         "grunt-legacy-util": "~2.0.1",
         "iconv-lite": "~0.6.3",
         "js-yaml": "~3.14.0",
-        "minimatch": "~3.0.4",
-        "nopt": "~3.0.6"
+        "minimatch": "^3.1.5",
+        "nopt": "^5.0.0"
       },
       "bin": {
         "grunt": "bin/grunt"
@@ -3569,22 +3569,6 @@
       },
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/grunt-cli/node_modules/nopt": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/nopt/-/nopt-5.0.0.tgz",
-      "integrity": "sha512-Tbj67rffqceeLpcRXrT7vKAN8CwfPeIBgM7E6iBkmKLV7bEMwpGgYLGv0jACUsECaa/vuxP0IjEont6umdMgtQ==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "abbrev": "1"
-      },
-      "bin": {
-        "nopt": "bin/nopt.js"
-      },
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/grunt-known-options": {
@@ -3667,44 +3651,10 @@
         "concat-map": "0.0.1"
       }
     },
-    "node_modules/grunt/node_modules/grunt-cli": {
-      "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/grunt-cli/-/grunt-cli-1.4.3.tgz",
-      "integrity": "sha512-9Dtx/AhVeB4LYzsViCjUQkd0Kw0McN2gYpdmGYKtE2a5Yt7v1Q+HYZVWhqXc/kGnxlMtqKDxSwotiGeFmkrCoQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "grunt-known-options": "~2.0.0",
-        "interpret": "~1.1.0",
-        "liftup": "~3.0.1",
-        "nopt": "~4.0.1",
-        "v8flags": "~3.2.0"
-      },
-      "bin": {
-        "grunt": "bin/grunt"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/grunt/node_modules/grunt-cli/node_modules/nopt": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.3.tgz",
-      "integrity": "sha512-CvaGwVMztSMJLOeXPrez7fyfObdZqNUK1cPAEzLHrTybIua9pMdmmPR5YwtfNftIOMv3DPUhFaxsZMNTQO20Kg==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "abbrev": "1",
-        "osenv": "^0.1.4"
-      },
-      "bin": {
-        "nopt": "bin/nopt.js"
-      }
-    },
     "node_modules/grunt/node_modules/minimatch": {
-      "version": "3.0.8",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.8.tgz",
-      "integrity": "sha512-6FsRAQsxQ61mw+qP1ZzbL9Bc78x2p5OqNgNpnoAFLTrX8n5Kxph0CsnhmKKNXTWjXqU5L0pGPR7hYk+XWZr60Q==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -3712,19 +3662,6 @@
       },
       "engines": {
         "node": "*"
-      }
-    },
-    "node_modules/grunt/node_modules/v8flags": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/v8flags/-/v8flags-3.2.0.tgz",
-      "integrity": "sha512-mH8etigqMfiGWdeXpaaqGfs6BndypxusHHcv2qSHyZkGEznCd/qAXCWWRzeowtL54147cktFOC4P5y+kl8d8Jg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "homedir-polyfill": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 0.10"
       }
     },
     "node_modules/has-flag": {
@@ -4186,9 +4123,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "3.14.2",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
-      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
+      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5190,9 +5127,9 @@
       }
     },
     "node_modules/nopt": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
-      "integrity": "sha512-4GUt3kSEYmk4ITxzB/b9vaIDfUVWN/Ml1Fwl11IlnIG2iaJ9O6WXZ9SrYM9NLI8OCBieN2Y8SWC2oJV0RQ7qYg==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-5.0.0.tgz",
+      "integrity": "sha512-Tbj67rffqceeLpcRXrT7vKAN8CwfPeIBgM7E6iBkmKLV7bEMwpGgYLGv0jACUsECaa/vuxP0IjEont6umdMgtQ==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -5200,6 +5137,9 @@
       },
       "bin": {
         "nopt": "bin/nopt.js"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/nth-check": {
@@ -5341,38 +5281,6 @@
         "oniguruma-parser": "^0.12.2",
         "regex": "^6.1.0",
         "regex-recursion": "^6.0.2"
-      }
-    },
-    "node_modules/os-homedir": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-      "integrity": "sha512-B5JU3cabzk8c67mRRd3ECmROafjYMXbuzlwtqdM8IbS8ktlTix8aFGb2bAGKrSRIlnfKwovGUUr72JUPyOb6kQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/os-tmpdir": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-      "integrity": "sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/osenv": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
-      "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
-      "deprecated": "This package is no longer supported.",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "os-homedir": "^1.0.0",
-        "os-tmpdir": "^1.0.0"
       }
     },
     "node_modules/oxc-parser": {
@@ -7499,13 +7407,13 @@
     },
     "packages/grunt-webfont-recipe": {
       "devDependencies": {
-        "grunt": "1.6.1",
+        "grunt": "1.6.2",
         "grunt-cli": "1.5.0",
         "webfont": "file:../webfont"
       }
     },
     "packages/webfont": {
-      "version": "12.4.1",
+      "version": "12.5.0",
       "license": "MIT",
       "dependencies": {
         "cosmiconfig": "9.0.2",
@@ -9701,7 +9609,7 @@
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
         "inherits": "2",
-        "minimatch": "^3.0.4",
+        "minimatch": "3.1.5",
         "once": "^1.3.0",
         "path-is-absolute": "^1.0.0"
       },
@@ -9783,9 +9691,9 @@
       "dev": true
     },
     "grunt": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/grunt/-/grunt-1.6.1.tgz",
-      "integrity": "sha512-/ABUy3gYWu5iBmrUSRBP97JLpQUm0GgVveDCp6t3yRNIoltIYw7rEj3g5y1o2PGPR2vfTRGa7WC/LZHLTXnEzA==",
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/grunt/-/grunt-1.6.2.tgz",
+      "integrity": "sha512-bUzh5nA/P5L66ihXTDP6J5BGnMB/8lXJXejYWSbH4Y4TvWM9t2S39sggQDYYQlx06cYcCsmu63HMYHGCIzUVfg==",
       "dev": true,
       "requires": {
         "dateformat": "~4.6.2",
@@ -9793,14 +9701,14 @@
         "exit": "~0.1.2",
         "findup-sync": "~5.0.0",
         "glob": "~7.1.6",
-        "grunt-cli": "~1.4.3",
+        "grunt-cli": "^1.4.3",
         "grunt-known-options": "~2.0.0",
         "grunt-legacy-log": "~3.0.0",
         "grunt-legacy-util": "~2.0.1",
         "iconv-lite": "~0.6.3",
-        "js-yaml": "~3.14.0",
-        "minimatch": "~3.0.4",
-        "nopt": "~3.0.6"
+        "js-yaml": "3.15.0",
+        "minimatch": "3.1.5",
+        "nopt": "^5.0.0"
       },
       "dependencies": {
         "balanced-match": {
@@ -9819,47 +9727,13 @@
             "concat-map": "0.0.1"
           }
         },
-        "grunt-cli": {
-          "version": "1.4.3",
-          "resolved": "https://registry.npmjs.org/grunt-cli/-/grunt-cli-1.4.3.tgz",
-          "integrity": "sha512-9Dtx/AhVeB4LYzsViCjUQkd0Kw0McN2gYpdmGYKtE2a5Yt7v1Q+HYZVWhqXc/kGnxlMtqKDxSwotiGeFmkrCoQ==",
-          "dev": true,
-          "requires": {
-            "grunt-known-options": "~2.0.0",
-            "interpret": "~1.1.0",
-            "liftup": "~3.0.1",
-            "nopt": "~4.0.1",
-            "v8flags": "~3.2.0"
-          },
-          "dependencies": {
-            "nopt": {
-              "version": "4.0.3",
-              "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.3.tgz",
-              "integrity": "sha512-CvaGwVMztSMJLOeXPrez7fyfObdZqNUK1cPAEzLHrTybIua9pMdmmPR5YwtfNftIOMv3DPUhFaxsZMNTQO20Kg==",
-              "dev": true,
-              "requires": {
-                "abbrev": "1",
-                "osenv": "^0.1.4"
-              }
-            }
-          }
-        },
         "minimatch": {
-          "version": "3.0.8",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.8.tgz",
-          "integrity": "sha512-6FsRAQsxQ61mw+qP1ZzbL9Bc78x2p5OqNgNpnoAFLTrX8n5Kxph0CsnhmKKNXTWjXqU5L0pGPR7hYk+XWZr60Q==",
+          "version": "3.1.5",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+          "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
           "dev": true,
           "requires": {
             "brace-expansion": "^1.1.7"
-          }
-        },
-        "v8flags": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/v8flags/-/v8flags-3.2.0.tgz",
-          "integrity": "sha512-mH8etigqMfiGWdeXpaaqGfs6BndypxusHHcv2qSHyZkGEznCd/qAXCWWRzeowtL54147cktFOC4P5y+kl8d8Jg==",
-          "dev": true,
-          "requires": {
-            "homedir-polyfill": "^1.0.1"
           }
         }
       }
@@ -9875,17 +9749,6 @@
         "liftup": "~3.0.1",
         "nopt": "~5.0.0",
         "v8flags": "^4.0.1"
-      },
-      "dependencies": {
-        "nopt": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/nopt/-/nopt-5.0.0.tgz",
-          "integrity": "sha512-Tbj67rffqceeLpcRXrT7vKAN8CwfPeIBgM7E6iBkmKLV7bEMwpGgYLGv0jACUsECaa/vuxP0IjEont6umdMgtQ==",
-          "dev": true,
-          "requires": {
-            "abbrev": "1"
-          }
-        }
       }
     },
     "grunt-known-options": {
@@ -9933,7 +9796,7 @@
     "grunt-webfont-recipe": {
       "version": "file:packages/grunt-webfont-recipe",
       "requires": {
-        "grunt": "1.6.1",
+        "grunt": "1.6.2",
         "grunt-cli": "1.5.0",
         "webfont": "file:../webfont"
       }
@@ -10251,9 +10114,9 @@
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
     },
     "js-yaml": {
-      "version": "3.14.2",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
-      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
+      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
       "dev": true,
       "requires": {
         "argparse": "^1.0.7",
@@ -10809,9 +10672,9 @@
       }
     },
     "nopt": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
-      "integrity": "sha512-4GUt3kSEYmk4ITxzB/b9vaIDfUVWN/Ml1Fwl11IlnIG2iaJ9O6WXZ9SrYM9NLI8OCBieN2Y8SWC2oJV0RQ7qYg==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-5.0.0.tgz",
+      "integrity": "sha512-Tbj67rffqceeLpcRXrT7vKAN8CwfPeIBgM7E6iBkmKLV7bEMwpGgYLGv0jACUsECaa/vuxP0IjEont6umdMgtQ==",
       "dev": true,
       "requires": {
         "abbrev": "1"
@@ -10909,28 +10772,6 @@
         "oniguruma-parser": "^0.12.2",
         "regex": "^6.1.0",
         "regex-recursion": "^6.0.2"
-      }
-    },
-    "os-homedir": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-      "integrity": "sha512-B5JU3cabzk8c67mRRd3ECmROafjYMXbuzlwtqdM8IbS8ktlTix8aFGb2bAGKrSRIlnfKwovGUUr72JUPyOb6kQ==",
-      "dev": true
-    },
-    "os-tmpdir": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-      "integrity": "sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==",
-      "dev": true
-    },
-    "osenv": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
-      "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
-      "dev": true,
-      "requires": {
-        "os-homedir": "^1.0.0",
-        "os-tmpdir": "^1.0.0"
       }
     },
     "oxc-parser": {

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "sync:homebrew": "node scripts/sync-homebrew-formula.mjs",
     "test": "npm run test:scripts && npm run test -w webfont",
     "test:scripts": "vitest run --config vitest.scripts.config.ts",
+    "audit": "npm audit --audit-level=moderate",
     "test:package": "npm run test:package -w webfont",
     "testc": "npm run testc -w webfont",
     "test-debug": "npm run test-debug -w webfont",
@@ -39,6 +40,10 @@
   },
   "overrides": {
     "minimatch": "10.2.5",
+    "grunt": {
+      "js-yaml": "3.15.0",
+      "minimatch": "3.1.5"
+    },
     "test-exclude": "7.0.2",
     "woff2sfnt-sfnt2woff": "1.0.0"
   },

--- a/package.json
+++ b/package.json
@@ -55,5 +55,9 @@
   "license": "MIT",
   "engines": {
     "node": ">=24.14.0"
+  },
+  "allowScripts": {
+    "lefthook@2.1.9": true,
+    "fsevents@2.3.3": true
   }
 }

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "sync:homebrew": "node scripts/sync-homebrew-formula.mjs",
     "test": "npm run test:scripts && npm run test -w webfont",
     "test:scripts": "vitest run --config vitest.scripts.config.ts",
-    "audit": "npm audit --audit-level=moderate",
+    "audit": "npm audit --audit-level=info",
     "test:package": "npm run test:package -w webfont",
     "testc": "npm run testc -w webfont",
     "test-debug": "npm run test-debug -w webfont",

--- a/packages/grunt-webfont-recipe/package.json
+++ b/packages/grunt-webfont-recipe/package.json
@@ -7,7 +7,7 @@
     "test": "grunt webfont"
   },
   "devDependencies": {
-    "grunt": "1.6.1",
+    "grunt": "1.6.2",
     "grunt-cli": "1.5.0",
     "webfont": "file:../webfont"
   }

--- a/scripts/grunt-recipe-smoke.vitest.ts
+++ b/scripts/grunt-recipe-smoke.vitest.ts
@@ -1,5 +1,5 @@
 import { execFile } from "node:child_process";
-import { access, rm } from "node:fs/promises";
+import { access, readFile, rm } from "node:fs/promises";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { promisify } from "node:util";
@@ -32,5 +32,13 @@ describe("grunt-webfont recipe smoke", () => {
 
     await expect(access(WOFF2_OUTPUT)).resolves.toBeUndefined();
     await expect(access(CSS_OUTPUT)).resolves.toBeUndefined();
+
+    const woff2 = await readFile(WOFF2_OUTPUT);
+    expect(woff2.subarray(0, 4).toString("ascii")).toBe("wOF2");
+    expect(woff2.length).toBeGreaterThan(100);
+
+    const css = await readFile(CSS_OUTPUT, "utf8");
+    expect(css).toMatch(/@font-face/u);
+    expect(css).toMatch(/icons\.woff2/u);
   }, 120_000);
 });


### PR DESCRIPTION
## Summary

### Proposed changes

This PR brings the following changes:

- Upgrade `grunt` to **1.6.2** in `packages/grunt-webfont-recipe` with root `overrides` for `grunt` → `js-yaml@3.15.0` and `minimatch@3.1.5` (fixes 3 audit findings: js-yaml DoS, minimatch ReDoS).
- Strengthen Grunt recipe smoke test: assert WOFF2 magic bytes (`wOF2`), minimum size, and CSS `@font-face` / `icons.woff2` output.
- Add root script **`npm run audit`** (`npm audit --audit-level=info` — strictest npm threshold) and wire it into PR CI, release `npm-publish` build job, and lefthook pre-push.
- Approve lifecycle scripts via `allowScripts` for `lefthook@2.1.9` and `fsevents@2.3.3` (silences npm 11+ install-script review warnings).

### Related issue

N/A — security hygiene for Grunt recipe workspace deps.

### Dependencies added/removed (if applicable)

- Update: `grunt` 1.6.1 → 1.6.2 (`packages/grunt-webfont-recipe`)
- Override: `grunt` → `js-yaml@3.15.0`, `minimatch@3.1.5`

---

### Testing

- [x] I have added or updated tests that prove my fix is effective or that my feature works (if applicable)
  - [x] Unit test

#### How to test

1. `npm ci && npm run audit` → `found 0 vulnerabilities`
2. `npm run test:scripts` → Grunt recipe smoke passes with strengthened assertions
3. `npm test`

#### Test configuration

N/A

---

## Checklist

- [x] I have added corresponding labels to this PR (like bug, enhancement...);
- [x] My commits follow the [Conventional Commits 1.0 Guidelines](https://www.conventionalcommits.org/en/v1.0.0/);
- [x] My code follows the style guidelines of this project;
- [x] I have performed a self-review of my own code;
- [x] I have mapped technical debts found on my changes;
- [ ] I have made changes to the documentation (if applicable);
- [x] My changes generate no new warnings or errors;