### PR TITLE
chore: tighten Knip configuration (#822)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -217,7 +217,7 @@ See also [CONTRIBUTING.md](./CONTRIBUTING.md) — “User-facing changes and doc
 ## General
 
 - Follow [CONTRIBUTING.md](./CONTRIBUTING.md) and existing ADRs under `docs/adr/`.
-- Run `npm run depcheck` (Knip) when changing imports or `package.json` dependencies; see [ADR 0008](docs/adr/0008-knip-instead-of-depcheck.md). The **pre-push** Lefthook runs `depcheck` before `npm test`.
+- Run `npm run depcheck` (Knip) when changing imports or `package.json` dependencies; see [ADR 0008](docs/adr/0008-knip-instead-of-depcheck.md). Keep the gate strict: fix `entry` / `project` and remove dead `export`s — do not exclude `exports`/`types` or grow `ignoreIssues` ([#822](https://github.com/itgalaxy/webfont/issues/822)). The **pre-push** Lefthook runs `depcheck` before `npm test`.
 - Use conventional commits (`feat`, `fix`, `test`, `docs`, `chore`, `refactor`, `ci`, `build`). Prefer **`chore(deps):`** when the PR changes `package.json` / lockfile dependencies (and **`ci(deps):`** for GitHub Actions bumps) — even if the diff is mostly tests or docs (see [Pull requests](#pull-requests)). This matches the prefixes Dependabot generates via [`.github/dependabot.yml`](./.github/dependabot.yml).
 - Releases are handled by Release Please on `master`; do not bump `package.json` version in feature PRs (see [ADR 0004](docs/adr/0004-release-please-instead-of-standard-version.md)). Release git tags use **`v{semver}`** (`v12.0.0`); `release-please-config.json` sets `include-component-in-tag: false` — do not use `webfont-v*` tags.
 - Keep changes focused; match surrounding code style and tooling (Biome, Vitest, Lefthook).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -179,7 +179,7 @@ See [ADR 0003](docs/adr/0003-lefthook-instead-of-husky-lint-staged.md) for ratio
 - When upgrading a dependency, pin its `@types/<package>` counterpart in the same pull request when one exists.
 - Update both `package.json` and `package-lock.json` in the same pull request.
 - [Dependabot](.github/dependabot.yml) opens upgrade PRs for pinned dependencies; do not use open ranges to get updates.
-- Run `npm run depcheck` before pushing when you add, remove, or move imports — it runs [Knip](https://knip.dev/) to find unused dependencies, unlisted imports, and dead exports (see [ADR 0008](docs/adr/0008-knip-instead-of-depcheck.md)). CI runs the same check on every pull request.
+- Run `npm run depcheck` before pushing when you add, remove, or move imports — it runs [Knip](https://knip.dev/) for unused dependencies, unlisted imports, orphan files, and unused exports (see [ADR 0008](docs/adr/0008-knip-instead-of-depcheck.md), amended in [#822](https://github.com/itgalaxy/webfont/issues/822)). Prefer fixing entries / removing dead exports over `ignoreIssues`. CI runs the same check on every pull request.
 
 ### CI changes
 

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -642,6 +642,6 @@ Per [#822](https://github.com/itgalaxy/webfont/issues/822) / [ADR 0008](docs/adr
 
 1. Prefer **removing the `export`** (or the dead re-export) when the symbol is not part of the public API.
 2. If it is public API, ensure the file is listed under `entry` in `packages/webfont/knip.json` (for example `src/index.ts`, `src/cli/index.ts`).
-3. Use `ignoreDependencies` only for dynamic tooling packages Knip cannot see (for example `@typescript/typescript6`); document why.
+3. Use `ignoreDependencies` only for dynamic tooling packages Knip cannot see; document why in TROUBLESHOOTING (do not reintroduce `@typescript/typescript6` — see [ADR 0016](docs/adr/0016-tsc-declarations-typescript7.md)).
 4. Re-run `npm run depcheck` and confirm pre-push Lefthook still passes.
 

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -622,18 +622,26 @@ TypeScript 7 removed the JavaScript Compiler API that `unplugin-dts` needed. The
 3. Re-run `npm run build -w webfont` and check `dist/src/index.d.ts` / `dist/src/index.d.mts`.
 4. Run `npm run test:package` (publint + attw + pack-smoke).
 
-## Knip reports unused exported types after a Knip upgrade
+## Knip reports unused exports or types
 
 ### What error appeared
 
-`npm run depcheck` (Knip) fails with `Unused exported types` for public API barrels such as `src/index.ts`, `src/cli/program.ts`, or `src/cli/meow/cliFlagCatalog.ts`, even though those types are intentional package exports.
+`npm run depcheck` (Knip) fails with `Unused exports` / `Unused exported types` (or a Knip upgrade starts failing on export-surface findings).
 
 ### Why it usually happens
 
-From Knip 6.29 onward, unused **type** exports are reported under the `types` issue class separately from value `exports`. Older `ignoreIssues` entries that only listed `"exports"` no longer cover those type-only exports.
+Usually one of:
+
+1. A symbol is `export`ed but only used inside the same module (should be module-private).
+2. A barrel re-exports something nothing imports.
+3. A public entry file is missing from `packages/webfont/knip.json` `entry` (Knip then treats intentional public exports as unused).
+
+Per [#822](https://github.com/itgalaxy/webfont/issues/822) / [ADR 0008](docs/adr/0008-knip-instead-of-depcheck.md), we **keep** export/type checks. Do not exclude those issue classes or paper over them with a large `ignoreIssues` map.
 
 ### Steps to try to resolve
 
-1. For intentional public / barrel type exports, add `"types"` alongside `"exports"` (or alone) in `packages/webfont/knip.json` `ignoreIssues` for the affected files.
-2. Re-run `npm run depcheck` and confirm pre-push Lefthook still passes.
+1. Prefer **removing the `export`** (or the dead re-export) when the symbol is not part of the public API.
+2. If it is public API, ensure the file is listed under `entry` in `packages/webfont/knip.json` (for example `src/index.ts`, `src/cli/index.ts`).
+3. Use `ignoreDependencies` only for dynamic tooling packages Knip cannot see (for example `@typescript/typescript6`); document why.
+4. Re-run `npm run depcheck` and confirm pre-push Lefthook still passes.
 

--- a/docs/adr/0008-knip-instead-of-depcheck.md
+++ b/docs/adr/0008-knip-instead-of-depcheck.md
@@ -93,15 +93,15 @@ Tighten instead:
 
 1. List real public and tooling entry files in `packages/webfont/knip.json` (`src/index.ts`, `src/standalone/index.ts`, `scripts/**`, fixtures, CLI, templates, browser).
 2. Expand `project` to include `scripts/**` so orphan script files are detectable.
-3. Remove the `ignoreIssues` map; keep only `ignoreDependencies` for known dynamic tooling (`@typescript/typescript6`).
-4. Delete unused `export` / re-export surface in source (private helpers stay module-local; dead barrels trimmed).
-5. Do **not** enable `includeEntryExports` — this is a published library; entry exports are the public API.
+3. Remove the `ignoreIssues` map (public barrels are covered by complete `entry` globs; dead re-exports removed in source).
+4. Do **not** enable `includeEntryExports` — this is a published library; entry exports are the public API.
+5. Document the change here and in CONTRIBUTING / AGENTS / TROUBLESHOOTING.
 
 ### Policy for future changes
 
 1. When Knip reports unused exports: **un-export** or **wire** them (entry / real import). Do not add `ignoreIssues` for public barrels.
 2. When Knip misses a file: add an **entry** or **project** glob.
-3. Use `ignoreDependencies` only for packages required dynamically by tools Knip cannot see; document why in TROUBLESHOOTING.
+3. Use `ignoreDependencies` only for packages required dynamically by tools Knip cannot see; document why in TROUBLESHOOTING. (The former `@typescript/typescript6` exception was removed with [ADR 0016](./0016-tsc-declarations-typescript7.md) / [#824](https://github.com/itgalaxy/webfont/issues/824).)
 4. Reject PRs that exclude `exports` / `types` from the default Knip gate without a superseding ADR.
 
 ## References
@@ -110,3 +110,4 @@ Tighten instead:
 - [depcheck](https://github.com/depcheck/depcheck) — prior art, narrower scope
 - [ADR 0003: Lefthook instead of Husky / lint-staged](./0003-lefthook-instead-of-husky-lint-staged.md)
 - [#822](https://github.com/itgalaxy/webfont/issues/822) — investigate keep / narrow / replace / remove
+- [ADR 0016](./0016-tsc-declarations-typescript7.md) — TypeScript 7 `tsc` declarations; no `@typescript/typescript6`

--- a/docs/adr/0008-knip-instead-of-depcheck.md
+++ b/docs/adr/0008-knip-instead-of-depcheck.md
@@ -1,6 +1,6 @@
 # ADR 0008: Adopt Knip instead of depcheck for dependency and dead-code analysis
 
-- **Status:** Accepted
+- **Status:** Accepted (amended 2026-07-26 — [#822](https://github.com/itgalaxy/webfont/issues/822))
 - **Date:** 2026-07-02
 - **Related:** [ADR 0003](./0003-lefthook-instead-of-husky-lint-staged.md) (removed `lint-staged.config.js` leftover)
 
@@ -75,11 +75,38 @@ The project is a small Node library + CLI with Vitest tests, Vite builds, cosmic
 
 ### Follow-up
 
-- Revisit `ignoreIssues` when CLI modules stop re-exporting test-only symbols.
-- Consider `knip --production` in a separate job if we want stricter publish-surface analysis.
+- Prefer fixing **entry** globs and removing dead `export`s over adding `ignoreIssues`.
+- Consider `knip --production` in a separate job only after entry mapping makes it truthful (today it false-positives most runtime dependencies).
+- Optionally extend Knip to `webfont-mcp` / root workspaces when that package stabilizes.
+
+## Amendment (2026-07-26) — keep Knip and **tighten** configuration ([#822](https://github.com/itgalaxy/webfont/issues/822))
+
+### Context
+
+A large `ignoreIssues` map was papering over incomplete `entry` coverage and dead re-exports. Narrowing Knip by excluding `exports` / `types` would weaken the gate; that approach was rejected.
+
+### Decision
+
+**Keep Knip.** Do **not** drop it, replace it with classic depcheck-only, or exclude export/type issue classes from CI.
+
+Tighten instead:
+
+1. List real public and tooling entry files in `packages/webfont/knip.json` (`src/index.ts`, `src/standalone/index.ts`, `scripts/**`, fixtures, CLI, templates, browser).
+2. Expand `project` to include `scripts/**` so orphan script files are detectable.
+3. Remove the `ignoreIssues` map; keep only `ignoreDependencies` for known dynamic tooling (`@typescript/typescript6`).
+4. Delete unused `export` / re-export surface in source (private helpers stay module-local; dead barrels trimmed).
+5. Do **not** enable `includeEntryExports` — this is a published library; entry exports are the public API.
+
+### Policy for future changes
+
+1. When Knip reports unused exports: **un-export** or **wire** them (entry / real import). Do not add `ignoreIssues` for public barrels.
+2. When Knip misses a file: add an **entry** or **project** glob.
+3. Use `ignoreDependencies` only for packages required dynamically by tools Knip cannot see; document why in TROUBLESHOOTING.
+4. Reject PRs that exclude `exports` / `types` from the default Knip gate without a superseding ADR.
 
 ## References
 
 - [Knip documentation](https://knip.dev/)
 - [depcheck](https://github.com/depcheck/depcheck) — prior art, narrower scope
 - [ADR 0003: Lefthook instead of Husky / lint-staged](./0003-lefthook-instead-of-husky-lint-staged.md)
+- [#822](https://github.com/itgalaxy/webfont/issues/822) — investigate keep / narrow / replace / remove

--- a/packages/webfont/knip.json
+++ b/packages/webfont/knip.json
@@ -1,32 +1,22 @@
 {
   "$schema": "https://unpkg.com/knip@6/schema.json",
   "entry": [
+    "src/index.ts",
     "src/browser.ts",
     "src/cli/index.ts",
+    "src/standalone/index.ts",
     "src/types/index.ts",
     "templates/index.ts",
+    "scripts/**/*.{js,mjs,ts}",
     "src/fixtures/config-discovery/js-config/webfont.config.js",
     "src/fixtures/configs/webfont.config-cli.js",
     "src/fixtures/config-discovery/js-rc/.webfontrc.js",
     "src/fixtures/config-package/index.js"
   ],
-  "project": ["src/**/*.{ts,js}", "templates/**/*.{ts,js}"],
+  "project": ["src/**/*.{ts,js}", "templates/**/*.{ts,js}", "scripts/**/*.{js,mjs,ts}"],
   "exclude": ["duplicates"],
   "ignoreExportsUsedInFile": {
     "interface": true,
     "type": true
-  },
-  "ignoreIssues": {
-    "src/cli/meow/index.ts": ["exports", "types"],
-    "src/cli/meow/cliFlagCatalog.ts": ["types"],
-    "src/cli/program.ts": ["exports", "types"],
-    "src/node/writeResultFiles.ts": ["exports", "types"],
-    "templates/index.ts": ["exports", "types"],
-    "src/index.ts": ["exports", "types"],
-    "src/standalone/index.ts": ["exports", "types"],
-    "src/lib/execCLI/index.ts": ["types"],
-    "src/standalone/toTtf.ts": ["types"],
-    "src/types/index.ts": ["types"],
-    "src/types/Result.ts": ["types"]
   }
 }

--- a/packages/webfont/src/cli/meow/cliFlagCatalog.ts
+++ b/packages/webfont/src/cli/meow/cliFlagCatalog.ts
@@ -4,5 +4,4 @@ export {
   CLI_USAGE_LINE,
   type CliFlagCatalogEntry,
   type CliFlagSection,
-  type CliFlagType,
 } from "../../optionsReference/cliFlagCatalog";

--- a/packages/webfont/src/cli/program.ts
+++ b/packages/webfont/src/cli/program.ts
@@ -10,9 +10,6 @@ import { parseFormatsFlag } from "./parseFormatsFlag";
 import { parseTemplateFlag } from "./parseTemplateFlag";
 import { resolveCliFiles } from "./resolveCliFiles";
 
-export type { ResultFileKey } from "../node/writeResultFiles";
-export { mergeCliDestIntoConfig, writeResultFiles } from "../node/writeResultFiles";
-
 export type CliLike = {
   flags: {
     addHashInFontUrl?: boolean;

--- a/packages/webfont/src/node/writeResultFiles.ts
+++ b/packages/webfont/src/node/writeResultFiles.ts
@@ -8,9 +8,9 @@ import type { Result } from "../types/Result";
 import type { ResultConfig } from "../types/ResultConfig";
 import type { TranscodedFont } from "../types/TranscodedFont";
 
-export type ResultFileKey = "eot" | "hash" | "otf" | "svg" | "template" | "ttf" | "woff" | "woff2";
+type ResultFileKey = "eot" | "hash" | "otf" | "svg" | "template" | "ttf" | "woff" | "woff2";
 
-export const resultFileKeys: ResultFileKey[] = ["svg", "ttf", "otf", "eot", "woff", "woff2", "hash", "template"];
+const resultFileKeys: ResultFileKey[] = ["svg", "ttf", "otf", "eot", "woff", "woff2", "hash", "template"];
 
 export const ensureResultConfig = (result: Result): ResultConfig => {
   if (!result.config) {
@@ -36,11 +36,7 @@ export const mergeCliDestIntoConfig = (
   return result;
 };
 
-export const resolveTemplateOutputPath = (
-  template: string,
-  config: ResultConfig,
-  usedBuiltIn: boolean,
-): string => {
+const resolveTemplateOutputPath = (template: string, config: ResultConfig, usedBuiltIn: boolean): string => {
   const dest = config.dest ?? process.cwd();
   let destTemplate = dest;
 
@@ -87,7 +83,7 @@ export const resolveDestTemplate = (result: Result, config: ResultConfig): strin
   return dest;
 };
 
-export const writeRenderedTemplates = async (
+const writeRenderedTemplates = async (
   templates: readonly RenderedTemplate[],
   config: ResultConfig,
 ): Promise<void> => {
@@ -121,7 +117,7 @@ export const getResultOutputPath = (
   return path.resolve(path.join(dest, `${fontName}.${type}`));
 };
 
-export const createMissingDestError = (dest: string): Error =>
+const createMissingDestError = (dest: string): Error =>
   new Error(`Destination directory "${dest}" does not exist. Use --dest-create (-m) to create it.`);
 
 export const ensureDestExists = async (dest: string, destCreate?: boolean): Promise<void> => {
@@ -175,7 +171,7 @@ export const writeDecompressedFontFiles = async (
   );
 };
 
-export const getTranscodedFontOutputBasename = (
+const getTranscodedFontOutputBasename = (
   fonts: readonly TranscodedFont[],
   font: TranscodedFont,
   config: ResultConfig,


### PR DESCRIPTION
## Summary

### Proposed changes

- **Keep Knip** and **tighten** it (reject excluding `exports`/`types` or growing `ignoreIssues`).
- Complete `packages/webfont/knip.json` `entry` / `project` (`src/index.ts`, standalone, scripts, fixtures).
- Remove dead re-exports / private helpers that Knip correctly flagged.
- Drop the `ignoreIssues` map; amend ADR 0008 + CONTRIBUTING / AGENTS / TROUBLESHOOTING policy.

### Related issue

https://github.com/itgalaxy/webfont/issues/822

### Testing

- [x] Unit / integration — `npm test` (465 tests)
- [x] `npm run depcheck` clean with no `ignoreIssues`
- [x] Docs / ADR — tooling policy; no user-facing runtime change

---

## Checklist

- [x] I have added corresponding labels to this PR (like bug, enhancement...);
- [x] My commits follow the [Conventional Commits 1.0 Guidelines](https://www.conventionalcommits.org/en/v1.0.0/);
- [x] My code follows the style guidelines of this project;
- [x] I have performed a self-review of my own code;
- [x] I have mapped technical debts found on my changes;
- [x] I have made changes to the documentation (if applicable);
- [x] My changes generate no new warnings or errors;

Made with [Cursor](https://cursor.com)