### PR TITLE
chore(deps): allow lefthook@2.1.10 install scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "node": ">=24.14.0"
   },
   "allowScripts": {
-    "lefthook@2.1.9": true,
-    "fsevents@2.3.3": true
+    "fsevents@2.3.3": true,
+    "lefthook@2.1.10": true
   }
 }


### PR DESCRIPTION
## Summary

### Proposed changes

- Update root \`allowScripts\` from \`lefthook@2.1.9\` to \`lefthook@2.1.10\` after #805 so npm stop warning about uncovered install scripts.

### Related issue

Follow-up to #805.

### Testing

- [x] Manual test — package.json allowScripts key matches installed lefthook version

#### How to test

1. \`npm ci\` — no \`allow-scripts\` pending warning for lefthook

---

## Checklist

- [x] I have added corresponding labels to this PR (like bug, enhancement...);
- [x] My commits follow the [Conventional Commits 1.0 Guidelines](https://www.conventionalcommits.org/en/v1.0.0/);
- [x] My code follows the style guidelines of this project;
- [x] I have performed a self-review of my own code;
- [x] I have mapped technical debts found on my changes;
- [x] I have made changes to the documentation (if applicable);
- [x] My changes generate no new warnings or errors;

Made with [Cursor](https://cursor.com)